### PR TITLE
Spark intercept removal

### DIFF
--- a/R/predict.R
+++ b/R/predict.R
@@ -244,7 +244,7 @@ prepare_data <- function(object, new_data) {
     get_encoding(class(object$spec)[1]) %>%
     dplyr::filter(mode == object$spec$mode, engine == object$spec$engine) %>%
     dplyr::pull(remove_intercept)
-  if (remove_intercept) {
+  if (remove_intercept & any(grepl("Intercept", names(new_data)))) {
     new_data <- new_data %>% dplyr::select(-dplyr::one_of("(Intercept)"))
   }
 

--- a/R/predict.R
+++ b/R/predict.R
@@ -245,7 +245,7 @@ prepare_data <- function(object, new_data) {
     dplyr::filter(mode == object$spec$mode, engine == object$spec$engine) %>%
     dplyr::pull(remove_intercept)
   if (remove_intercept) {
-    new_data <- new_data[, colnames(new_data) != "(Intercept)", drop = FALSE]
+    new_data <- new_data %>% dplyr::select(-dplyr::one_of("(Intercept)"))
   }
 
   switch(


### PR DESCRIPTION
This updates the last PR to work well with Spark, which cannot execute:

```r
new_data[, colnames(new_data) != "(Intercept)", drop = FALSE]
```

Unit tests in [`extratests`](https://github.com/tidymodels/extratests)