### PR TITLE
Fix predict_numeric error message on classification models

### DIFF
--- a/R/predict_numeric.R
+++ b/R/predict_numeric.R
@@ -8,7 +8,7 @@
 predict_numeric.model_fit <- function (object, new_data, ...) {
   if (object$spec$mode != "regression")
     stop("`predict_numeric` is for predicting numeric outcomes.  ",
-         "Use `predict_class` or `predict_prob` for ",
+         "Use `predict_class` or `predict_classprob` for ",
          "classification models.", call. = FALSE)
 
   if (!any(names(object$spec$method) == "numeric"))


### PR DESCRIPTION
There is no `predict_prob` function.