### PR TITLE
adjust for cases where parsnip predictions are from a parsnip model

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # parsnip (development version)
 
+# parsnip 0.0.5.9000
+
+
+
 # parsnip 0.0.5
 
 ## Fixes

--- a/R/predict.R
+++ b/R/predict.R
@@ -144,7 +144,6 @@ predict.model_fit <- function(object, new_data, type = NULL, opts = list(), ...)
     raw      = predict_raw(object = object, new_data = new_data, opts = opts, ...),
     rlang::abort(glue::glue("I don't know about type = '{type}'"))
   )
-
   if (!inherits(res, "tbl_spark")) {
     res <- switch(
       type,
@@ -188,7 +187,9 @@ format_num <- function(x) {
 
   if (isTRUE(ncol(x) > 1)) {
     x <- as_tibble(x, .name_repair = "minimal")
-    names(x) <- paste0(".pred_", names(x))
+    if (!any(grepl("^\\.pred", names(x)))) {
+      names(x) <- paste0(".pred_", names(x))
+    }
   } else {
     x <- tibble(.pred = x)
   }
@@ -204,7 +205,9 @@ format_class <- function(x) {
 }
 
 format_classprobs <- function(x) {
-  names(x) <- paste0(".pred_", names(x))
+  if (!any(grepl("^\\.pred_", names(x)))) {
+    names(x) <- paste0(".pred_", names(x))
+  }
   x <- as_tibble(x)
   x
 }

--- a/R/predict.R
+++ b/R/predict.R
@@ -185,7 +185,7 @@ format_num <- function(x) {
   if (inherits(x, "tbl_spark"))
     return(x)
 
-  if (isTRUE(ncol(x) > 1)) {
+  if (isTRUE(ncol(x) > 1) | is.data.frame(x)) {
     x <- as_tibble(x, .name_repair = "minimal")
     if (!any(grepl("^\\.pred", names(x)))) {
       names(x) <- paste0(".pred_", names(x))

--- a/R/predict_class.R
+++ b/R/predict_class.R
@@ -40,8 +40,14 @@ predict_class.model_fit <- function(object, new_data, ...) {
   if (is.vector(res) || is.factor(res)) {
     res <- factor(as.character(res), levels = object$lvl)
   } else {
-    if (!inherits(res, "tbl_spark"))
-      res$values <- factor(as.character(res$values), levels = object$lvl)
+    if (!inherits(res, "tbl_spark")) {
+      # Now case where a parsnip model generated `res`
+      if (tibble::is_tibble(res) && ncol(res) == 1 && is.factor(res[[1]])) {
+        res <- res[[1]]
+      } else {
+        res$values <- factor(as.character(res$values), levels = object$lvl)
+      }
+    }
   }
 
   res

--- a/R/predict_class.R
+++ b/R/predict_class.R
@@ -42,7 +42,7 @@ predict_class.model_fit <- function(object, new_data, ...) {
   } else {
     if (!inherits(res, "tbl_spark")) {
       # Now case where a parsnip model generated `res`
-      if (tibble::is_tibble(res) && ncol(res) == 1 && is.factor(res[[1]])) {
+      if (is.data.frame(res) && ncol(res) == 1 && is.factor(res[[1]])) {
         res <- res[[1]]
       } else {
         res$values <- factor(as.character(res$values), levels = object$lvl)


### PR DESCRIPTION
For hard class predictions and numeric predictions, the `predict()` method was having issues when the results were already in tidymodels-tibble format. 