### PR TITLE
Tables for engine specific params in model docs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,7 @@ Imports:
     prettyunits,
     vctrs (>= 0.2.0)
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.0.2.9000
+RoxygenNote: 7.1.0
 Suggests: 
     testthat,
     knitr,

--- a/R/aaa.R
+++ b/R/aaa.R
@@ -24,6 +24,29 @@ convert_stan_interval <- function(x, level = 0.95, lower = TRUE) {
   res
 }
 
+convert_args <- function(model_name) {
+  envir <- get_model_env()
+
+  args <-
+    ls(envir) %>%
+    tibble::tibble(name = .) %>%
+    dplyr::filter(grepl("args", name)) %>%
+    dplyr::mutate(model = sub("_args", "", name),
+                  args  = purrr::map(name, ~envir[[.x]])) %>%
+    tidyr::unnest(args) %>%
+    dplyr::select(model:original)
+
+  convert_df <- args %>%
+    dplyr::filter(grepl(model_name, model)) %>%
+    dplyr::select(-model) %>%
+    tidyr::pivot_wider(names_from = engine, values_from = original)
+
+  convert_df %>%
+    knitr::kable(col.names = paste0("**", colnames(convert_df), "**"))
+
+}
+
+
 # ------------------------------------------------------------------------------
 # nocov
 
@@ -32,8 +55,8 @@ utils::globalVariables(
   c('.', '.label', '.pred', '.row', 'data', 'engine', 'engine2', 'group',
     'lab', 'original', 'predicted_label', 'prediction', 'value', 'type',
     "neighbors", ".submodels", "has_submodel", "max_neighbor", "max_penalty",
-    "max_terms", "max_tree", "name", "num_terms", "penalty", "trees",
+    "max_terms", "max_tree", "model", "name", "num_terms", "penalty", "trees",
     "sub_neighbors", ".pred_class")
-  )
+)
 
 # nocov end

--- a/R/boost_tree.R
+++ b/R/boost_tree.R
@@ -61,6 +61,13 @@
 #'
 #' @section Engine Details:
 #'
+#' The standardized parameter names in parsnip can be mapped to their original
+#' names in each engine:
+#'
+#' ```{r echo = FALSE}
+#' convert_args("boost_tree")
+#' ```
+#'
 #' Engines may have pre-set default arguments when executing the
 #'  model fit call.  For this type of model, the template of the
 #'  fit calls are:

--- a/R/decision_tree.R
+++ b/R/decision_tree.R
@@ -46,6 +46,13 @@
 #'
 #' @section Engine Details:
 #'
+#' The standardized parameter names in parsnip can be mapped to their original
+#' names in each engine:
+#'
+#' ```{r echo = FALSE}
+#' convert_args("decision_tree")
+#' ```
+#'
 #' Engines may have pre-set default arguments when executing the
 #'  model fit call. For this type of
 #'  model, the template of the fit calls are::

--- a/R/linear_reg.R
+++ b/R/linear_reg.R
@@ -44,6 +44,13 @@
 #'
 #' @section Engine Details:
 #'
+#' The standardized parameter names in parsnip can be mapped to their original
+#' names in each engine:
+#'
+#' ```{r echo = FALSE}
+#' convert_args("linear_reg")
+#' ```
+#'
 #' Engines may have pre-set default arguments when executing the
 #'  model fit call. For this type of
 #'  model, the template of the fit calls are:

--- a/R/logistic_reg.R
+++ b/R/logistic_reg.R
@@ -42,6 +42,13 @@
 #'
 #' @section Engine Details:
 #'
+#' The standardized parameter names in parsnip can be mapped to their original
+#' names in each engine:
+#'
+#' ```{r echo = FALSE}
+#' convert_args("logistic_reg")
+#' ```
+#'
 #' Engines may have pre-set default arguments when executing the
 #'  model fit call.  For this type of
 #'  model, the template of the fit calls are:

--- a/R/mars.R
+++ b/R/mars.R
@@ -38,6 +38,13 @@
 #'
 #' @section Engine Details:
 #'
