### PR TITLE
Add LiblineaR engine to `logistic_reg()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,7 @@ Imports:
     prettyunits,
     vctrs (>= 0.2.0)
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.1.9000
+RoxygenNote: 7.1.1.9001
 Suggests: 
     testthat,
     knitr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 * The `liquidSVM` engine for `svm_rbf()` was deprecated due to that package's removal from CRAN. (#425)
 
-* A new linear SVM model `svm_linear()` is now available with the `LiblineaR` engine (#424), and the `LiblineaR` engine is available for `logistic_reg()` as well.
+* A new linear SVM model `svm_linear()` is now available with the `LiblineaR` engine (#424), and the `LiblineaR` engine is available for `logistic_reg()` as well (#429).
 
 # parsnip 0.1.5
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 * The `liquidSVM` engine for `svm_rbf()` was deprecated due to that package's removal from CRAN. (#425)
 
-* A new linear SVM model `svm_linear()` is now available with the `LiblineaR` engine. (#424)
+* A new linear SVM model `svm_linear()` is now available with the `LiblineaR` engine (#424), and the `LiblineaR` engine is available for `logistic_reg()` as well.
 
 # parsnip 0.1.5
 

--- a/R/logistic_reg_data.R
+++ b/R/logistic_reg_data.R
@@ -233,6 +233,104 @@ set_pred(
 
 # ------------------------------------------------------------------------------
 
+set_model_engine("logistic_reg", "classification", "LiblineaR")
+set_dependency("logistic_reg", "LiblineaR", "LiblineaR")
+
+set_fit(
+  model = "logistic_reg",
+  eng = "LiblineaR",
+  mode = "classification",
+  value = list(
+    interface = "matrix",
+    protect = c("x", "y", "wi"),
+    data = c(x = "data", y = "target"),
+    func = c(pkg = "LiblineaR", fun = "LiblineaR"),
+    defaults = list(verbose = FALSE)
+  )
+)
+
+set_encoding(
+  model = "logistic_reg",
+  eng = "LiblineaR",
+  mode = "classification",
+  options = list(
+    predictor_indicators = "none",
+    compute_intercept = FALSE,
+    remove_intercept = FALSE,
+    allow_sparse_x = FALSE
+  )
+)
+
+set_model_arg(
+  model = "logistic_reg",
+  eng = "LiblineaR",
+  parsnip = "penalty",
+  original = "cost",
+  func = list(pkg = "dials", fun = "penalty"),
+  has_submodel = TRUE
+)
+
+set_model_arg(
+  model = "logistic_reg",
+  eng = "LiblineaR",
+  parsnip = "mixture",
+  original = "type",
+  func = list(pkg = "dials", fun = "mixture"),
+  has_submodel = FALSE
+)
+
+set_pred(
+  model = "logistic_reg",
+  eng = "LiblineaR",
+  mode = "classification",
+  type = "class",
+  value = list(
+    pre = NULL,
+    post = liblinear_preds,
+    func = c(fun = "predict"),
+    args =
+      list(
+        object = quote(object$fit),
+        newx = expr(as.matrix(new_data))
+      )
+  )
+)
+
+set_pred(
+  model = "logistic_reg",
+  eng = "LiblineaR",
+  mode = "classification",
+  type = "prob",
+  value = list(
+    pre = NULL,
+    post = liblinear_probs,
+    func = c(fun = "predict"),
+    args =
+      list(
+        object = quote(object$fit),
+        newx = expr(as.matrix(new_data)),
+        proba = TRUE
+      )
+  )
+)
+
+set_pred(
+  model = "logistic_reg",
+  eng = "LiblineaR",
+  mode = "classification",
+  type = "raw",
+  value = list(
+    pre = NULL,
+    post = NULL,
+    func = c(fun = "predict"),
+    args = list(
+      object = quote(object$fit),
+      newx = quote(new_data))
+  )
+)
+
+# ------------------------------------------------------------------------------
+
 set_model_engine("logistic_reg", "classification", "spark")
 set_dependency("logistic_reg", "spark", "sparklyr")
 

--- a/man/logistic_reg.Rd
+++ b/man/logistic_reg.Rd
@@ -150,7 +150,9 @@ ridge) or 1 (for lasso) but not other intermediate values. In the
 \code{LiblineaR} documentation, these correspond to types 0 (L2-regularized)
 and 6 (L1-regularized).
 
-Be aware that the \code{LiblineaR} engine regularizes the intercept.
+Be aware that the \code{LiblineaR} engine regularizes the intercept. Other
+regularized regression models do not, which will result in different
+parameter estimates.
 }
 
 \subsection{stan}{\if{html}{\out{<div class="r">}}\preformatted{logistic_reg() \%>\% 

--- a/man/logistic_reg.Rd
+++ b/man/logistic_reg.Rd
@@ -21,15 +21,16 @@ logistic_reg(mode = "classification", penalty = NULL, mixture = NULL)
 The only possible value for this model is "classification".}
 
 \item{penalty}{A non-negative number representing the total
-amount of regularization (\code{glmnet}, \code{keras}, and \code{spark} only).
+amount of regularization (\code{glmnet}, \code{LiblineaR}, \code{keras}, and \code{spark} only).
 For \code{keras} models, this corresponds to purely L2 regularization
-(aka weight decay) while the other models can be a combination
+(aka weight decay) while the other models can be either or a combination
 of L1 and L2 (depending on the value of \code{mixture}).}
 
 \item{mixture}{A number between zero and one (inclusive) that is the
 proportion of L1 regularization (i.e. lasso) in the model. When
 \code{mixture = 1}, it is a pure lasso model while \code{mixture = 0} indicates that
-ridge regression is being used. (\code{glmnet} and \code{spark} only).}
+ridge regression is being used. (\code{glmnet}, \code{LiblineaR}, and \code{spark} only).
+For \code{LiblineaR} models, \code{mixture} must be exactly 0 or 1 only.}
 
 \item{object}{A logistic regression model specification.}
 
@@ -67,7 +68,7 @@ For \code{logistic_reg()}, the mode will always be "classification".
 The model can be created using the \code{fit()} function using the
 following \emph{engines}:
 \itemize{
-\item \pkg{R}:  \code{"glm"}  (the default) or \code{"glmnet"}
+\item \pkg{R}:  \code{"glm"}  (the default), \code{"glmnet"}, or \code{"LiblineaR"}
 \item \pkg{Stan}:  \code{"stan"}
 \item \pkg{Spark}: \code{"spark"}
 \item \pkg{keras}: \code{"keras"}
@@ -131,6 +132,23 @@ column called \code{.pred} that contains a tibble with all of the penalty
 results.
 }
 
+\subsection{LiblineaR}{\if{html}{\out{<div class="r">}}\preformatted{logistic_reg() \%>\% 
+  set_engine("LiblineaR") \%>\% 
+  set_mode("classification") \%>\% 
+  translate()
+}\if{html}{\out{</div>}}\preformatted{## Logistic Regression Model Specification (classification)
+## 
+## Computational engine: LiblineaR 
+## 
+## Model fit template:
+## LiblineaR::LiblineaR(x = missing_arg(), y = missing_arg(), wi = missing_arg(), 
+##     verbose = FALSE)
+}
+
+For \code{LiblineaR} models, the value for \code{mixture} can either be 0 (for
+ridge) or 1 (for lasso) but not other intermediate values.
+}
+
 \subsection{stan}{\if{html}{\out{<div class="r">}}\preformatted{logistic_reg() \%>\% 
   set_engine("stan") \%>\% 
   set_mode("classification") \%>\% 
@@ -187,10 +205,10 @@ predictive distribution as appropriate) is returned.
 The standardized parameter names in parsnip can be mapped to their
 original names in each engine that has main parameters. Each engine
 typically has a different default value (shown in parentheses) for each
-parameter.\tabular{llll}{
-   \strong{parsnip} \tab \strong{glmnet} \tab \strong{spark} \tab \strong{keras} \cr
-   penalty \tab lambda \tab reg_param (0) \tab penalty (0) \cr
-   mixture \tab alpha (1) \tab elastic_net_param (0) \tab NA \cr
+parameter.\tabular{lllll}{
+   \strong{parsnip} \tab \strong{glmnet} \tab \strong{LiblineaR} \tab \strong{spark} \tab \strong{keras} \cr
+   penalty \tab lambda \tab cost \tab reg_param (0) \tab penalty (0) \cr
+   mixture \tab alpha (1) \tab type (0) \tab elastic_net_param (0) \tab NA \cr
 }
 
 }

--- a/man/logistic_reg.Rd
+++ b/man/logistic_reg.Rd
@@ -146,7 +146,11 @@ results.
 }
 
 For \code{LiblineaR} models, the value for \code{mixture} can either be 0 (for
-ridge) or 1 (for lasso) but not other intermediate values.
+ridge) or 1 (for lasso) but not other intermediate values. In the
+\code{LiblineaR} documentation, these correspond to types 0 (L2-regularized)
+and 6 (L1-regularized).
+
+Be aware that the \code{LiblineaR} engine regularizes the intercept.
 }
 
 \subsection{stan}{\if{html}{\out{<div class="r">}}\preformatted{logistic_reg() \%>\% 

--- a/man/rmd/logistic-reg.Rmd
+++ b/man/rmd/logistic-reg.Rmd
@@ -46,7 +46,7 @@ For `LiblineaR` models, the value for `mixture` can either be 0 (for ridge) or 1
 (for lasso) but not other intermediate values. In the `LiblineaR` documentation, 
 these correspond to types 0 (L2-regularized) and 6 (L1-regularized).
 
-Be aware that the `LiblineaR` engine regularizes the intercept.
+Be aware that the `LiblineaR` engine regularizes the intercept. Other regularized regression models do not and will result in different parameter estimates.
 
 ## stan
 
@@ -104,4 +104,3 @@ get_defaults_logistic_reg <- function() {
 }
 convert_args("logistic_reg")
 ```
