### PR TITLE
Reorder columns at prediction time for glmnet

### DIFF
--- a/R/linear_reg_data.R
+++ b/R/linear_reg_data.R
@@ -168,7 +168,7 @@ set_pred(
     args =
       list(
         object = expr(object$fit),
-        newx = quote(as.matrix(new_data[, rownames(object$fit$beta)])),
+        newx = expr(as.matrix(new_data[, rownames(object$fit$beta)])),
         type = "response",
         s = expr(object$spec$args$penalty)
       )

--- a/R/linear_reg_data.R
+++ b/R/linear_reg_data.R
@@ -168,7 +168,7 @@ set_pred(
     args =
       list(
         object = expr(object$fit),
-        newx = expr(as.matrix(new_data)),
+        newx = quote(as.matrix(new_data[, rownames(object$fit$beta)])),
         type = "response",
         s = expr(object$spec$args$penalty)
       )

--- a/R/logistic_reg_data.R
+++ b/R/logistic_reg_data.R
@@ -186,10 +186,10 @@ set_pred(
     func = c(fun = "predict"),
     args =
       list(
-        object = quote(object$fit),
-        newx = quote(as.matrix(new_data[, rownames(object$fit$beta)])),
+        object = expr(object$fit),
+        newx = expr(as.matrix(new_data[, rownames(object$fit$beta)])),
         type = "response",
-        s = quote(object$spec$args$penalty)
+        s = expr(object$spec$args$penalty)
       )
   )
 )

--- a/R/logistic_reg_data.R
+++ b/R/logistic_reg_data.R
@@ -187,7 +187,7 @@ set_pred(
     args =
       list(
         object = quote(object$fit),
-        newx = quote(as.matrix(new_data)),
+        newx = quote(as.matrix(new_data[, rownames(object$fit$beta)])),
         type = "response",
         s = quote(object$spec$args$penalty)
       )

--- a/R/multinom_reg_data.R
+++ b/R/multinom_reg_data.R
@@ -79,10 +79,10 @@ set_pred(
     func = c(fun = "predict"),
     args =
       list(
-        object = quote(object$fit),
-        newx = quote(as.matrix(new_data[, rownames(object$fit$beta[[1]])])),
+        object = expr(object$fit),
+        newx = expr(as.matrix(new_data[, rownames(object$fit$beta[[1]])])),
         type = "response",
-        s = quote(object$spec$args$penalty)
+        s = expr(object$spec$args$penalty)
       )
   )
 )

--- a/R/multinom_reg_data.R
+++ b/R/multinom_reg_data.R
@@ -61,7 +61,7 @@ set_pred(
     args =
       list(
         object = quote(object$fit),
-        newx = quote(as.matrix(new_data)),
+        newx = quote(as.matrix(new_data[, rownames(object$fit$beta[[1]])])),
         type = "class",
         s = quote(object$spec$args$penalty)
       )
@@ -80,7 +80,7 @@ set_pred(
     args =
       list(
         object = quote(object$fit),
-        newx = quote(as.matrix(new_data)),
+        newx = quote(as.matrix(new_data[, rownames(object$fit$beta[[1]])])),
         type = "response",
         s = quote(object$spec$args$penalty)
       )


### PR DESCRIPTION
Closes #273.

I played around in the various `predict` functions and methods today, and I think the best place to do this reordering is in the prediction module for the two glmnet models. This is mainly because:

- the fitted object is available
- all the preprocessing has already been done

``` r
library(parsnip)
library(tidyverse)
set.seed(989)
# Gaussian
x = matrix(rnorm(100 * length(letters)), 100, length(letters)) %>%
  magrittr::set_colnames(letters)
y = rnorm(100)

glmnet_spec <- linear_reg(penalty = .1) %>%
  set_engine('glmnet')

glmnet_fit <- fit_xy(glmnet_spec, x, y)

glmnet_fit %>%
  predict(x)
#> # A tibble: 100 x 1
#>      .pred
#>      <dbl>
#>  1 -0.135 
#>  2  0.285 
#>  3 -0.126 
#>  4  0.222 
#>  5 -0.138 
#>  6 -0.157 
#>  7  0.0271
#>  8 -0.0215
#>  9 -0.0702
#> 10 -0.0283
#> # … with 90 more rows

glmnet_fit %>%
  predict(x[, sample(colnames(x))])
#> # A tibble: 100 x 1
#>      .pred
#>      <dbl>
#>  1 -0.135 
#>  2  0.285 
#>  3 -0.126 
#>  4  0.222 
#>  5 -0.138 
#>  6 -0.157 
#>  7  0.0271
#>  8 -0.0215
#>  9 -0.0702
#> 10 -0.0283
#> # … with 90 more rows



## still works with dummy variables
data(ames, package = "modeldata")

parsnip_form_fit <- glmnet_spec %>%
  fit(Sale_Price ~ Year_Built + Alley, data = ames)

predict(parsnip_form_fit, ames %>% select(Year_Built, Alley))
#> # A tibble: 2,930 x 1
#>      .pred
#>      <dbl>
#>  1 163033.
#>  2 164552.
#>  3 159996.
#>  4 175180.
#>  5 219215.
#>  6 220733.
#>  7 225289.
#>  8 211623.
#>  9 216178.
#> 10 222252.
#> # … with 2,920 more rows
```

<sup>Created on 2020-10-20 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>

I ran [extratests](https://github.com/tidymodels/extratests/) with this change and there were no failures related to this.