### PR TITLE
Update and make `mode` checking more robust

### DIFF
--- a/R/misc.R
+++ b/R/misc.R
@@ -212,11 +212,11 @@ check_outcome <- function(y, spec) {
   if (spec$mode == "unknown") {
     return(invisible(NULL))
   } else if (spec$mode == "regression") {
-    if (!is.numeric(y))
-      rlang::abort("The model outcome should be numeric for regression models.")
+    if (!all(map_lgl(y, is.numeric)))
+      rlang::abort("For a regression model, the outcome should be numeric.")
   } else if (spec$mode == "classification") {
-    if (!is.factor(y)) {
-      rlang::abort("The model outcome should be a factor for regression models.")
+    if (!all(map_lgl(y, is.factor))) {
+      rlang::abort("For a classification model, the outcome should be a factor.")
     }
   }
   invisible(NULL)

--- a/tests/testthat/test_boost_tree_xgboost.R
+++ b/tests/testthat/test_boost_tree_xgboost.R
@@ -122,6 +122,16 @@ test_that('xgboost execution, regression', {
     ),
     regexp = NA
   )
+
+  expect_error(
+    res <- parsnip::fit_xy(
+      car_basic,
+      x = mtcars[, num_pred],
+      y = factor(mtcars$vs),
+      control = ctrl
+    ),
+    regexp = "For a regression model"
+  )
 })
 
 

--- a/tests/testthat/test_linear_reg.R
+++ b/tests/testthat/test_linear_reg.R
@@ -242,6 +242,16 @@ test_that('lm execution', {
   )
 
   expect_error(
+    res <- fit_xy(
+      hpc_basic,
+      x = hpc[, num_pred],
+      y = hpc$class,
+      control = ctrl
+    ),
+    regexp = "For a regression model"
+  )
+
+  expect_error(
     res <- fit(
       hpc_basic,
       hpc_bad_form,
@@ -250,13 +260,15 @@ test_that('lm execution', {
     )
   )
 
-  lm_form_catch <- fit(
-    hpc_basic,
-    hpc_bad_form,
-    data = hpc,
-    control = caught_ctrl
+  expect_error(
+    lm_form_catch <- fit(
+      hpc_basic,
+      hpc_bad_form,
+      data = hpc,
+      control = caught_ctrl
+    ),
+    regexp = "For a regression model"
   )
-  expect_true(inherits(lm_form_catch$fit, "try-error"))
 
   ## multivariate y
 

--- a/tests/testthat/test_mars.R
+++ b/tests/testthat/test_mars.R
@@ -151,16 +151,14 @@ test_that('mars execution', {
   expect_true(has_multi_predict(res))
   expect_equal(multi_predict_args(res), "num_terms")
 
-  expect_message(
-    expect_error(
-      res <- fit(
-        hpc_basic,
-        hpc_bad_form,
-        data = hpc,
-        control = ctrl
-      )
+  expect_error(
+    res <- fit(
+      hpc_basic,
+      hpc_bad_form,
+      data = hpc,
+      control = ctrl
     ),
-    "Timing stopped"
+    regexp = "For a regression model"
   )
 
   ## multivariate y
@@ -203,7 +201,7 @@ test_that('mars prediction', {
            input_fields =
              c(430.476046435458, 158.833790342308, 218.07635084308,
                158.833790342308, 158.833790342308)
-           ),
+      ),
       class = "data.frame", row.names = c(NA, -5L)
     )
 

--- a/tests/testthat/test_rand_forest_ranger.R
+++ b/tests/testthat/test_rand_forest_ranger.R
@@ -38,6 +38,16 @@ test_that('ranger classification execution', {
   expect_output(print(res), "parsnip model object")
 
   expect_error(
+    res <- fit(
+      lc_ranger,
+      funded_amnt ~ Class + term,
+      data = lending_club,
+      control = ctrl
+    ),
+    regexp = "For a classification model"
+  )
+
+  expect_error(
     res <- fit_xy(
       lc_ranger,
       x = lending_club[, num_pred],


### PR DESCRIPTION
This PR closes #80.

Before this PR, we had some good checking for the data type on outcomes for classification models. This PR extends the error checking to regression models in the fit helpers. I updated the `check_outcomes()` function and used it when appropriate (when `x` and `y` are available); as far as I can tell, this function wasn't being used before.

``` r
library(parsnip)

data(penguins, package = "modeldata")

penguins_species <- penguins$species
penguins_preds <- dplyr::select(penguins, -species)

rand_forest() %>%
  set_mode("regression") %>%
  set_engine("ranger") %>%
  fit(species ~ ., data = penguins)
#> Error: For a regression model, the outcome should be numeric.

rand_forest() %>%
  set_mode("regression") %>%
  set_engine("ranger") %>%
  fit_xy(x = penguins_preds, y = penguins_species)
#> Error: For a regression model, the outcome should be numeric.

rand_forest() %>%
  set_mode("classification") %>%
  set_engine("ranger") %>%
  fit(bill_length_mm ~ ., data = penguins)
#> Error: For a classification model, the outcome should be a factor.
```

<sup>Created on 2020-10-19 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>