-

--- a/man/rmd/logistic-reg.Rmd
+++ b/man/rmd/logistic-reg.Rmd
@@ -46,7 +46,8 @@ For `LiblineaR` models, the value for `mixture` can either be 0 (for ridge) or 1
 (for lasso) but not other intermediate values. In the `LiblineaR` documentation, 
 these correspond to types 0 (L2-regularized) and 6 (L1-regularized).
 
-Be aware that the `LiblineaR` engine regularizes the intercept. Other regularized regression models do not and will result in different parameter estimates.
+Be aware that the `LiblineaR` engine regularizes the intercept. Other 
+regularized regression models do not, which will result in different parameter estimates.
 
 ## stan
 

--- a/man/rmd/logistic-reg.Rmd
+++ b/man/rmd/logistic-reg.Rmd
@@ -33,6 +33,18 @@ multiple  penalties, the `multi_predict()` function can be used. It  returns a
 tibble with a list column called `.pred` that contains  a tibble with all of the
 penalty results.
 
+## LiblineaR
+
+```{r liblinear-reg}
+logistic_reg() %>% 
+  set_engine("LiblineaR") %>% 
+  set_mode("classification") %>% 
+  translate()
+```
+
+For `LiblineaR` models, the value for `mixture` can either be 0 (for ridge) or 1 
+(for lasso) but not other intermediate values.
+
 ## stan
 
 ```{r stan-reg}
@@ -81,6 +93,7 @@ get_defaults_logistic_reg <- function() {
   tibble::tribble(
     ~model,          ~engine,     ~parsnip,            ~original,  ~default,
     "logistic_reg",  "glmnet",    "mixture",              "alpha",  get_arg("glmnet", "glmnet", "alpha"),
+    "logistic_reg",  "LiblineaR", "mixture",              "type",   "0",
     "logistic_reg",  "spark",     "penalty",          "reg_param",  get_arg("sparklyr", "ml_logistic_regression", "reg_param"),
     "logistic_reg",  "spark",     "mixture",  "elastic_net_param",  get_arg("sparklyr", "ml_logistic_regression", "elastic_net_param"),
     "logistic_reg",  "keras",     "penalty",            "penalty",  get_arg("parsnip", "keras_mlp", "penalty"),

--- a/man/rmd/logistic-reg.Rmd
+++ b/man/rmd/logistic-reg.Rmd
@@ -43,7 +43,10 @@ logistic_reg() %>%
 ```
 
 For `LiblineaR` models, the value for `mixture` can either be 0 (for ridge) or 1 