+#' The standardized parameter names in parsnip can be mapped to their original
+#' names in each engine:
+#'
+#' ```{r echo = FALSE}
+#' convert_args("mars")
+#' ```
+#'
 #' Engines may have pre-set default arguments when executing the
 #'  model fit call.  For this type of
 #'  model, the template of the fit calls are:

--- a/R/mlp.R
+++ b/R/mlp.R
@@ -56,6 +56,13 @@
 #'
 #' @section Engine Details:
 #'
+#' The standardized parameter names in parsnip can be mapped to their original
+#' names in each engine:
+#'
+#' ```{r echo = FALSE}
+#' convert_args("mlp")
+#' ```
+#'
 #' Engines may have pre-set default arguments when executing the
 #'  model fit call. For this type of
 #'  model, the template of the fit calls are:

--- a/R/multinom_reg.R
+++ b/R/multinom_reg.R
@@ -41,6 +41,13 @@
 #'
 #' @section Engine Details:
 #'
+#' The standardized parameter names in parsnip can be mapped to their original
+#' names in each engine:
+#'
+#' ```{r echo = FALSE}
+#' convert_args("multinom_reg")
+#' ```
+#'
 #' Engines may have pre-set default arguments when executing the
 #'  model fit call.  For this type of
 #'  model, the template of the fit calls are:

--- a/R/nearest_neighbor.R
+++ b/R/nearest_neighbor.R
@@ -48,6 +48,13 @@
 #'
 #' @section Engine Details:
 #'
+#' The standardized parameter names in parsnip can be mapped to their original
+#' names in each engine:
+#'
+#' ```{r echo = FALSE}
+#' convert_args("nearest_neighbor")
+#' ```
+#'
 #' Engines may have pre-set default arguments when executing the
 #'  model fit call. For this type of
 #'  model, the template of the fit calls are:

--- a/R/rand_forest.R
+++ b/R/rand_forest.R
@@ -40,6 +40,13 @@
 #'
 #' @section Engine Details:
 #'
+#' The standardized parameter names in parsnip can be mapped to their original
+#' names in each engine:
+#'
+#' ```{r echo = FALSE}
+#' convert_args("rand_forest")
+#' ```
+#'
 #' Engines may have pre-set default arguments when executing the
 #'  model fit call. For this type of
 #'  model, the template of the fit calls are::

--- a/R/surv_reg.R
+++ b/R/surv_reg.R
@@ -41,6 +41,13 @@
 #'
 #' @section Engine Details:
 #'
+#' The standardized parameter names in parsnip can be mapped to their original
+#' names in each engine:
+#'
+#' ```{r echo = FALSE}
+#' convert_args("surv_reg")
+#' ```
+#'
 #' Engines may have pre-set default arguments when executing the
 #'  model fit call. For this type of
 #'  model, the template of the fit calls are:

--- a/R/svm_poly.R
+++ b/R/svm_poly.R
@@ -38,6 +38,13 @@
 #'
 #' @section Engine Details:
 #'
+#' The standardized parameter names in parsnip can be mapped to their original
+#' names in each engine:
+#'
+#' ```{r echo = FALSE}
+#' convert_args("svm_poly")
+#' ```
+#'
 #' Engines may have pre-set default arguments when executing the
 #'  model fit call. For this type of
 #'  model, the template of the fit calls are::

--- a/R/svm_rbf.R
+++ b/R/svm_rbf.R
@@ -37,6 +37,13 @@
 #'
 #' @section Engine Details:
 #'
+#' The standardized parameter names in parsnip can be mapped to their original
+#' names in each engine:
+#'
+#' ```{r echo = FALSE}
+#' convert_args("svm_rbf")
+#' ```
+#'
 #' Engines may have pre-set default arguments when executing the
 #'  model fit call. For this type of
 #'  model, the template of the fit calls are::

