### PR TITLE
Removed unused argument for ml_decision_tree_classifier

### DIFF
--- a/R/decision_tree.R
+++ b/R/decision_tree.R
@@ -187,8 +187,6 @@ translate.decision_tree <- function(x, engine = x$engine, ...) {
         "if the specification is to be translated.",
         call. = FALSE
       )
-    } else {
-      arg_vals$type <- x$mode
     }
 
     # See "Details" in ?ml_random_forest_classifier. `feature_subset_strategy`


### PR DESCRIPTION
`type` argument passed in from `mode = "classification"` is not needed for `sparklyr::ml_decision_tree_classifier`

``` r
library(parsnip)
#> Warning: package 'parsnip' was built under R version 3.5.2
library(sparklyr)
#> Warning: package 'sparklyr' was built under R version 3.5.2

sc <- spark_connect(master = "local")

iris_tbls <- sdf_copy_to(sc, iris, overwrite = TRUE) %>%
  sdf_random_split(train = 2/3, validation = 2/3, seed = 2018)
train <- iris_tbls$train
validation <- iris_tbls$validation

spark_model <- decision_tree(mode = "classification") %>%
  set_engine("spark")

spark_fit <- spark_model %>%
  fit(Species ~ ., data = train)
#> 1 components of `...` were not used.
#> 
#> We detected these problematic arguments:
#> * `type`
#> 
#> Did you misspecify an argument?

rlang::last_error()
#> <error>
#> message: 1 components of `...` were not used.
#> 
#> We detected these problematic arguments:
#> * `type`
#> 
#> Did you misspecify an argument?
#> class:   `rlib_error_dots_unnused`
#> backtrace:
#>   1. generics::fit(., Species ~ ., data = train)
#>  14. ellipsis:::stop_dots(...)
#>  16. generics::fit(., Species ~ ., data = train)
#> Call `rlang::last_trace()` to see the full backtrace

rlang::last_trace()
#>      █
#>   1. ├─spark_model %>% fit(Species ~ ., data = train)
#>   2. │ ├─base::withVisible(eval(quote(`_fseq`(`_lhs`)), env, env))
#>   3. │ └─base::eval(quote(`_fseq`(`_lhs`)), env, env)
#>   4. │   └─base::eval(quote(`_fseq`(`_lhs`)), env, env)
#>   5. │     └─`_fseq`(`_lhs`)
#>   6. │       └─magrittr::freduce(value, `_function_list`)
#>   7. │         ├─base::withVisible(function_list[[k]](value))
#>   8. │         └─function_list[[k]](value)
#>   9. │           ├─generics::fit(., Species ~ ., data = train)
#>  10. │           └─parsnip::fit.model_spec(., Species ~ ., data = train)
#>  11. │             └─parsnip:::form_form(object = object, control = control, env = eval_env)
#>  12. │               └─parsnip:::eval_mod(...)
#>  13. │                 └─rlang::eval_tidy(e, ...)
#>  14. └─sparklyr::ml_decision_tree_classifier(...)
#>  15.   └─(function (env = parent.frame()) ...
#>  16.     └─ellipsis:::stop_dots(...)
```