### PR TITLE
Improve `std_error` documentation

### DIFF
--- a/R/predict.R
+++ b/R/predict.R
@@ -23,9 +23,9 @@
 #'            is the parameter for the tail area of the intervals
 #'            (e.g. confidence level for confidence intervals).
 #'            Default value is 0.95.
-#'     \item `std_error`: add the standard error of fit or
-#'            prediction for `type`s of "conf_int" and "pred_int".
-#'            Default value is `FALSE`.
+#'     \item `std_error`: add the standard error of fit or prediction (on
+#'            the scale of the linear predictors) for `type`s of "conf_int"
+#'            and "pred_int". Default value is `FALSE`.
 #'     \item `quantile`: the quantile(s) for quantile regression
 #'            (not implemented yet)
 #'     \item `time`: the time(s) for hazard probability estimates

--- a/man/other_predict.Rd
+++ b/man/other_predict.Rd
@@ -36,9 +36,9 @@ value of \code{type}. Possible arguments are:
 is the parameter for the tail area of the intervals
 (e.g. confidence level for confidence intervals).
 Default value is 0.95.
-\item \code{std_error}: add the standard error of fit or
-prediction for \code{type}s of "conf_int" and "pred_int".
-Default value is \code{FALSE}.
+\item \code{std_error}: add the standard error of fit or prediction (on
+the scale of the linear predictors) for \code{type}s of "conf_int"
+and "pred_int". Default value is \code{FALSE}.
 \item \code{quantile}: the quantile(s) for quantile regression
 (not implemented yet)
 \item \code{time}: the time(s) for hazard probability estimates

--- a/man/predict.model_fit.Rd
+++ b/man/predict.model_fit.Rd
@@ -36,9 +36,9 @@ value of \code{type}. Possible arguments are:
 is the parameter for the tail area of the intervals
 (e.g. confidence level for confidence intervals).
 Default value is 0.95.
-\item \code{std_error}: add the standard error of fit or
-prediction for \code{type}s of "conf_int" and "pred_int".
-Default value is \code{FALSE}.
+\item \code{std_error}: add the standard error of fit or prediction (on
+the scale of the linear predictors) for \code{type}s of "conf_int"
+and "pred_int". Default value is \code{FALSE}.
 \item \code{quantile}: the quantile(s) for quantile regression
 (not implemented yet)
 \item \code{time}: the time(s) for hazard probability estimates

--- a/man/svm_rbf.Rd
+++ b/man/svm_rbf.Rd
@@ -142,7 +142,7 @@ typically has a different default value (shown in parentheses) for each
 parameter.\tabular{lll}{
    \strong{parsnip} \tab \strong{kernlab} \tab \strong{liquidSVM} \cr
    cost \tab C (1) \tab lambdas (varies) \cr
-   rbf_sigma \tab sigma (1) \tab gammas (varies) \cr
+   rbf_sigma \tab sigma (varies) \tab gammas (varies) \cr
    margin \tab epsilon (0.1) \tab NA \cr
 }
 


### PR DESCRIPTION
Add a tiny tweak to `std_error` documentation (it's on a different scale than everything else that it could get returned with) and redocument