--- a/man/boost_tree.Rd
+++ b/man/boost_tree.Rd
@@ -128,6 +128,20 @@ reloaded and reattached to the \code{parsnip} object.
 \section{Engine Details}{
 
 
+The standardized parameter names in parsnip can be mapped to their original
+names in each engine:\tabular{llll}{
+   \strong{parsnip} \tab \strong{xgboost} \tab \strong{C5.0} \tab \strong{spark} \cr
+   tree_depth \tab max_depth \tab NA \tab max_depth \cr
+   trees \tab nrounds \tab trials \tab max_iter \cr
+   learn_rate \tab eta \tab NA \tab step_size \cr
+   mtry \tab colsample_bytree \tab NA \tab feature_subset_strategy \cr
+   min_n \tab min_child_weight \tab minCases \tab min_instances_per_node \cr
+   loss_reduction \tab gamma \tab NA \tab NA \cr
+   sample_size \tab subsample \tab sample \tab subsampling_rate \cr
+   min_info_gain \tab NA \tab NA \tab loss_reduction \cr
+}
+
+
 Engines may have pre-set default arguments when executing the
 model fit call.  For this type of model, the template of the
 fit calls are:

--- a/man/decision_tree.Rd
+++ b/man/decision_tree.Rd
@@ -98,6 +98,15 @@ reloaded and reattached to the \code{parsnip} object.
 \section{Engine Details}{
 
 
+The standardized parameter names in parsnip can be mapped to their original
+names in each engine:\tabular{llll}{
+   \strong{parsnip} \tab \strong{rpart} \tab \strong{C5.0} \tab \strong{spark} \cr
+   tree_depth \tab maxdepth \tab NA \tab max_depth \cr
+   min_n \tab minsplit \tab minCases \tab min_instances_per_node \cr
+   cost_complexity \tab cp \tab NA \tab NA \cr
+}
+
+
 Engines may have pre-set default arguments when executing the
 model fit call. For this type of
 model, the template of the fit calls are::

--- a/man/linear_reg.Rd
+++ b/man/linear_reg.Rd
@@ -92,6 +92,14 @@ reloaded and reattached to the \code{parsnip} object.
 \section{Engine Details}{
 
 
+The standardized parameter names in parsnip can be mapped to their original
+names in each engine:\tabular{llll}{
+   \strong{parsnip} \tab \strong{glmnet} \tab \strong{spark} \tab \strong{keras} \cr
+   penalty \tab lambda \tab reg_param \tab penalty \cr
+   mixture \tab alpha \tab elastic_net_param \tab NA \cr
+}
+
+
 Engines may have pre-set default arguments when executing the
 model fit call. For this type of
 model, the template of the fit calls are:

--- a/man/logistic_reg.Rd
+++ b/man/logistic_reg.Rd
@@ -90,6 +90,14 @@ reloaded and reattached to the \code{parsnip} object.
 \section{Engine Details}{
 
 
+The standardized parameter names in parsnip can be mapped to their original
+names in each engine:\tabular{llll}{
+   \strong{parsnip} \tab \strong{glmnet} \tab \strong{spark} \tab \strong{keras} \cr
+   penalty \tab lambda \tab reg_param \tab penalty \cr
+   mixture \tab alpha \tab elastic_net_param \tab NA \cr
+}
+
+
 Engines may have pre-set default arguments when executing the
 model fit call.  For this type of
 model, the template of the fit calls are:

--- a/man/mars.Rd
+++ b/man/mars.Rd
@@ -77,6 +77,15 @@ following \emph{engines}:
 \section{Engine Details}{
 
 
+The standardized parameter names in parsnip can be mapped to their original
+names in each engine:\tabular{ll}{
+   \strong{parsnip} \tab \strong{earth} \cr
+   num_terms \tab nprune \cr
+   prod_degree \tab degree \cr
+   prune_method \tab pmethod \cr
+}
+
+
 Engines may have pre-set default arguments when executing the
 model fit call.  For this type of
 model, the template of the fit calls are:

--- a/man/mlp.Rd
+++ b/man/mlp.Rd
@@ -104,6 +104,17 @@ An error is thrown if both \code{penalty} and \code{dropout} are specified for
 \section{Engine Details}{
 
 
+The standardized parameter names in parsnip can be mapped to their original
+names in each engine:\tabular{lll}{
+   \strong{parsnip} \tab \strong{keras} \tab \strong{nnet} \cr
+   hidden_units \tab hidden_units \tab size \cr
+   penalty \tab penalty \tab decay \cr
+   dropout \tab dropout \tab NA \cr
+   epochs \tab epochs \tab maxit \cr
+   activation \tab activation \tab NA \cr
+}
+
+
 Engines may have pre-set default arguments when executing the
 model fit call. For this type of
 model, the template of the fit calls are:

--- a/man/multinom_reg.Rd
+++ b/man/multinom_reg.Rd
@@ -89,6 +89,14 @@ reloaded and reattached to the \code{parsnip} object.
 \section{Engine Details}{
 
 
+The standardized parameter names in parsnip can be mapped to their original
+names in each engine:\tabular{lllll}{
+   \strong{parsnip} \tab \strong{glmnet} \tab \strong{spark} \tab \strong{keras} \tab \strong{nnet} \cr
+   penalty \tab lambda \tab reg_param \tab penalty \tab decay \cr
+   mixture \tab alpha \tab elastic_net_param \tab NA \tab NA \cr
+}
+
+
 Engines may have pre-set default arguments when executing the
 model fit call.  For this type of
 model, the template of the fit calls are:

--- a/man/nearest_neighbor.Rd
+++ b/man/nearest_neighbor.Rd
@@ -66,6 +66,15 @@ on new data. This also means that a single value of that function's
 \section{Engine Details}{
 
 
+The standardized parameter names in parsnip can be mapped to their original
+names in each engine:\tabular{ll}{
+   \strong{parsnip} \tab \strong{kknn} \cr
+   neighbors \tab ks \cr
+   weight_func \tab kernel \cr
+   dist_power \tab distance \cr
+}
+
+
 Engines may have pre-set default arguments when executing the
 model fit call. For this type of
 model, the template of the fit calls are:

--- a/man/rand_forest.Rd
+++ b/man/rand_forest.Rd
@@ -87,6 +87,15 @@ reloaded and reattached to the \code{parsnip} object.
 \section{Engine Details}{
 
 
+The standardized parameter names in parsnip can be mapped to their original
+names in each engine:\tabular{llll}{
+   \strong{parsnip} \tab \strong{ranger} \tab \strong{randomForest} \tab \strong{spark} \cr
+   mtry \tab mtry \tab mtry \tab feature_subset_strategy \cr
+   trees \tab num.trees \tab ntree \tab num_trees \cr
+   min_n \tab min.node.size \tab nodesize \tab min_instances_per_node \cr
+}
+
+
 Engines may have pre-set default arguments when executing the
 model fit call. For this type of
 model, the template of the fit calls are::

--- a/man/surv_reg.Rd
+++ b/man/surv_reg.Rd
@@ -69,6 +69,13 @@ following \emph{engines}:
 \section{Engine Details}{
 
 
+The standardized parameter names in parsnip can be mapped to their original
+names in each engine:\tabular{lll}{
+   \strong{parsnip} \tab \strong{flexsurv} \tab \strong{survival} \cr
+   dist \tab dist \tab dist \cr
+}
+
+
 Engines may have pre-set default arguments when executing the
 model fit call. For this type of
 model, the template of the fit calls are:

--- a/man/svm_poly.Rd
+++ b/man/svm_poly.Rd
@@ -81,6 +81,16 @@ following \emph{engines}:
 \section{Engine Details}{
 
 
+The standardized parameter names in parsnip can be mapped to their original
+names in each engine:\tabular{ll}{
+   \strong{parsnip} \tab \strong{kernlab} \cr
+   cost \tab C \cr
+   degree \tab degree \cr
+   scale_factor \tab scale \cr
+   margin \tab epsilon \cr
+}
+
+
 Engines may have pre-set default arguments when executing the
 model fit call. For this type of
 model, the template of the fit calls are::

--- a/man/svm_rbf.Rd
+++ b/man/svm_rbf.Rd
@@ -72,6 +72,15 @@ following \emph{engines}:
 \section{Engine Details}{
 
 
+The standardized parameter names in parsnip can be mapped to their original
+names in each engine:\tabular{ll}{
+   \strong{parsnip} \tab \strong{kernlab} \cr
+   cost \tab C \cr
+   rbf_sigma \tab sigma \cr
+   margin \tab epsilon \cr
+}
+
+
 Engines may have pre-set default arguments when executing the
 model fit call. For this type of
 model, the template of the fit calls are::

--- a/tests/testthat/test_nearest_neighbor_kknn.R
+++ b/tests/testthat/test_nearest_neighbor_kknn.R
@@ -132,14 +132,15 @@ test_that('kknn multi-predict', {
   )
 
   pred_multi <- multi_predict(res_xy, iris[iris_te, num_pred], neighbors = k_vals)
-  expect_equal(pred_multi %>% unnest() %>% nrow(), length(iris_te) * length(k_vals))
+  expect_equal(pred_multi %>% unnest(cols = c(.pred)) %>% nrow(),
+               length(iris_te) * length(k_vals))
   expect_equal(pred_multi %>% nrow(), length(iris_te))
 
   pred_uni <- predict(res_xy, iris[iris_te, num_pred])
   pred_uni_obs <-
     pred_multi %>%
     mutate(.rows = row_number()) %>%
-    unnest() %>%
+    unnest(cols = c(.pred)) %>%
     dplyr::filter(neighbors == 3) %>%
     arrange(.rows) %>%
     dplyr::select(.pred_class)
@@ -148,14 +149,15 @@ test_that('kknn multi-predict', {
 
   prob_multi <- multi_predict(res_xy, iris[iris_te, num_pred],
                               neighbors = k_vals, type = "prob")
-  expect_equal(prob_multi %>% unnest() %>% nrow(), length(iris_te) * length(k_vals))
+  expect_equal(prob_multi %>% unnest(cols = c(.pred)) %>% nrow(),
+               length(iris_te) * length(k_vals))
   expect_equal(prob_multi %>% nrow(), length(iris_te))
 
   prob_uni <- predict(res_xy, iris[iris_te, num_pred], type = "prob")
   prob_uni_obs <-
     prob_multi %>%
     mutate(.rows = row_number()) %>%
-    unnest() %>%
+    unnest(cols = c(.pred)) %>%
     dplyr::filter(neighbors == 3) %>%
     arrange(.rows) %>%
     dplyr::select(!!names(prob_uni))
@@ -175,14 +177,15 @@ test_that('kknn multi-predict', {
   )
 
   pred_multi <- multi_predict(res_xy, mtcars[cars_te, -1], neighbors = k_vals)
-  expect_equal(pred_multi %>% unnest() %>% nrow(), length(cars_te) * length(k_vals))
+  expect_equal(pred_multi %>% unnest(cols = c(.pred)) %>% nrow(),
+               length(cars_te) * length(k_vals))
   expect_equal(pred_multi %>% nrow(), length(cars_te))
 
   pred_uni <- predict(res_xy, mtcars[cars_te, -1])
   pred_uni_obs <-
     pred_multi %>%
     mutate(.rows = row_number()) %>%
-    unnest() %>%
+    unnest(cols = c(.pred)) %>%
     dplyr::filter(neighbors == 3) %>%
     arrange(.rows) %>%
     dplyr::select(.pred)


### PR DESCRIPTION
Addresses #211. This PR implements a table in each individual model `.Rd` file to show the mapping from the parsnip parameters to the engine parameters.

Still TODO is the defaults for these parameters but that is a WHOLE THING (maybe not something that can be automated) so I plan to do that in another PR in the hopefully near future. If this piece is good as is, let's merge it.