### PR TITLE
Fix issue 131

### DIFF
--- a/R/varying.R
+++ b/R/varying.R
@@ -139,6 +139,8 @@ is_varying <- function(x) {
 
 find_varying <- function(x) {
 
+  # STEP 1 - Early exits
+
   # Early exit for empty elements (like list())
   if (length(x) == 0L) {
     return(FALSE)
@@ -157,27 +159,17 @@ find_varying <- function(x) {
     return(FALSE)
   }
 
-  # Walk along the call and look for varying() elements
-  if (is.call(x) || is.pairlist(x)) {
+  # STEP 2 - Recursion
 
-    for (i in seq_along(x)) {
+  varying_elems <- vector("logical", length = length(x))
 
-      if (is_varying(x[[i]]))
-        return(TRUE)
-
-    }
-
-    return(FALSE)
+  for (i in seq_along(x)) {
+    varying_elems[i] <- find_varying(x[[i]])
   }
 
-  # Recursive call
-  if (is.vector(x) | is.list(x)) {
-    any_nested_varying <- any(map_lgl(x, find_varying))
-    return(any_nested_varying)
-  }
+  any_varying_elems <- any(varying_elems)
 
-  # User supplied incorrect input
-  stop("Don't know how to handle type ", typeof(x), call. = FALSE)
+  return(any_varying_elems)
 }
 
 caller_method <- function(cl) {

--- a/R/varying.R
+++ b/R/varying.R
@@ -56,10 +56,9 @@ varying_args.model_spec <- function(x, id = NULL, ...) {
 
   if (is.null(id))
     id <- deparse(cl$x)
-  varying_args <- map(x$args, find_varying)
-  varying_eng_args <- map(x$eng_args, find_varying)
+  varying_args <- map_lgl(x$args, find_varying)
+  varying_eng_args <- map_lgl(x$eng_args, find_varying)
   res <- c(varying_args, varying_eng_args)
-  res <- map_lgl(res, any)
   tibble(
     name = names(res),
     varying = unname(res),
@@ -114,9 +113,8 @@ varying_args.step <- function(x, id = NULL, ...) {
       "prefix", "naming", "denom", "outcome", "id")
   x <- x[!(names(x) %in% exclude)]
   x <- x[!map_lgl(x, is.null)]
-  res <- map(x, find_varying)
+  res <- map_lgl(x, find_varying)
 
-  res <- map_lgl(res, any)
   tibble(
     name = names(res),
     varying = unname(res),

--- a/tests/testthat/test_varying.R
+++ b/tests/testthat/test_varying.R
@@ -120,3 +120,21 @@ test_that('recipe parameters', {
   expect_equal(rec_res_4, exp_4)
 })
 
+test_that("empty lists return FALSE - #131", {
+  expect_equal(
+    parsnip:::find_varying(list()),
+    FALSE
+  )
+})
+
+test_that("lists with multiple elements return a single logical - #131", {
+  expect_equal(
+    parsnip:::find_varying(list(1, 2)),
+    FALSE
+  )
+
+  expect_equal(
+    parsnip:::find_varying(list(1, varying())),
+    TRUE
+  )
+})

--- a/tests/testthat/test_varying.R
+++ b/tests/testthat/test_varying.R
@@ -138,3 +138,12 @@ test_that("lists with multiple elements return a single logical - #131", {
     TRUE
   )
 })
+
+test_that("varying() deeply nested in calls can be located - #134", {
+  deep_varying <- rlang::call2("list", x = list(xx = list(xxx = varying())))
+
+  expect_equal(
+    parsnip:::find_varying(deep_varying),
+    TRUE
+  )
+})


### PR DESCRIPTION
Fixes #131 

- The structure of `find_varying()` has been "flattened" to be easier to maintain by using a number of early exist statements.

- `find_varying()` will now _always_ return a single logical value, or fail. Previously it could return a logical vector when given a list.

- `find_varying()` now returns `FALSE` when empty elements are passed in (i.e. `length(x) == 0`). Previously it returned `logical(0)`.