### PR TITLE
Add kernlab engine for svm_linear()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 * The `liquidSVM` engine for `svm_rbf()` was deprecated due to that package's removal from CRAN. (#425)
 
-* A new linear SVM model `svm_linear()` is now available with the `LiblineaR` engine (#424), and the `LiblineaR` engine is available for `logistic_reg()` as well (#429).
+* A new linear SVM model `svm_linear()` is now available with the `LiblineaR` engine (#424) and the `kernlab` engine (#438), and the `LiblineaR` engine is available for `logistic_reg()` as well (#429).
 
 # parsnip 0.1.5
 

--- a/R/svm_linear.R
+++ b/R/svm_linear.R
@@ -29,7 +29,7 @@
 #' The model can be created using the `fit()` function using the
 #'  following _engines_:
 #' \itemize{
-#' \item \pkg{R}:  `"LiblineaR"` (the default)
+#' \item \pkg{R}:  `"LiblineaR"` (the default) or `"kernlab"`
 #' }
 #'
 #'
@@ -173,6 +173,16 @@ translate.svm_linear <- function(x, engine = x$engine, ...) {
     }
   }
 
+  if (x$engine == "kernlab") {
+
+    # unless otherwise specified, classification models predict probabilities
+    if (x$mode == "classification" && !any(arg_names == "prob.model"))
+      arg_vals$prob.model <- TRUE
+    if (x$mode == "classification" && any(arg_names == "epsilon"))
+      arg_vals$epsilon <- NULL
+
+  }
+
   x$method$fit$args <- arg_vals
 
   # worried about people using this to modify the specification
@@ -189,5 +199,9 @@ check_args.svm_linear <- function(object) {
 
 svm_linear_post <- function(results, object) {
   results$predictions
+}
+
+svm_reg_linear_post <- function(results, object) {
+  results[,1]
 }
 

--- a/R/svm_linear_data.R
+++ b/R/svm_linear_data.R
@@ -36,9 +36,7 @@ set_fit(
     protect = c("x", "y", "wi"),
     data = c(x = "data", y = "target"),
     func = c(pkg = "LiblineaR", fun = "LiblineaR"),
-    defaults = list(
-      type = 11
-    )
+    defaults = list(type = 11)
   )
 )
 
@@ -51,9 +49,7 @@ set_fit(
     data = c(x = "data", y = "target"),
     protect = c("x", "y", "wi"),
     func = c(pkg = "LiblineaR", fun = "LiblineaR"),
-    defaults = list(
-      type = 1
-    )
+    defaults = list(type = 1)
   )
 )
 
@@ -162,3 +158,158 @@ set_pred(
       newx = quote(new_data))
   )
 )
