### PR TITLE
Add MacOS testing back to parsnip

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -18,19 +18,22 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: macOS-latest,   r: 'devel',   miniconda: '../miniconda/'}
-          - {os: macOS-latest,   r: 'release', miniconda: '../miniconda/'}
+          - {os: macOS-latest,   r: 'devel'}
+          - {os: macOS-latest,   r: 'release'}
           - {os: windows-latest, r: 'release'}
           - {os: windows-latest, r: '3.6'}
           - {os: ubuntu-16.04,   r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
           - {os: ubuntu-16.04,   r: 'oldrel',  rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
           - {os: ubuntu-16.04,   r: '3.5',     rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
+        include:
+          - os: macOS-latest
+            miniconda: '../miniconda/'
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       RSPM: ${{ matrix.config.rspm }}
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      RETICULATE_MINICONDA_PATH: ${{ matrix.config.miniconda }}
+      RETICULATE_MINICONDA_PATH: ${{ matrix.miniconda }}
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -18,22 +18,19 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: macOS-latest,   r: 'devel'}
-          - {os: macOS-latest,   r: 'release'}
+          - {os: macOS-latest,   r: 'devel',   miniconda: '../miniconda/'}
+          - {os: macOS-latest,   r: 'release', miniconda: '../miniconda/'}
           - {os: windows-latest, r: 'release'}
           - {os: windows-latest, r: '3.6'}
           - {os: ubuntu-16.04,   r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
           - {os: ubuntu-16.04,   r: 'oldrel',  rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
           - {os: ubuntu-16.04,   r: '3.5',     rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
-        include:
-          - os: macOS-latest
-            miniconda: '../miniconda/'
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       RSPM: ${{ matrix.config.rspm }}
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      RETICULATE_MINICONDA_PATH: ${{ matrix.miniconda }}
+      RETICULATE_MINICONDA_PATH: ${{ matrix.config.miniconda }}
 
     steps:
       - uses: actions/checkout@v2
@@ -77,16 +74,18 @@ jobs:
       - name: Install TensorFlow on macOS
         if: runner.os == 'macOS'
         run: |
-          Rscript -e "reticulate::install_miniconda()"
-          Rscript -e "reticulate::conda_create('r-reticulate', packages = 'python==3.6.9', conda = '../miniconda/bin/conda')"
-          Rscript -e "tensorflow::install_tensorflow(version='1.14.0', conda = '../miniconda/bin/conda')"
+          reticulate::install_miniconda()
+          reticulate::conda_create('r-reticulate', packages = 'python==3.6.9', conda = '../miniconda/bin/conda')
+          tensorflow::install_tensorflow(version='1.14.0', conda = '../miniconda/bin/conda')
+        shell: Rscript {0}
 
       - name: Install TensorFlow on Windows and Ubuntu
         if: runner.os != 'macOS'
         run: |
-          Rscript -e "reticulate::install_miniconda()"
-          Rscript -e "reticulate::conda_create('r-reticulate', packages = 'python==3.6.9')"
-          Rscript -e "tensorflow::install_tensorflow(version='1.14.0')"
+          reticulate::install_miniconda()
+          reticulate::conda_create('r-reticulate', packages = 'python==3.6.9')
+          tensorflow::install_tensorflow(version='1.14.0')
+        shell: Rscript {0}
 
       - name: Session info
         run: |

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -21,7 +21,7 @@ jobs:
           - {os: macOS-latest,   r: 'devel'}
           - {os: macOS-latest,   r: 'release'}
           - {os: windows-latest, r: 'release'}
-          - {os: windows-latest, r: 'oldrel'}
+          - {os: windows-latest, r: '3.6'}
           - {os: ubuntu-16.04,   r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
           - {os: ubuntu-16.04,   r: 'oldrel',  rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
           - {os: ubuntu-16.04,   r: '3.5',     rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -70,6 +70,11 @@ jobs:
           remotes::install_cran("rcmdcheck")
         shell: Rscript {0}
 
+      - name: Set Miniconda path
+        if: runner.os == 'MacOS'
+        env:
+          RETICULATE_MINICONDA_PATH: 'miniconda/'
+
       - name: Install TensorFlow
         run: |
           Rscript -e "reticulate::install_miniconda()"

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -18,8 +18,8 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: macOS-latest,   r: 'devel',   miniconda: 'miniconda/'}
-          - {os: macOS-latest,   r: 'release', miniconda: 'miniconda/'}
+          - {os: macOS-latest,   r: 'devel'}
+          - {os: macOS-latest,   r: 'release'}
           - {os: windows-latest, r: 'release'}
           - {os: windows-latest, r: '3.6'}
           - {os: ubuntu-16.04,   r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
@@ -30,7 +30,6 @@ jobs:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       RSPM: ${{ matrix.config.rspm }}
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      RETICULATE_MINICONDA_PATH: ${{ matrix.config.miniconda }}
 
     steps:
       - uses: actions/checkout@v2
@@ -71,21 +70,21 @@ jobs:
           remotes::install_cran("rcmdcheck")
         shell: Rscript {0}
 
-      - name: Install TensorFlow on macOS
-        if: runner.os == 'macOS'
+      - name: Install TensorFlow on macOS and Ubuntu
+        if: runner.os != 'Windows'
+        env:
+          RETICULATE_MINICONDA_PATH: 'miniconda/'
         run: |
-          reticulate::install_miniconda()
-          reticulate::conda_create('r-reticulate', packages = 'python==3.6.9', conda = 'miniconda/bin/conda')
-          tensorflow::install_tensorflow(version='1.14.0', conda = 'miniconda/bin/conda')
-        shell: Rscript {0}
+          Rscript -e "reticulate::install_miniconda()"
+          Rscript -e "reticulate::conda_create('r-reticulate', packages = 'python==3.6.9', conda = 'miniconda/bin/conda')"
+          Rscript -e "tensorflow::install_tensorflow(version='1.14.0', conda = 'miniconda/bin/conda')"
 
-      - name: Install TensorFlow on Ubuntu and Windows
-        if: runner.os != 'macOS'
+      - name: Install TensorFlow on Windows
+        if: runner.os == 'Windows'
         run: |
-          reticulate::install_miniconda()
-          reticulate::conda_create('r-reticulate', packages = 'python==3.6.9')
-          tensorflow::install_tensorflow(version='1.14.0')
-        shell: Rscript {0}
+          Rscript -e "reticulate::install_miniconda()"
+          Rscript -e "reticulate::conda_create('r-reticulate', packages = 'python==3.6.9')"
+          Rscript -e "tensorflow::install_tensorflow(version='1.14.0')"
 
       - name: Session info
         run: |

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -73,7 +73,7 @@ jobs:
       - name: Install TensorFlow on macOS and Ubuntu
         if: runner.os != 'Windows'
         env:
-          RETICULATE_MINICONDA_PATH: 'miniconda/'
+          RETICULATE_MINICONDA_PATH: '../miniconda/'
         run: |
           Rscript -e "reticulate::install_miniconda()"
           Rscript -e "reticulate::conda_create('r-reticulate', packages = 'python==3.6.9', conda = 'miniconda/bin/conda')"

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -18,8 +18,8 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: macOS-latest,   r: 'devel'}
-          - {os: macOS-latest,   r: 'release'}
+          - {os: macOS-latest,   r: 'devel',   miniconda: 'miniconda/'}
+          - {os: macOS-latest,   r: 'release', miniconda: 'miniconda/'}
           - {os: windows-latest, r: 'release'}
           - {os: windows-latest, r: '3.6'}
           - {os: ubuntu-16.04,   r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
@@ -30,6 +30,7 @@ jobs:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       RSPM: ${{ matrix.config.rspm }}
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      RETICULATE_MINICONDA_PATH: ${{ matrix.config.miniconda }}
 
     steps:
       - uses: actions/checkout@v2
@@ -70,21 +71,21 @@ jobs:
           remotes::install_cran("rcmdcheck")
         shell: Rscript {0}
 
-      - name: Install TensorFlow on macOS and Ubuntu
-        if: runner.os != 'Windows'
-        env:
-          RETICULATE_MINICONDA_PATH: 'miniconda/'
+      - name: Install TensorFlow on macOS
+        if: runner.os == 'macOS'
         run: |
-          Rscript -e "reticulate::install_miniconda()"
-          Rscript -e "reticulate::conda_create('r-reticulate', packages = 'python==3.6.9', conda = 'miniconda/bin/conda')"
-          Rscript -e "tensorflow::install_tensorflow(version='1.14.0', conda = 'miniconda/bin/conda')"
+          reticulate::install_miniconda()
+          reticulate::conda_create('r-reticulate', packages = 'python==3.6.9', conda = 'miniconda/bin/conda')
+          tensorflow::install_tensorflow(version='1.14.0', conda = 'miniconda/bin/conda')
+        shell: Rscript {0}
 
-      - name: Install TensorFlow on Windows
-        if: runner.os == 'Windows'
+      - name: Install TensorFlow on Ubuntu and Windows
+        if: runner.os != 'macOS'
         run: |
-          Rscript -e "reticulate::install_miniconda()"
-          Rscript -e "reticulate::conda_create('r-reticulate', packages = 'python==3.6.9')"
-          Rscript -e "tensorflow::install_tensorflow(version='1.14.0')"
+          reticulate::install_miniconda()
+          reticulate::conda_create('r-reticulate', packages = 'python==3.6.9')
+          tensorflow::install_tensorflow(version='1.14.0')
+        shell: Rscript {0}
 
       - name: Session info
         run: |

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,7 +1,10 @@
 on:
   push:
+    branches:
+      - master
   pull_request:
-    types: [opened, synchronize, reopened]
+    branches:
+      - master
 
 name: R-CMD-check
 
@@ -15,11 +18,13 @@ jobs:
       fail-fast: false
       matrix:
         config:
-        - { os: windows-latest, r: '3.6'}
-        - { os: windows-latest, r: '4.0'}
-        - { os: windows-latest, r: 'devel'}
-        - { os: ubuntu-16.04, r: '3.5', cran: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
-        - { os: ubuntu-16.04, r: '3.6', cran: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
+          - {os: macOS-latest,   r: 'devel'}
+          - {os: macOS-latest,   r: 'release'}
+          - {os: windows-latest, r: 'release'}
+          - {os: windows-latest, r: 'oldrel'}
+          - {os: ubuntu-16.04,   r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
+          - {os: ubuntu-16.04,   r: 'oldrel',  rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
+          - {os: ubuntu-16.04,   r: '3.5',     rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,10 +1,7 @@
 on:
   push:
-    branches:
-      - master
   pull_request:
-    branches:
-      - master
+    types: [opened, synchronize, reopened]
 
 name: R-CMD-check
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -70,22 +70,21 @@ jobs:
           remotes::install_cran("rcmdcheck")
         shell: Rscript {0}
 
-      - name: Create Miniconda on macOS and Ubuntu
+      - name: Install TensorFlow on macOS and Ubuntu
         if: runner.os != 'Windows'
         env:
           RETICULATE_MINICONDA_PATH: 'miniconda/'
         run: |
           Rscript -e "reticulate::install_miniconda()"
           Rscript -e "reticulate::conda_create('r-reticulate', packages = 'python==3.6.9', conda = 'miniconda/bin/conda')"
+          Rscript -e "tensorflow::install_tensorflow(version='1.14.0', conda = 'miniconda/bin/conda')"
 
-      - name: Create Miniconda on Windows
+      - name: Install TensorFlow on Windows
         if: runner.os == 'Windows'
         run: |
           Rscript -e "reticulate::install_miniconda()"
           Rscript -e "reticulate::conda_create('r-reticulate', packages = 'python==3.6.9')"
-
-      - name: Install TensorFlow
-        run: Rscript -e "tensorflow::install_tensorflow(version='1.14.0')"
+          Rscript -e "tensorflow::install_tensorflow(version='1.14.0')"
 
       - name: Session info
         run: |

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -25,11 +25,15 @@ jobs:
           - {os: ubuntu-16.04,   r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
           - {os: ubuntu-16.04,   r: 'oldrel',  rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
           - {os: ubuntu-16.04,   r: '3.5',     rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
+        include:
+          - os: macOS-latest
+            miniconda: '../miniconda/'
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       RSPM: ${{ matrix.config.rspm }}
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      RETICULATE_MINICONDA_PATH: ${{ matrix.miniconda }}
 
     steps:
       - uses: actions/checkout@v2
@@ -70,17 +74,15 @@ jobs:
           remotes::install_cran("rcmdcheck")
         shell: Rscript {0}
 
-      - name: Install TensorFlow on macOS and Ubuntu
-        if: runner.os != 'Windows'
-        env:
-          RETICULATE_MINICONDA_PATH: '../miniconda/'
+      - name: Install TensorFlow on macOS
+        if: runner.os == 'macOS'
         run: |
           Rscript -e "reticulate::install_miniconda()"
           Rscript -e "reticulate::conda_create('r-reticulate', packages = 'python==3.6.9', conda = '../miniconda/bin/conda')"
           Rscript -e "tensorflow::install_tensorflow(version='1.14.0', conda = '../miniconda/bin/conda')"
 
-      - name: Install TensorFlow on Windows
-        if: runner.os == 'Windows'
+      - name: Install TensorFlow on Windows and Ubuntu
+        if: runner.os != 'macOS'
         run: |
           Rscript -e "reticulate::install_miniconda()"
           Rscript -e "reticulate::conda_create('r-reticulate', packages = 'python==3.6.9')"

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -76,8 +76,8 @@ jobs:
           RETICULATE_MINICONDA_PATH: '../miniconda/'
         run: |
           Rscript -e "reticulate::install_miniconda()"
-          Rscript -e "reticulate::conda_create('r-reticulate', packages = 'python==3.6.9', conda = 'miniconda/bin/conda')"
-          Rscript -e "tensorflow::install_tensorflow(version='1.14.0', conda = 'miniconda/bin/conda')"
+          Rscript -e "reticulate::conda_create('r-reticulate', packages = 'python==3.6.9', conda = '../miniconda/bin/conda')"
+          Rscript -e "tensorflow::install_tensorflow(version='1.14.0', conda = '../miniconda/bin/conda')"
 
       - name: Install TensorFlow on Windows
         if: runner.os == 'Windows'

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -25,15 +25,11 @@ jobs:
           - {os: ubuntu-16.04,   r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
           - {os: ubuntu-16.04,   r: 'oldrel',  rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
           - {os: ubuntu-16.04,   r: '3.5',     rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
-        include:
-          - os: macOS-latest
-            miniconda: '../miniconda/'
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       RSPM: ${{ matrix.config.rspm }}
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      RETICULATE_MINICONDA_PATH: ${{ matrix.miniconda }}
 
     steps:
       - uses: actions/checkout@v2
@@ -74,19 +70,18 @@ jobs:
           remotes::install_cran("rcmdcheck")
         shell: Rscript {0}
 
-      - name: Install TensorFlow on macOS
-        if: runner.os == 'macOS'
+      - name: Install Miniconda
         run: |
-          reticulate::install_miniconda()
-          reticulate::conda_create('r-reticulate', packages = 'python==3.6.9', conda = '../miniconda/bin/conda')
-          tensorflow::install_tensorflow(version='1.14.0', conda = '../miniconda/bin/conda')
-        shell: Rscript {0}
+          Rscript -e "remotes::install_github('rstudio/reticulate')"
+          Rscript -e "reticulate::install_miniconda()"
 
-      - name: Install TensorFlow on Windows and Ubuntu
-        if: runner.os != 'macOS'
+      - name: Find Miniconda on macOS
+        if: runner.os == 'macOS'
+        run: echo "options(reticulate.conda_binary = reticulate:::miniconda_conda())" >> .Rprofile
+
+      - name: Install TensorFlow
         run: |
-          reticulate::install_miniconda()
-          reticulate::conda_create('r-reticulate', packages = 'python==3.6.9')
+          reticulate::conda_create('r-reticulate', packages = c('python==3.6.9'))
           tensorflow::install_tensorflow(version='1.14.0')
         shell: Rscript {0}
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -70,16 +70,22 @@ jobs:
           remotes::install_cran("rcmdcheck")
         shell: Rscript {0}
 
-      - name: Set Miniconda path
-        if: runner.os == 'MacOS'
+      - name: Create Miniconda on macOS and Ubuntu
+        if: runner.os != 'Windows'
         env:
           RETICULATE_MINICONDA_PATH: 'miniconda/'
+        run: |
+          Rscript -e "reticulate::install_miniconda()"
+          Rscript -e "reticulate::conda_create('r-reticulate', packages = 'python==3.6.9', conda = 'miniconda/bin/conda')"
 
-      - name: Install TensorFlow
+      - name: Create Miniconda on Windows
+        if: runner.os == 'Windows'
         run: |
           Rscript -e "reticulate::install_miniconda()"
           Rscript -e "reticulate::conda_create('r-reticulate', packages = 'python==3.6.9')"
-          Rscript -e "tensorflow::install_tensorflow(version='1.14.0')"
+
+      - name: Install TensorFlow
+        run: Rscript -e "tensorflow::install_tensorflow(version='1.14.0')"
 
       - name: Session info
         run: |

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -13,6 +13,7 @@ jobs:
     runs-on: macOS-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      RETICULATE_MINICONDA_PATH: 'miniconda/'
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: macOS-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      RETICULATE_MINICONDA_PATH: 'miniconda/'
+      RETICULATE_MINICONDA_PATH: '../miniconda/'
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -13,7 +13,6 @@ jobs:
     runs-on: macOS-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      RETICULATE_MINICONDA_PATH: '../miniconda/'
     steps:
       - uses: actions/checkout@v2
 
@@ -44,9 +43,11 @@ jobs:
 
       - name: Install TensorFlow
         run: |
+          Rscript -e "remotes::install_github('rstudio/reticulate')"
           Rscript -e "reticulate::install_miniconda()"
-          Rscript -e "reticulate::conda_create('r-reticulate', packages = 'python==3.6.9', conda = '../miniconda/bin/conda')"
-          Rscript -e "tensorflow::install_tensorflow(version='1.14.0', conda = '../miniconda/bin/conda')"
+          echo "options(reticulate.conda_binary = reticulate:::miniconda_conda())" >> .Rprofile
+          Rscript -e "reticulate::conda_create('r-reticulate', packages = 'python==3.6.9')"
+          Rscript -e "tensorflow::install_tensorflow(version='1.14.0')"
 
       - name: Test coverage
         run: covr::codecov()

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -46,7 +46,7 @@ jobs:
         run: |
           Rscript -e "reticulate::install_miniconda()"
           Rscript -e "reticulate::conda_create('r-reticulate', packages = 'python==3.6.9', conda = 'miniconda/bin/conda')"
-          Rscript -e "tensorflow::install_tensorflow(version='1.14.0')"
+          Rscript -e "tensorflow::install_tensorflow(version='1.14.0', conda = 'miniconda/bin/conda')"
 
       - name: Test coverage
         run: covr::codecov()

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -45,8 +45,8 @@ jobs:
       - name: Install TensorFlow
         run: |
           Rscript -e "reticulate::install_miniconda()"
-          Rscript -e "reticulate::conda_create('r-reticulate', packages = 'python==3.6.9', conda = 'miniconda/bin/conda')"
-          Rscript -e "tensorflow::install_tensorflow(version='1.14.0', conda = 'miniconda/bin/conda')"
+          Rscript -e "reticulate::conda_create('r-reticulate', packages = 'python==3.6.9', conda = '../miniconda/bin/conda')"
+          Rscript -e "tensorflow::install_tensorflow(version='1.14.0', conda = '../miniconda/bin/conda')"
 
       - name: Test coverage
         run: covr::codecov()

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Install TensorFlow
         run: |
           Rscript -e "reticulate::install_miniconda()"
-          Rscript -e "reticulate::conda_create('r-reticulate', packages = 'python==3.6.9')"
+          Rscript -e "reticulate::conda_create('r-reticulate', packages = 'python==3.6.9', conda = 'miniconda/bin/conda')"
           Rscript -e "tensorflow::install_tensorflow(version='1.14.0')"
 
       - name: Test coverage


### PR DESCRIPTION
This PR adds testing on MacOS via GH actions back, and better aligns the R CMD check with current `usethis::use_tidy_github_actions()`.