### PR TITLE
Use reg:squarederror objective for xgboost

### DIFF
--- a/R/boost_tree.R
+++ b/R/boost_tree.R
@@ -301,7 +301,7 @@ xgb_train <- function(
 
 
   if (is.numeric(y)) {
-    loss <- "reg:linear"
+    loss <- "reg:squarederror"
   } else {
     lvl <- levels(y)
     y <- as.numeric(y) - 1
@@ -399,7 +399,7 @@ xgb_pred <- function(object, newdata, ...) {
 
   x = switch(
     object$params$objective,
-    "reg:linear" = , "reg:logistic" = , "binary:logistic" = res,
+    "reg:squarederror" = , "reg:logistic" = , "binary:logistic" = res,
     "binary:logitraw" = stats::binomial()$linkinv(res),
     "multi:softprob" = matrix(res, ncol = object$params$num_class, byrow = TRUE),
     res


### PR DESCRIPTION
This PR closes #310 and addresses the current [CRAN checks](https://cran.r-project.org/web/checks/check_results_parsnip.html).

I don't think we need to worry about deprecating the old objective or anything because it's been changed for so long in xgboost. This solves all the warnings showing up in tests.