### PR TITLE
Remove inner names from prediction output

### DIFF
--- a/R/predict.R
+++ b/R/predict.R
@@ -191,7 +191,7 @@ format_num <- function(x) {
       names(x) <- paste0(".pred_", names(x))
     }
   } else {
-    x <- tibble(.pred = x)
+    x <- tibble(.pred = unname(x))
   }
 
   x
@@ -201,7 +201,7 @@ format_class <- function(x) {
   if (inherits(x, "tbl_spark"))
     return(x)
 
-  tibble(.pred_class = x)
+  tibble(.pred_class = unname(x))
 }
 
 format_classprobs <- function(x) {
@@ -209,6 +209,7 @@ format_classprobs <- function(x) {
     names(x) <- paste0(".pred_", names(x))
   }
   x <- as_tibble(x)
+  x <- purrr::map_dfr(x, rlang::set_names, NULL)
   x
 }
 

--- a/tests/testthat/test_logistic_reg.R
+++ b/tests/testthat/test_logistic_reg.R
@@ -300,7 +300,9 @@ test_that('glm probabilities', {
     control = ctrl
   )
 
-  xy_pred <- predict(classes_xy$fit, newdata = lending_club[1:7, num_pred], type = "response")
+  xy_pred <- unname(predict(classes_xy$fit,
+                            newdata = lending_club[1:7, num_pred],
+                            type = "response"))
   xy_pred <- tibble(.pred_bad = 1 - xy_pred, .pred_good = xy_pred)
   expect_equal(xy_pred, predict(classes_xy, lending_club[1:7, num_pred], type = "prob"))
 

--- a/tests/testthat/test_logistic_reg_glmnet.R
+++ b/tests/testthat/test_logistic_reg_glmnet.R
@@ -251,9 +251,9 @@ test_that('glmnet probabilities, one lambda', {
   form_mat <- form_mat[1:7, -1]
 
   form_pred <-
-    predict(res_form$fit,
+    unname(predict(res_form$fit,
             newx = form_mat,
-            s = 0.1, type = "response")[, 1]
+            s = 0.1, type = "response")[, 1])
   form_pred <- tibble(.pred_bad = 1 - form_pred, .pred_good = form_pred)
 
   expect_equal(
@@ -358,7 +358,8 @@ test_that('glmnet probabilities, no lambda', {
 
   expect_equal(
     mult_pred,
-    multi_predict(xy_fit, lending_club[1:7, num_pred], type = "prob") %>% unnest()
+    multi_predict(xy_fit, lending_club[1:7, num_pred], type = "prob") %>%
+      unnest(cols = c(.pred))
   )
 
   res_form <- fit(


### PR DESCRIPTION
This PR removes names on vectors from prediction output (created by `format_num()` and similar) and updates related tests. This is related to tibble 3.0 and closes #312.

```` r
library(parsnip)
classes_wool <- logistic_reg() %>%
  set_engine("glm") %>%
  fit(
    wool ~ .,
    data = warpbreaks
)
output <- predict(classes_wool, warpbreaks, type = "prob")

## no more names
output$.pred_A
#>  [1] 0.3861308 0.4313066 0.6997228 0.3751053 0.8312219 0.6797094 0.6694427
#>  [8] 0.3861308 0.8106131 0.4034408 0.4376177 0.5307937 0.3922368 0.3380998
#> [15] 0.4034408 0.5996377 0.5424232 0.6108120 0.6625599 0.4932905 0.5283378
#> [22] 0.4583089 0.3678808 0.7314750 0.5745785 0.4237337 0.5515696 0.3972744
#> [29] 0.2640826 0.4198734 0.3119537 0.4198734 0.4428135 0.5592102 0.3220797
#> [36] 0.5934557 0.6751018 0.4957547 0.4147465 0.3811452 0.6436036 0.5191306
#> [43] 0.4376177 0.6436036 0.5307937 0.4816056 0.4932905 0.5283378 0.4467222
#> [50] 0.4010705 0.4237337 0.4237337 0.4351931 0.5745785
```

<sup>Created on 2020-05-19 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>