### PR TITLE
get predicted probabilities from logistic regression

### DIFF
--- a/R/logistic_reg_data.R
+++ b/R/logistic_reg_data.R
@@ -50,7 +50,9 @@ logistic_reg_glm_data <-
       pre = NULL,
       post = function(x, object) {
         x <- tibble(v1 = 1 - x, v2 = x)
-        colnames(x) <- object$lvl
+        if (!is.null(object$lvl))
+          colnames(x) <- object$lvl
+        else (colnames(x) <- c("0", "1"))
         x
       },
       func = c(fun = "predict"),


### PR DESCRIPTION
Fixes error that occurred when trying to get predicted probabilities from logistic regression when Y was not a factor:

> Error: Columns 1, 2 must be named.
> Use .name_repair to specify repair.

Noted in https://github.com/tidymodels/parsnip/issues/120

When this is the case I replaced the names with "0" and "1" (so the column names of the tibble that results from predict(type = "prob") are .pred_0 and .pred_1) but you may want other names instead -- these seemed to make sense for my use.