### PR TITLE
Remove backticks in Spark error messages

### DIFF
--- a/R/descriptors.R
+++ b/R/descriptors.R
@@ -250,9 +250,9 @@ get_descr_spark <- function(formula, data) {
   .obs   <- function() obs
   .lvls  <- function() y_vals
   .facts <- function() factor_pred
-  .x       <- function() abort("Descriptor `.x()` not defined for Spark.")
-  .y       <- function() abort("Descriptor `.y()` not defined for Spark.")
-  .dat     <- function() abort("Descriptor `.dat()` not defined for Spark.")
+  .x       <- function() abort("Descriptor .x() not defined for Spark.")
+  .y       <- function() abort("Descriptor .y() not defined for Spark.")
+  .dat     <- function() abort("Descriptor .dat() not defined for Spark.")
 
   # still need .x(), .y(), .dat() ?
 


### PR DESCRIPTION
Closes #393 

The backticks in these error messages cause... errors. 🆒 😎 😭 

When this is merged in, we can look at adding back in the tests in tidymodels/extratests#12.