### PR TITLE
REF test_control to helper-objects

### DIFF
--- a/tests/testthat/helper-objects.R
+++ b/tests/testthat/helper-objects.R
@@ -1,3 +1,3 @@
-ctrl          <- fit_control(verbosity = 1, catch = FALSE)
-caught_ctrl   <- fit_control(verbosity = 1, catch = TRUE)
-quiet_ctrl    <- fit_control(verbosity = 0, catch = TRUE)
+ctrl          <- control_parsnip(verbosity = 1, catch = FALSE)
+caught_ctrl   <- control_parsnip(verbosity = 1, catch = TRUE)
+quiet_ctrl    <- control_parsnip(verbosity = 0, catch = TRUE)

--- a/tests/testthat/helper-objects.R
+++ b/tests/testthat/helper-objects.R
@@ -1,0 +1,3 @@
+ctrl          <- fit_control(verbosity = 1, catch = FALSE)
+caught_ctrl   <- fit_control(verbosity = 1, catch = TRUE)
+quiet_ctrl    <- fit_control(verbosity = 0, catch = TRUE)

--- a/tests/testthat/test_boost_tree_C50.R
+++ b/tests/testthat/test_boost_tree_C50.R
@@ -6,6 +6,7 @@ library(dplyr)
 # ------------------------------------------------------------------------------
 
 context("boosted tree execution with C5.0")
+source("helper-objects.R")
 
 data("lending_club")
 lending_club <- head(lending_club, 200)
@@ -16,10 +17,6 @@ num_pred <- c("funded_amnt", "annual_inc", "num_il_tl")
 lc_basic <-
   boost_tree(mode = "classification")  %>%
       set_engine("C5.0", bands = 2)
-
-ctrl <- control_parsnip(verbosity = 1, catch = FALSE)
-caught_ctrl <- control_parsnip(verbosity = 1, catch = TRUE)
-quiet_ctrl <- control_parsnip(verbosity = 0, catch = TRUE)
 
 # ------------------------------------------------------------------------------
 

--- a/tests/testthat/test_boost_tree_spark.R
+++ b/tests/testthat/test_boost_tree_spark.R
@@ -5,10 +5,7 @@ library(dplyr)
 # ------------------------------------------------------------------------------
 
 context("boosted tree execution with spark")
-
-ctrl <- control_parsnip(verbosity = 1, catch = FALSE)
-caught_ctrl <- control_parsnip(verbosity = 1, catch = TRUE)
-quiet_ctrl <- control_parsnip(verbosity = 0, catch = TRUE)
+source("helper-objects.R")
 
 # ------------------------------------------------------------------------------
 

--- a/tests/testthat/test_boost_tree_xgboost.R
+++ b/tests/testthat/test_boost_tree_xgboost.R
@@ -98,10 +98,6 @@ bad_rf_reg <-
   boost_tree(mode = "regression") %>%
   set_engine("xgboost", sampsize = -10)
 