+
+# ------------------------------------------------------------------------------
+
+set_model_engine("svm_linear", "classification", "kernlab")
+set_model_engine("svm_linear", "regression", "kernlab")
+set_dependency("svm_linear", "kernlab", "kernlab")
+
+set_model_arg(
+  model = "svm_linear",
+  eng = "kernlab",
+  parsnip = "cost",
+  original = "C",
+  func = list(pkg = "dials", fun = "cost", range = c(-10, 5)),
+  has_submodel = FALSE
+)
+
+set_model_arg(
+  model = "svm_linear",
+  eng = "kernlab",
+  parsnip = "margin",
+  original = "epsilon",
+  func = list(pkg = "dials", fun = "svm_margin"),
+  has_submodel = FALSE
+)
+
+set_fit(
+  model = "svm_linear",
+  eng = "kernlab",
+  mode = "regression",
+  value = list(
+    interface = "formula",
+    data = c(formula = "x", data = "data"),
+    protect = c("x", "data"),
+    func = c(pkg = "kernlab", fun = "ksvm"),
+    defaults = list(kernel = "vanilladot")
+  )
+)
+
+set_fit(
+  model = "svm_linear",
+  eng = "kernlab",
+  mode = "classification",
+  value = list(
+    interface = "formula",
+    data = c(formula = "x", data = "data"),
+    protect = c("x", "data"),
+    func = c(pkg = "kernlab", fun = "ksvm"),
+    defaults = list(kernel = "vanilladot")
+  )
+)
+
+set_encoding(
+  model = "svm_linear",
+  eng = "kernlab",
+  mode = "regression",
+  options = list(
+    predictor_indicators = "none",
+    compute_intercept = FALSE,
+    remove_intercept = FALSE,
+    allow_sparse_x = FALSE
+  )
+)
+
+set_pred(
+  model = "svm_linear",
+  eng = "kernlab",
+  mode = "regression",
+  type = "numeric",
+  value = list(
+    pre = NULL,
+    post = svm_reg_linear_post,
+    func = c(pkg = "kernlab", fun = "predict"),
+    args =
+      list(
+        object = quote(object$fit),
+        newdata = quote(new_data),
+        type = "response"
+      )
+  )
+)
+
+set_pred(
+  model = "svm_linear",
+  eng = "kernlab",
+  mode = "regression",
+  type = "raw",
+  value = list(
+    pre = NULL,
+    post = NULL,
+    func = c(pkg = "kernlab", fun = "predict"),
+    args = list(object = quote(object$fit), newdata = quote(new_data))
+  )
+)
+
+set_encoding(
+  model = "svm_linear",
+  eng = "kernlab",
+  mode = "classification",
+  options = list(
+    predictor_indicators = "none",
+    compute_intercept = FALSE,
+    remove_intercept = FALSE,
+    allow_sparse_x = FALSE
+  )
+)
+
+set_pred(
+  model = "svm_linear",
+  eng = "kernlab",
+  mode = "classification",
+  type = "class",
+  value = list(
+    pre = NULL,
+    post = NULL,
+    func = c(pkg = "kernlab", fun = "predict"),
+    args =
+      list(
+        object = quote(object$fit),
+        newdata = quote(new_data),
+        type = "response"
+      )
+  )
+)
+
+set_pred(
+  model = "svm_linear",
+  eng = "kernlab",
+  mode = "classification",
+  type = "prob",
+  value = list(
+    pre = NULL,
+    post = function(result, object) as_tibble(result),
+    func = c(pkg = "kernlab", fun = "predict"),
+    args =
+      list(
+        object = quote(object$fit),
+        newdata = quote(new_data),
+        type = "probabilities"
+      )
+  )
+)
+
+set_pred(
+  model = "svm_linear",
+  eng = "kernlab",
+  mode = "classification",
+  type = "raw",
+  value = list(
+    pre = NULL,
+    post = NULL,
+    func = c(pkg = "kernlab", fun = "predict"),
+    args = list(object = quote(object$fit), newdata = quote(new_data))
+  )
+)
+

--- a/man/rmd/svm-linear.Rmd
+++ b/man/rmd/svm-linear.Rmd
@@ -31,6 +31,25 @@ predictions (e.g., accuracy and so on).
 This engine fits models that are L2-regularized for L2-loss. In the `LiblineaR` 
 documentation, these are types 1 (classification) and 11 (regression).
 
+## kernlab
+
+```{r kernlab-reg}
+svm_linear() %>% 
+  set_engine("kernlab") %>% 
+  set_mode("regression") %>% 
+  translate()
+```
+
+```{r kernlab-cls}
+svm_linear() %>% 
+  set_engine("kernlab") %>% 
+  set_mode("classification") %>% 
+  translate()
+```
+
+`fit()` passes the data directly to `kernlab::ksvm()` so that its formula method can create dummy variables as-needed. 
+
+
 ## Parameter translations
 
 The standardized parameter names in parsnip can be mapped to their original 
@@ -44,6 +63,8 @@ get_defaults_svm_linear <- function() {
     ~model,    ~engine,       ~parsnip,        ~original,  ~default,
     "svm_linear", "LiblineaR",   "cost",          "C",        "1",
     "svm_linear", "LiblineaR",   "margin",        "svr_eps",  "0.1",
+    "svm_linear", "kernlab",     "cost",          "C",        "1",
+    "svm_linear", "kernlab",     "margin",        "epsilon",  "0.1",
   )
 }
 convert_args("svm_linear")

--- a/man/svm_linear.Rd
+++ b/man/svm_linear.Rd
@@ -61,7 +61,7 @@ in lieu of recreating the object from scratch.
 The model can be created using the \code{fit()} function using the
 following \emph{engines}:
 \itemize{
-\item \pkg{R}:  \code{"LiblineaR"} (the default)
+\item \pkg{R}:  \code{"LiblineaR"} (the default) or \code{"kernlab"}
 }
 }
 \section{Engine Details}{
@@ -103,15 +103,42 @@ This engine fits models that are L2-regularized for L2-loss. In the
 (regression).
 }
 
