### PR TITLE
Avoid tibble warning.

### DIFF
--- a/R/boost_tree_data.R
+++ b/R/boost_tree_data.R
@@ -178,7 +178,7 @@ set_pred(
       if (is.vector(x)) {
         x <- tibble(v1 = 1 - x, v2 = x)
       } else {
-        x <- as_tibble(x)
+        x <- as_tibble(x, .name_repair = "minimal")
       }
       colnames(x) <- object$lvl
       x


### PR DESCRIPTION
When converting a nameless matrix to tibble with `as_tibble()`, you need to specify `.name_repair` to avoid a warning. In this case, the colnames are set on the following line, so it makes sense to do the minimum with colnames inside the `as_tibble` call.