-ctrl <- list(verbosity = 1, catch = FALSE)
-caught_ctrl <- list(verbosity = 1, catch = TRUE)
-quiet_ctrl <- list(verbosity = 0, catch = TRUE)
-
 test_that('xgboost execution, regression', {
 
   skip_if_not_installed("xgboost")

--- a/tests/testthat/test_boost_tree_xgboost.R
+++ b/tests/testthat/test_boost_tree_xgboost.R
@@ -4,16 +4,13 @@ library(parsnip)
 # ------------------------------------------------------------------------------
 
 context("boosted tree execution with xgboost")
+source("helper-objects.R")
 
 num_pred <- names(iris)[1:4]
 
 iris_xgboost <-
   boost_tree(trees = 2, mode = "classification") %>%
   set_engine("xgboost")
-
-ctrl <- control_parsnip(verbosity = 1, catch = FALSE)
-caught_ctrl <- control_parsnip(verbosity = 1, catch = TRUE)
-quiet_ctrl <- control_parsnip(verbosity = 0, catch = TRUE)
 
 # ------------------------------------------------------------------------------
 

--- a/tests/testthat/test_linear_reg.R
+++ b/tests/testthat/test_linear_reg.R
@@ -7,6 +7,7 @@ library(tibble)
 
 context("linear regression")
 source("helpers.R")
+source("helper-objects.R")
 
 # ------------------------------------------------------------------------------
 
@@ -208,10 +209,6 @@ test_that('bad input', {
 num_pred <- c("Sepal.Width", "Petal.Width", "Petal.Length")
 iris_bad_form <- as.formula(Species ~ term)
 iris_basic <- linear_reg() %>% set_engine("lm")
-
-ctrl <- control_parsnip(verbosity = 1, catch = FALSE)
-caught_ctrl <- control_parsnip(verbosity = 1, catch = TRUE)
-quiet_ctrl <- control_parsnip(verbosity = 0, catch = TRUE)
 
 # ------------------------------------------------------------------------------
 

--- a/tests/testthat/test_linear_reg_glmnet.R
+++ b/tests/testthat/test_linear_reg_glmnet.R
@@ -6,6 +6,7 @@ library(tidyr)
 # ------------------------------------------------------------------------------
 
 context("linear regression execution with glmnet")
+source("helper-objects.R")
 
 num_pred <- c("Sepal.Width", "Petal.Width", "Petal.Length")
 iris_bad_form <- as.formula(Species ~ term)
@@ -13,10 +14,6 @@ iris_basic <- linear_reg(penalty = .1, mixture = .3) %>%
   set_engine("glmnet", nlambda = 15)
 no_lambda <- linear_reg(mixture = .3) %>%
   set_engine("glmnet")
-
-ctrl <- control_parsnip(verbosity = 1, catch = FALSE)
-caught_ctrl <- control_parsnip(verbosity = 1, catch = TRUE)
-quiet_ctrl <- control_parsnip(verbosity = 0, catch = TRUE)
 
 # ------------------------------------------------------------------------------
 

--- a/tests/testthat/test_linear_reg_keras.R
+++ b/tests/testthat/test_linear_reg_keras.R
@@ -7,6 +7,7 @@ library(tibble)
 
 context("keras linear regression")
 source("helpers.R")
+source("helper-objects.R")
 
 # ------------------------------------------------------------------------------
 
@@ -49,7 +50,6 @@ test_that('model fitting', {
       ),
     regexp = NA
   )
-  fit1$elapsed <- fit2$elapsed
   expect_equal(fit1, fit2)
 
   expect_error(

--- a/tests/testthat/test_linear_reg_keras.R
+++ b/tests/testthat/test_linear_reg_keras.R
@@ -50,6 +50,7 @@ test_that('model fitting', {
       ),
     regexp = NA
   )
+  fit1$elapsed <- fit2$elapsed
   expect_equal(fit1, fit2)
 
   expect_error(

--- a/tests/testthat/test_linear_reg_spark.R
+++ b/tests/testthat/test_linear_reg_spark.R
@@ -5,10 +5,7 @@ library(dplyr)
 # ------------------------------------------------------------------------------
 
 context("linear regression execution with spark")
-
-ctrl <- control_parsnip(verbosity = 1, catch = FALSE)
-caught_ctrl <- control_parsnip(verbosity = 1, catch = TRUE)
-quiet_ctrl <- control_parsnip(verbosity = 0, catch = TRUE)
+source("helper-objects.R")
 
 # ------------------------------------------------------------------------------
 

--- a/tests/testthat/test_logistic_reg.R
+++ b/tests/testthat/test_logistic_reg.R
@@ -7,6 +7,7 @@ library(tibble)
 
 context("logistic regression")
 source("helpers.R")
+source("helper-objects.R")
 
 # ------------------------------------------------------------------------------
 
@@ -219,9 +220,6 @@ lending_club <- head(lending_club, 200)
 lc_form <- as.formula(Class ~ log(funded_amnt) + int_rate)
 num_pred <- c("funded_amnt", "annual_inc", "num_il_tl")
 lc_basic <- logistic_reg() %>% set_engine("glm")
-ctrl <- control_parsnip(verbosity = 1, catch = FALSE)
-caught_ctrl <- control_parsnip(verbosity = 1, catch = TRUE)
-quiet_ctrl <- control_parsnip(verbosity = 0, catch = TRUE)
 
 test_that('glm execution', {
 

--- a/tests/testthat/test_logistic_reg_glmnet.R
+++ b/tests/testthat/test_logistic_reg_glmnet.R
@@ -7,6 +7,7 @@ library(tidyr)
 # ------------------------------------------------------------------------------
 
 context("logistic regression execution with glmnet")
+source("helper-objects.R")
 
 data("lending_club")
 lending_club <- head(lending_club, 200)
@@ -14,10 +15,6 @@ lc_form <- as.formula(Class ~ log(funded_amnt) + int_rate)
 num_pred <- c("funded_amnt", "annual_inc", "num_il_tl")
 lc_bad_form <- as.formula(funded_amnt ~ term)
 lc_basic <- logistic_reg() %>% set_engine("glmnet")
-
-ctrl <- control_parsnip(verbosity = 1, catch = FALSE)
-caught_ctrl <- control_parsnip(verbosity = 1, catch = TRUE)
-quiet_ctrl <- control_parsnip(verbosity = 0, catch = TRUE)
 
 # ------------------------------------------------------------------------------
 

--- a/tests/testthat/test_logistic_reg_spark.R
+++ b/tests/testthat/test_logistic_reg_spark.R
@@ -5,10 +5,7 @@ library(dplyr)
 # ------------------------------------------------------------------------------
 
 context("logistic regression execution with spark")
-
-ctrl <- control_parsnip(verbosity = 1, catch = FALSE)
-caught_ctrl <- control_parsnip(verbosity = 1, catch = TRUE)
-quiet_ctrl <- control_parsnip(verbosity = 0, catch = TRUE)
+source("helper-objects.R")
 
 # ------------------------------------------------------------------------------
 

--- a/tests/testthat/test_logistic_reg_stan.R
+++ b/tests/testthat/test_logistic_reg_stan.R
@@ -6,6 +6,7 @@ library(tibble)
 # ------------------------------------------------------------------------------
 
 context("execution tests for stan logistic regression")
+source("helper-objects.R")
 
 data("lending_club")
 lending_club <- head(lending_club, 200)

--- a/tests/testthat/test_mars.R
+++ b/tests/testthat/test_mars.R
@@ -6,6 +6,7 @@ library(rlang)
 
 context("mars tests")
 source("helpers.R")
+source("helper-objects.R")
 
 # ------------------------------------------------------------------------------
 
@@ -123,10 +124,6 @@ test_that('bad input', {
 num_pred <- c("Sepal.Width", "Petal.Width", "Petal.Length")
 iris_bad_form <- as.formula(Species ~ term)
 iris_basic <- mars(mode = "regression") %>% set_engine("earth")
-
-ctrl <- control_parsnip(verbosity = 1, catch = FALSE)
-caught_ctrl <- control_parsnip(verbosity = 1, catch = TRUE)
-quiet_ctrl <- control_parsnip(verbosity = 0, catch = TRUE)
 
 # ------------------------------------------------------------------------------
 

--- a/tests/testthat/test_mlp_keras.R
+++ b/tests/testthat/test_mlp_keras.R
@@ -5,16 +5,13 @@ library(tibble)
 # ------------------------------------------------------------------------------
 
 context("simple neural network execution with keras")
+source("helper-objects.R")
 
 num_pred <- names(iris)[1:4]
 
 iris_keras <-
   mlp(mode = "classification", hidden_units = 2, epochs = 10) %>%
   set_engine("keras", verbose = 0)
-
-ctrl <- control_parsnip(verbosity = 1, catch = FALSE)
-caught_ctrl <- control_parsnip(verbosity = 1, catch = TRUE)
-quiet_ctrl <- control_parsnip(verbosity = 0, catch = TRUE)
 
 nn_dat <- read.csv("nnet_test.txt")
 
@@ -142,10 +139,6 @@ car_basic <- mlp(mode = "regression", epochs = 10) %>%
 bad_keras_reg <-
   mlp(mode = "regression") %>%
   set_engine("keras", min.node.size = -10)
-
-ctrl <- list(verbosity = 1, catch = FALSE)
-caught_ctrl <- list(verbosity = 1, catch = TRUE)
-quiet_ctrl <- list(verbosity = 0, catch = TRUE)
 
 # ------------------------------------------------------------------------------
 

--- a/tests/testthat/test_mlp_nnet.R
+++ b/tests/testthat/test_mlp_nnet.R
@@ -4,16 +4,13 @@ library(parsnip)
 # ------------------------------------------------------------------------------
 
 context("simple neural network execution with nnet")
+source("helper-objects.R")
 
 num_pred <- names(iris)[1:4]
 
 iris_nnet <-
   mlp(mode = "classification", hidden_units = 5) %>%
   set_engine("nnet")
-
-ctrl <- control_parsnip(verbosity = 1, catch = FALSE)
-caught_ctrl <- control_parsnip(verbosity = 1, catch = TRUE)
-quiet_ctrl <- control_parsnip(verbosity = 0, catch = TRUE)
 
 # ------------------------------------------------------------------------------
 

--- a/tests/testthat/test_mlp_nnet.R
+++ b/tests/testthat/test_mlp_nnet.R
@@ -91,10 +91,6 @@ bad_rf_reg <-
   mlp(mode = "regression") %>%
   set_engine("nnet", sampsize = -10)
 
-ctrl <- list(verbosity = 1, catch = FALSE)
-caught_ctrl <- list(verbosity = 1, catch = TRUE)
-quiet_ctrl <- list(verbosity = 0, catch = TRUE)
-
 # ------------------------------------------------------------------------------
 
 

--- a/tests/testthat/test_multinom_reg_glmnet.R
+++ b/tests/testthat/test_multinom_reg_glmnet.R
@@ -6,10 +6,7 @@ library(tibble)
 # ------------------------------------------------------------------------------
 
 context("multinom regression execution with glmnet")
-
-ctrl <- control_parsnip(verbosity = 1, catch = FALSE)
-caught_ctrl <- control_parsnip(verbosity = 1, catch = TRUE)
-quiet_ctrl <- control_parsnip(verbosity = 0, catch = TRUE)
+source("helper-objects.R")
 
 rows <- c(1, 51, 101)
 

--- a/tests/testthat/test_multinom_reg_spark.R
+++ b/tests/testthat/test_multinom_reg_spark.R
@@ -5,10 +5,7 @@ library(dplyr)
 # ------------------------------------------------------------------------------
 
 context("multinomial regression execution with spark")
-
-ctrl <- control_parsnip(verbosity = 1, catch = FALSE)
-caught_ctrl <- control_parsnip(verbosity = 1, catch = TRUE)
-quiet_ctrl <- control_parsnip(verbosity = 0, catch = TRUE)
+source("helper-objects.R")
 
 # ------------------------------------------------------------------------------
 

--- a/tests/testthat/test_nearest_neighbor_kknn.R
+++ b/tests/testthat/test_nearest_neighbor_kknn.R
@@ -5,6 +5,7 @@ library(rlang)
 # ------------------------------------------------------------------------------
 
 context("nearest neighbor execution with kknn")
+source("helper-objects.R")
 
 num_pred <- c("Sepal.Width", "Petal.Width", "Petal.Length")
 iris_bad_form <- as.formula(Species ~ term)
@@ -12,10 +13,6 @@ iris_basic <- nearest_neighbor(mode = "classification",
                                neighbors = 8,
                                weight_func = "triangular") %>%
   set_engine("kknn")
-
-ctrl <- control_parsnip(verbosity = 1, catch = FALSE)
-caught_ctrl <- control_parsnip(verbosity = 1, catch = TRUE)
-quiet_ctrl <- control_parsnip(verbosity = 0, catch = TRUE)
 
 # ------------------------------------------------------------------------------
 

--- a/tests/testthat/test_rand_forest_randomForest.R
+++ b/tests/testthat/test_rand_forest_randomForest.R
@@ -5,6 +5,7 @@ library(tibble)
 # ------------------------------------------------------------------------------
 
 context("random forest execution with randomForest")
+source("helper-objects.R")
 
 # ------------------------------------------------------------------------------
 
@@ -16,10 +17,6 @@ lc_basic <- rand_forest(mode = "classification") %>%
   set_engine("randomForest")
 bad_rf_cls <- rand_forest(mode = "classification") %>%
   set_engine("randomForest", sampsize = -10)
-
-ctrl <- control_parsnip(verbosity = 1, catch = FALSE)
-caught_ctrl <- control_parsnip(verbosity = 1, catch = TRUE)
-quiet_ctrl <- control_parsnip(verbosity = 0, catch = TRUE)
 
 # ------------------------------------------------------------------------------
 

--- a/tests/testthat/test_rand_forest_randomForest.R
+++ b/tests/testthat/test_rand_forest_randomForest.R
@@ -153,10 +153,6 @@ bad_ranger_reg <- rand_forest(mode = "regression") %>%
 bad_rf_reg <- rand_forest(mode = "regression") %>%
   set_engine("randomForest", sampsize = -10)
 
-ctrl <- list(verbosity = 1, catch = FALSE)
-caught_ctrl <- list(verbosity = 1, catch = TRUE)
-quiet_ctrl <- list(verbosity = 0, catch = TRUE)
-
 # ------------------------------------------------------------------------------
 
 test_that('randomForest regression execution', {

--- a/tests/testthat/test_rand_forest_ranger.R
+++ b/tests/testthat/test_rand_forest_ranger.R
@@ -6,6 +6,7 @@ library(rlang)
 # ------------------------------------------------------------------------------
 
 context("random forest execution with ranger")
+source("helper-objects.R")
 
 # ------------------------------------------------------------------------------
 
@@ -18,10 +19,6 @@ lc_ranger <- rand_forest(mode = "classification") %>% set_engine("ranger", seed 
 
 bad_ranger_cls <- rand_forest(mode = "classification") %>% set_engine("ranger", replace = "bad")
 bad_rf_cls <- rand_forest(mode = "classification") %>% set_engine("ranger", sampsize = -10)
-
-ctrl <- control_parsnip(verbosity = 1, catch = FALSE)
-caught_ctrl <- control_parsnip(verbosity = 1, catch = TRUE)
-quiet_ctrl <- control_parsnip(verbosity = 0, catch = TRUE)
 
 # ------------------------------------------------------------------------------
 

--- a/tests/testthat/test_rand_forest_ranger.R
+++ b/tests/testthat/test_rand_forest_ranger.R
@@ -175,10 +175,6 @@ car_basic <- rand_forest(mode = "regression") %>% set_engine("ranger")
 bad_ranger_reg <- rand_forest(mode = "regression") %>% set_engine("ranger", replace = "bad")
 bad_rf_reg <- rand_forest(mode = "regression") %>% set_engine("ranger", sampsize = -10)
 
-ctrl <- list(verbosity = 1, catch = FALSE)
-caught_ctrl <- list(verbosity = 1, catch = TRUE)
-quiet_ctrl <- list(verbosity = 0, catch = TRUE)
-
 # ------------------------------------------------------------------------------
 
 test_that('ranger regression execution', {

--- a/tests/testthat/test_rand_forest_spark.R
+++ b/tests/testthat/test_rand_forest_spark.R
@@ -5,10 +5,7 @@ library(dplyr)
 # ------------------------------------------------------------------------------
 
 context("random forest execution with spark")
-
-ctrl <- control_parsnip(verbosity = 1, catch = FALSE)
-caught_ctrl <- control_parsnip(verbosity = 1, catch = TRUE)
-quiet_ctrl <- control_parsnip(verbosity = 0, catch = TRUE)
+source("helper-objects.R")
 
 # ------------------------------------------------------------------------------
 

--- a/tests/testthat/test_surv_reg_flexsurv.R
+++ b/tests/testthat/test_surv_reg_flexsurv.R
@@ -6,13 +6,12 @@ library(tibble)
 
 # ------------------------------------------------------------------------------
 
+source("helper-objects.R")
+
 basic_form <- Surv(time, status) ~ age
 complete_form <- Surv(time) ~ age
 
 surv_basic <- surv_reg() %>% set_engine("flexsurv")
-ctrl <- control_parsnip(verbosity = 1, catch = FALSE)
-caught_ctrl <- control_parsnip(verbosity = 1, catch = TRUE)
-quiet_ctrl <- control_parsnip(verbosity = 0, catch = TRUE)
 
 # ------------------------------------------------------------------------------
 

--- a/tests/testthat/test_surv_reg_survreg.R
+++ b/tests/testthat/test_surv_reg_survreg.R
@@ -5,15 +5,13 @@ library(tibble)
 
 # ------------------------------------------------------------------------------
 
+source("helper-objects.R")
+
 basic_form <- Surv(time, status) ~ group
 complete_form <- Surv(time) ~ group
 
 surv_basic <- surv_reg() %>% set_engine("survival")
 surv_lnorm <- surv_reg(dist = "lognormal") %>% set_engine("survival")
-
-ctrl <- control_parsnip(verbosity = 1, catch = FALSE)
-caught_ctrl <- control_parsnip(verbosity = 1, catch = TRUE)
-quiet_ctrl <- control_parsnip(verbosity = 0, catch = TRUE)
 
 # ------------------------------------------------------------------------------
 


### PR DESCRIPTION
This is a quick refactor to move control objects in tests to a single file, `helper-objects.R` as suggested in #88. This was relatively standard across tests, with exceptions for stan which needed less verbosity.

This is the easiest refactor suggested in the issue to be sure, but I'd like to handle the refactor of data references separately in smaller chunks. There's a bit of variability that will take some work to standardize, but I think it could be nice to have.