+\subsection{kernlab}{\if{html}{\out{<div class="r">}}\preformatted{svm_linear() \%>\% 
+  set_engine("kernlab") \%>\% 
+  set_mode("regression") \%>\% 
+  translate()
+}\if{html}{\out{</div>}}\preformatted{## Linear Support Vector Machine Specification (regression)
+## 
+## Computational engine: kernlab 
+## 
+## Model fit template:
+## kernlab::ksvm(x = missing_arg(), data = missing_arg(), kernel = "vanilladot")
+}\if{html}{\out{<div class="r">}}\preformatted{svm_linear() \%>\% 
+  set_engine("kernlab") \%>\% 
+  set_mode("classification") \%>\% 
+  translate()
+}\if{html}{\out{</div>}}\preformatted{## Linear Support Vector Machine Specification (classification)
+## 
+## Computational engine: kernlab 
+## 
+## Model fit template:
+## kernlab::ksvm(x = missing_arg(), data = missing_arg(), kernel = "vanilladot", 
+##     prob.model = TRUE)
+}
+
+\code{fit()} passes the data directly to \code{kernlab::ksvm()} so that its
+formula method can create dummy variables as-needed.
+}
+
 \subsection{Parameter translations}{
 
 The standardized parameter names in parsnip can be mapped to their
 original names in each engine that has main parameters. Each engine
 typically has a different default value (shown in parentheses) for each
-parameter.\tabular{ll}{
-   \strong{parsnip} \tab \strong{LiblineaR} \cr
-   cost \tab C (1) \cr
-   margin \tab svr_eps (0.1) \cr
+parameter.\tabular{lll}{
+   \strong{parsnip} \tab \strong{LiblineaR} \tab \strong{kernlab} \cr
+   cost \tab C (1) \tab C (1) \cr
+   margin \tab svr_eps (0.1) \tab epsilon (0.1) \cr
 }
 
 }

--- a/tests/testthat/test_svm_linear.R
+++ b/tests/testthat/test_svm_linear.R
@@ -14,6 +14,7 @@ hpc <- hpc_data[1:150, c(2:5, 8)]
 test_that('primary arguments', {
   basic <- svm_linear(mode = "regression")
   basic_LiblineaR <- translate(basic %>% set_engine("LiblineaR"))
+  basic_kernlab <- translate(basic %>% set_engine("kernlab"))
 
   expect_equal(
     object = basic_LiblineaR$method$fit$args,
@@ -26,11 +27,21 @@ test_that('primary arguments', {
     )
   )
 
+  expect_equal(
+    object = basic_kernlab$method$fit$args,
+    expected = list(
+      x = expr(missing_arg()),
+      data = expr(missing_arg()),
+      kernel = "vanilladot"
+    )
+  )
+
 })
 
 test_that('engine arguments', {
 
   LiblineaR_type <- svm_linear(mode = "regression") %>% set_engine("LiblineaR", type = 12)
+  kernlab_cv <- svm_linear(mode = "regression") %>% set_engine("kernlab", cross = 10)
 
   expect_equal(
     object = translate(LiblineaR_type, "LiblineaR")$method$fit$args,
@@ -40,6 +51,16 @@ test_that('engine arguments', {
       wi = expr(missing_arg()),
       type = new_empty_quosure(12),
       svr_eps = 0.1
+    )
+  )
+
+  expect_equal(
+    object = translate(kernlab_cv, "kernlab")$method$fit$args,
+    expected = list(
+      x = expr(missing_arg()),
+      data = expr(missing_arg()),
+      cross = new_empty_quosure(10),
+      kernel = "vanilladot"
     )
   )
 
@@ -54,6 +75,11 @@ test_that('updating', {
   expr2_exp <- svm_linear(mode = "regression") %>% set_engine("LiblineaR", type = 13)
   expr3     <- svm_linear(mode = "regression", cost = 2) %>% set_engine("LiblineaR")
   expr3_exp <- svm_linear(mode = "regression", cost = 5) %>% set_engine("LiblineaR")
+  expr4     <- svm_linear(mode = "regression")  %>% set_engine("kernlab", cross = 10)
+  expr4_exp <- svm_linear(mode = "regression", cost = 2) %>% set_engine("kernlab", cross = 10)
+  expr5     <- svm_linear(mode = "regression") %>% set_engine("kernlab", cross = varying())
+  expr5_exp <- svm_linear(mode = "regression") %>% set_engine("kernlab", cross = 10)
+
 
   expect_equal(update(expr1, cost = 3), expr1_exp)
   expect_equal(update(expr2, type = 13), expr2_exp)
@@ -71,6 +97,10 @@ test_that('updating', {
   expect_equal(expr1_updated_lst$args$margin, 0.05)
   expect_equal(expr1_updated_lst$args$cost, 10)
   expect_equal(expr1_updated_lst$eng_args$type, rlang::quo(12))
+
+  expect_equal(update(expr4, cost = 2), expr4_exp)
+  expect_equal(update(expr5, cross = 10), expr5_exp)
+
 })
 
 test_that('bad input', {
@@ -96,7 +126,7 @@ ctrl <- control_parsnip(verbosity = 0, catch = FALSE)
 
 # ------------------------------------------------------------------------------
 
-test_that('linear svm regression', {
+test_that('linear svm regression: LiblineaR', {
 
   skip_if_not_installed("LiblineaR")
 
@@ -126,7 +156,7 @@ test_that('linear svm regression', {
 })
 
 
-test_that('svm rbf regression prediction', {
+test_that('linear svm regression prediction: LiblineaR', {
 
   skip_if_not_installed("LiblineaR")
 
@@ -171,7 +201,7 @@ test_that('svm rbf regression prediction', {
 
 # ------------------------------------------------------------------------------
 
-test_that('linear svm classification', {
+test_that('linear svm classification: LiblineaR', {
 
   skip_if_not_installed("LiblineaR")
 
@@ -203,7 +233,7 @@ test_that('linear svm classification', {
 })
 
 
-test_that('linear svm classification prediction', {
+test_that('linear svm classification prediction: LiblineaR', {
 
   skip_if_not_installed("LiblineaR")
 
@@ -252,5 +282,181 @@ test_that('linear svm classification prediction', {
   )
 
 })
+
+# ------------------------------------------------------------------------------
+
+reg_mod <-
+  svm_linear(mode = "regression", cost = 1/4) %>%
+  set_engine("kernlab") %>%
+  set_mode("regression")
+
+cls_mod <-
+  svm_linear(mode = "classification", cost = 1/8) %>%
+  set_engine("kernlab") %>%
+  set_mode("classification")
+
+ctrl <- control_parsnip(verbosity = 0, catch = FALSE)
+
+# ------------------------------------------------------------------------------
+
+test_that('linear svm regression: kernlab', {
+
+  skip_if_not_installed("kernlab")
+
+  expect_error(
+    res <- fit_xy(
+      reg_mod,
+      control = ctrl,
+      x = hpc[,2:4],
+      y = hpc$input_fields
+    ),
+    regexp = NA
+  )
+  expect_false(has_multi_predict(res))
+  expect_equal(multi_predict_args(res), NA_character_)
+  expect_output(print(res), "parsnip model object")
+
+  expect_error(
+    fit(
+      reg_mod,
+      input_fields ~ .,
+      data = hpc[, -5],
+      control = ctrl
+    ),
+    regexp = NA
+  )
+
+})
+
+
+test_that('linear svm regression prediction: kernlab', {
+
+  skip_if_not_installed("kernlab")
+
+  hpc_no_m <- hpc[-c(84, 85, 86, 87, 88, 109, 128),] %>%
+    droplevels()
+
+  ind <- c(2, 1, 143)
+
+  reg_form <-
+    fit(
+      reg_mod,
+      input_fields ~ .,
+      data = hpc[, -5],
+      control = ctrl
+    )
+
+  kernlab_pred <-
+    structure(
+      list(.pred = c(129.9097, 376.1049, 1032.8989)),
+      row.names = c(NA, -3L), class = c("tbl_df", "tbl", "data.frame"))
+
+  parsnip_pred <- predict(reg_form, hpc[ind, -c(2, 5)])
+  expect_equal(as.data.frame(kernlab_pred),
+               as.data.frame(parsnip_pred),
+               tolerance = .0001)
+
+
+  reg_xy_form <-
+    fit_xy(
+      reg_mod,
+      x = hpc[, c(1, 3, 4)],
+      y = hpc$input_fields,
+      control = ctrl
+    )
+  expect_equal(reg_form$fit@alphaindex, reg_xy_form$fit@alphaindex)
+
+  parsnip_xy_pred <- predict(reg_xy_form, hpc[ind, -c(2, 5)])
+  expect_equal(as.data.frame(kernlab_pred),
+               as.data.frame(parsnip_xy_pred),
+               tolerance = .0001)
+})
+
+# ------------------------------------------------------------------------------
+
+test_that('linear svm classification: kernlab', {
+
+  skip_if_not_installed("kernlab")
+
+  hpc_no_m <- hpc[-c(84, 85, 86, 87, 88, 109, 128),] %>%
+    droplevels()
+
+  ind <- c(2, 1, 143)
+
+  expect_error(
+    fit_xy(
+      cls_mod,
+      control = ctrl,
+      x = hpc_no_m[, -5],
+      y = hpc_no_m$class
+    ),
+    regexp = NA
+  )
+
+  expect_error(
+    fit(
+      cls_mod,
+      class ~ .,
+      data = hpc_no_m,
+      control = ctrl
+    ),
+    regexp = NA
+  )
+
+})
+
+
+test_that('linear svm classification prediction: kernlab', {
+
+  skip_if_not_installed("kernlab")
+
+  hpc_no_m <- hpc[-c(84, 85, 86, 87, 88, 109, 128),] %>%
+    droplevels()
+
+  ind <- c(4, 55, 143)
+
+  set.seed(34562)
+  cls_form <-
+    fit(
+      cls_mod,
+      class ~ .,
+      data = hpc_no_m,
+      control = ctrl
+    )
+
+  kernlab_class <-
+    structure(list(
+      .pred_class = structure(
+        c(1L, 1L, 3L),
+        .Label = c("VF", "F", "L"), class = "factor")),
+      row.names = c(NA, -3L), class = c("tbl_df", "tbl", "data.frame"))
+
+  parsnip_class <- predict(cls_form, hpc_no_m[ind, -5])
+  expect_equal(kernlab_class, parsnip_class)
+
+  set.seed(34562)
+  cls_xy_form <-
+    fit_xy(
+      cls_mod,
+      x = hpc_no_m[, 1:4],
+      y = hpc_no_m$class,
+      control = ctrl
+    )
+  expect_equal(cls_form$fit@alphaindex, cls_xy_form$fit@alphaindex)
+
+  library(kernlab)
+  kern_probs <-
+    kernlab::predict(cls_form$fit, hpc_no_m[ind, -5], type = "probabilities") %>%
+    as_tibble() %>%
+    setNames(c('.pred_VF', '.pred_F', '.pred_L'))
+
+  parsnip_probs <- predict(cls_form, hpc_no_m[ind, -5], type = "prob")
+  expect_equal(as.data.frame(kern_probs), as.data.frame(parsnip_probs))
+
+  parsnip_xy_probs <- predict(cls_xy_form, hpc_no_m[ind, -5], type = "prob")
+  expect_equal(as.data.frame(kern_probs), as.data.frame(parsnip_xy_probs))
+
+})
+
 
 


### PR DESCRIPTION
Closes #336 


This PR adds a second engine for `svm_linear()`. We already have `"LiblineaR"` and this PR adds `"kernlab"`.

``` r
library(tidymodels)

data(two_class_dat, package = "modeldata")
example_split <- initial_split(two_class_dat, prop = 0.99)
example_train <- training(example_split)
example_test  <-  testing(example_split)

set.seed(123)
mod <- svm_linear() %>%
  set_engine("kernlab") %>%
  set_mode("classification") %>%
  fit(Class ~ ., example_train)
#>  Setting default kernel parameters

mod
#> parsnip model object
#> 
#> Fit time:  856ms 
#> Support Vector Machine object of class "ksvm" 
#> 
#> SV type: C-svc  (classification) 
#>  parameter : cost C = 1 
#> 
#> Linear (vanilla) kernel function. 
#> 
#> Number of Support Vectors : 358 
#> 
#> Objective Function Value : -355.0963 
#> Training error : 0.179847 
#> Probability model included.

predict(mod, new_data = example_test)
#> # A tibble: 7 x 1
#>   .pred_class
#>   <fct>      
#> 1 Class2     
#> 2 Class1     
#> 3 Class2     
#> 4 Class1     
#> 5 Class1     
#> 6 Class1     
#> 7 Class2
predict(mod, new_data = example_test, type = "prob")
#> # A tibble: 7 x 2
#>   .pred_Class1 .pred_Class2
#>          <dbl>        <dbl>
#> 1        0.457       0.543 
#> 2        0.850       0.150 
#> 3        0.172       0.828 
#> 4        0.980       0.0203
#> 5        0.698       0.302 
#> 6        0.983       0.0166
#> 7        0.439       0.561
predict(mod, new_data = example_test, type = "raw")
#> [1] Class2 Class1 Class2 Class1 Class1 Class1 Class2
#> Levels: Class1 Class2
```

<sup>Created on 2021-03-01 by the [reprex package](https://reprex.tidyverse.org) (v1.0.0)</sup>

Unlike the `"LiblineaR"` engine, the `"kernlab"` engine does support class probabilities.