### PR TITLE
Change redirect url

### DIFF
--- a/vignettes/articles/Models.Rmd
+++ b/vignettes/articles/Models.Rmd
@@ -9,4 +9,4 @@ output:
 ---
 
 
-This list can now be found at [`tidymodels.org`](https://www.tidymodels.org/find/).
+This list can now be found at [`tidymodels.org`](https://www.tidymodels.org/find/parsnip/).


### PR DESCRIPTION
Just proposing that the redirect should go straight to the find/parsnip page which lists all models (saves 1 click)