### PR TITLE
Use drop = FALSE for glmnet predictions on single observation

### DIFF
--- a/R/linear_reg_data.R
+++ b/R/linear_reg_data.R
@@ -168,7 +168,7 @@ set_pred(
     args =
       list(
         object = expr(object$fit),
-        newx = expr(as.matrix(new_data[, rownames(object$fit$beta)])),
+        newx = expr(as.matrix(new_data[, rownames(object$fit$beta), drop = FALSE])),
         type = "response",
         s = expr(object$spec$args$penalty)
       )

--- a/R/logistic_reg_data.R
+++ b/R/logistic_reg_data.R
@@ -187,7 +187,7 @@ set_pred(
     args =
       list(
         object = expr(object$fit),
-        newx = expr(as.matrix(new_data[, rownames(object$fit$beta)])),
+        newx = expr(as.matrix(new_data[, rownames(object$fit$beta), drop = FALSE])),
         type = "response",
         s = expr(object$spec$args$penalty)
       )

--- a/R/multinom_reg_data.R
+++ b/R/multinom_reg_data.R
@@ -61,7 +61,7 @@ set_pred(
     args =
       list(
         object = quote(object$fit),
-        newx = quote(as.matrix(new_data[, rownames(object$fit$beta[[1]])])),
+        newx = quote(as.matrix(new_data[, rownames(object$fit$beta[[1]]), drop = FALSE])),
         type = "class",
         s = quote(object$spec$args$penalty)
       )
@@ -80,7 +80,7 @@ set_pred(
     args =
       list(
         object = expr(object$fit),
-        newx = expr(as.matrix(new_data[, rownames(object$fit$beta[[1]])])),
+        newx = expr(as.matrix(new_data[, rownames(object$fit$beta[[1]]), drop = FALSE])),
         type = "response",
         s = expr(object$spec$args$penalty)
       )


### PR DESCRIPTION
Closes #392 

This PR adds `drop = FALSE` for the linear, logistic, and multinomial glmnet models.

``` r
library(parsnip)

fitted_parsnip <- linear_reg(
  penalty = 0.1 # set for simiplicity
) %>%
  set_mode('regression') %>%
  set_engine('glmnet') %>%
  fit(Sepal.Length ~ Sepal.Width + Petal.Length, iris)

predict(fitted_parsnip, head(iris))
#> # A tibble: 6 x 1
#>   .pred
#>   <dbl>
#> 1  5.05
#> 2  4.95
#> 3  4.96
#> 4  5.01
#> 5  5.07
#> 6  5.24
predict(fitted_parsnip, head(iris, 1))
#> # A tibble: 1 x 1
#>   .pred
#>   <dbl>
#> 1  5.05
```

<sup>Created on 2020-11-17 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>