-(for lasso) but not other intermediate values.
+(for lasso) but not other intermediate values. In the `LiblineaR` documentation, 
+these correspond to types 0 (L2-regularized) and 6 (L1-regularized).
+
+Be aware that the `LiblineaR` engine regularizes the intercept.
 
 ## stan
 

--- a/tests/testthat/test_logistic_reg.R
+++ b/tests/testthat/test_logistic_reg.R
@@ -147,6 +147,37 @@ test_that('primary arguments', {
                )
   )
 
+  penalty_v <- logistic_reg(penalty = varying())
+  penalty_v_glmnet <- translate(penalty_v %>% set_engine("glmnet"))
+  penalty_v_liblinear <- translate(penalty_v %>% set_engine("LiblineaR"))
+  penalty_v_spark <- translate(penalty_v %>% set_engine("spark"))
+  expect_equal(penalty_v_glmnet$method$fit$args,
+               list(
+                 x = expr(missing_arg()),
+                 y = expr(missing_arg()),
+                 weights = expr(missing_arg()),
+                 family = "binomial"
+               )
+  )
+  expect_equal(penalty_v_liblinear$method$fit$args,
+               list(
+                 x = expr(missing_arg()),
+                 y = expr(missing_arg()),
+                 wi = expr(missing_arg()),
+                 cost = new_empty_quosure(varying()),
+                 verbose = FALSE
+               )
+  )
+  expect_equal(penalty_v_spark$method$fit$args,
+               list(
+                 x = expr(missing_arg()),
+                 formula = expr(missing_arg()),
+                 weight_col = expr(missing_arg()),
+                 reg_param = new_empty_quosure(varying()),
+                 family = "binomial"
+               )
+  )
+
 })
 
 test_that('engine arguments', {

--- a/tests/testthat/test_logistic_reg.R
+++ b/tests/testthat/test_logistic_reg.R
@@ -175,14 +175,15 @@ test_that('engine arguments', {
     )
   )
 
-  liblinear_verb <- logistic_reg()
+  liblinear_bias <- logistic_reg()
   expect_equal(
-    translate(liblinear_verb %>% set_engine("LiblineaR", verbose = TRUE))$method$fit$args,
+    translate(liblinear_bias %>% set_engine("LiblineaR", bias = 0))$method$fit$args,
     list(
       x = expr(missing_arg()),
       y = expr(missing_arg()),
       wi = expr(missing_arg()),
-      verbose = new_empty_quosure(TRUE)
+      bias = new_empty_quosure(0),
+      verbose = FALSE
     )
   )
 


### PR DESCRIPTION
This PR adds the LiblineaR engine to `logistic_reg()`.

We are currently having some real uncertainty about what is going on with the `cost` argument to `LiblineaR::LiblineaR()`. The docs say:

> cost of constraints violation (default: 1). Rules the trade-off between regularization and correct classification on data. It can be seen as the inverse of a regularization constant. 

However, for both lasso and ridge regression, treating `1 / cost` like a regularization penalty gives very different results than glmnet. It seems like LIBLINEAR is using a different optimizer or maybe solving a different thing altogether??? 😮 

Here is ridge (similar for lasso):

``` r
library(tidyverse)
library(parsnip)
data(two_class_dat, package = "modeldata")
data_grid <- crossing(A = seq(0.4, 4, length = 200), B = seq(.14, 3.9, length = 200))

liblinear_pred <- 
  logistic_reg(penalty = 0.01, mixture = 0) %>%
  set_engine("LiblineaR") %>%
  set_mode("classification") %>%
  fit(Class ~ ., two_class_dat) %>% 
  predict(data_grid, type = "prob") %>% 
  bind_cols(data_grid) %>% 
  mutate(engine = "LiblineaR")

glmnet_pred <- 
  logistic_reg(penalty = 0.01, mixture = 0) %>%
  set_engine("glmnet") %>%
  set_mode("classification") %>%
  fit(Class ~ ., two_class_dat) %>% 
  predict(data_grid, type = "prob") %>% 
  bind_cols(data_grid) %>% 
  mutate(engine = "glmnet")

glm_pred <- 
  logistic_reg() %>%
  set_engine("glm") %>%
  set_mode("classification") %>%
  fit(Class ~ ., two_class_dat) %>% 
  predict(data_grid, type = "prob") %>% 
  bind_cols(data_grid) %>% 
  mutate(engine = "glm")


bind_rows(liblinear_pred, glmnet_pred, glm_pred) %>%
  ggplot(aes(x = A, y = B)) + 
  geom_point(data = two_class_dat, aes(col = Class), alpha = .5, show.legend = FALSE) + 
  geom_contour(aes( z = .pred_Class1, lty = engine), breaks = 0.5, col = "black") + 
  coord_equal() + 
  theme_minimal()
```

![](https://i.imgur.com/uVA6AGN.png)

<sup>Created on 2021-02-11 by the [reprex package](https://reprex.tidyverse.org) (v1.0.0)</sup>

You have to really bump up the regularization to get LiblineaR to do anything different than `glm()`.