### PR TITLE
update rstudio addin binding for parsnip_addin

### DIFF
--- a/inst/rstudio/addins.dcf
+++ b/inst/rstudio/addins.dcf
@@ -1,5 +1,5 @@
 
 Name: Generate parsnip model specifications
 Description: Automatically generate code for multiple parsnip model specifications.
-Binding: write_parsnip_specs
+Binding: parsnip_addin
 Interactive: true


### PR DESCRIPTION
The binding for the Rstudio addin wasn't updated when the function was changed from `write_parsnip_specs()` to `parsnip_addin()`. https://github.com/tidymodels/parsnip/pull/408/commits/ea6ec0dda5a78e628c83f840759cd459d3306885

This PR updates the binding