### PR TITLE
Fix documentation of available engines for `multinom_reg()`

### DIFF
--- a/R/multinom_reg.R
+++ b/R/multinom_reg.R
@@ -35,7 +35,7 @@
 #'  following _engines_:
 #' \itemize{
 #' \item \pkg{R}:   `"glmnet"`  (the default), `"nnet"`
-#' \item \pkg{Stan}:  `"stan"`
+#' \item \pkg{Spark}: `"spark"`
 #' \item \pkg{keras}: `"keras"`
 #' }
 #'

--- a/man/linear_reg.Rd
+++ b/man/linear_reg.Rd
@@ -146,7 +146,7 @@ results.
 }
 
 Note that the \code{refresh} default prevents logging of the estimation
-process. Change this value in \code{set_engine()} will show the logs.
+process. Change this value in \code{set_engine()} to show the logs.
 
 For prediction, the \code{stan} engine can compute posterior intervals
 analogous to confidence and prediction intervals. In these instances,

--- a/man/logistic_reg.Rd
+++ b/man/logistic_reg.Rd
@@ -145,7 +145,7 @@ results.
 }
 
 Note that the \code{refresh} default prevents logging of the estimation
-process. Change this value in \code{set_engine()} will show the logs.
+process. Change this value in \code{set_engine()} to show the logs.
 
 For prediction, the \code{stan} engine can compute posterior intervals
 analogous to confidence and prediction intervals. In these instances,

--- a/man/multinom_reg.Rd
+++ b/man/multinom_reg.Rd
@@ -68,7 +68,7 @@ The model can be created using the \code{fit()} function using the
 following \emph{engines}:
 \itemize{
 \item \pkg{R}:   \code{"glmnet"}  (the default), \code{"nnet"}
-\item \pkg{Stan}:  \code{"stan"}
+\item \pkg{Spark}: \code{"spark"}
 \item \pkg{keras}: \code{"keras"}
 }
 }

--- a/man/rmd/linear-reg.Rmd
+++ b/man/rmd/linear-reg.Rmd
@@ -42,7 +42,7 @@ linear_reg() %>%
 ```
 
 Note that the `refresh` default prevents logging of the estimation process.
-Change this value in `set_engine()` will show the logs.
+Change this value in `set_engine()` to show the logs.
 
 For prediction, the `stan` engine can compute posterior  intervals analogous to
 confidence and prediction intervals. In  these instances, the units are the

--- a/man/rmd/logistic-reg.Rmd
+++ b/man/rmd/logistic-reg.Rmd
@@ -43,7 +43,7 @@ logistic_reg() %>%
 ```
 
 Note that the `refresh` default prevents logging of the estimation process.
-Change this value in `set_engine()` will show the logs.
+Change this value in `set_engine()` to show the logs.
 
 For prediction, the `stan` engine can compute posterior  intervals analogous to
 confidence and prediction intervals. In  these instances, the units are the


### PR DESCRIPTION
The documentation said there was a Stan engine but it's Spark:

``` r
parsnip::show_engines("multinom_reg")
#> # A tibble: 4 x 2
#>   engine mode          
#>   <chr>  <chr>         
#> 1 glmnet classification
#> 2 spark  classification
#> 3 keras  classification
#> 4 nnet   classification
```

<sup>Created on 2021-02-23 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>
