### PR TITLE
Fix pkgdown site

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -33,6 +33,9 @@ jobs:
       - name: Install dependencies
         run: |
           remotes::install_deps(dependencies = TRUE)
+          remotes::install_github("tidyverse/tidytemplate")
+          remotes::install_cran("tidymodels")
+          remotes::install_cran("C50")
           install.packages("pkgdown")
         shell: Rscript {0}
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -71,11 +71,11 @@ navbar:
   - text: "Articles"
     menu:
      - text: Regression modeling
-       href: articles/articles/Regression.html
+       href: https://www.tidymodels.org/learn/models/parsnip-ranger-glmnet/
      - text: Classification modeling
-       href: articles/articles/Classification.html
+       href: https://www.tidymodels.org/learn/models/parsnip-nnet/
      - text: Making a parsnip model from scratch
-       href: articles/articles/Scratch.html
+       href: https://www.tidymodels.org/learn/develop/models/
      - text: Evaluating submodels with the same model object
        href: articles/articles/Submodels.html
   - text: News


### PR DESCRIPTION
This PR fixes the GitHub action for pkgdown, and adds the links for the replaced articles directly to the navbar, which is somewhat nicer than having to click through multiple times.