### PR TITLE
restrict `fit_xy()` from working for censored regression models

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,8 @@
 
 * Column names for `x` are now required when `fit_xy()` is used. (#398)
 
+* Censored regression models cannot use `fit_xy()` (use `fit()`). (#442)
+
 
 # parsnip 0.1.4
 

--- a/R/fit.R
+++ b/R/fit.R
@@ -192,6 +192,14 @@ fit_xy.model_spec <-
            control = control_parsnip(),
            ...
   ) {
+    if (object$mode == "censored regression") {
+      rlang::abort("Models for censored regression must use the formula interface.")
+    }
+
+    if (inherits(object, "surv_reg")) {
+      rlang::abort("Survival models must use the formula interface.")
+    }
+
     if (!identical(class(control), class(control_parsnip()))) {
       rlang::abort("The 'control' argument should have class 'control_parsnip'.")
     }
@@ -387,10 +395,6 @@ check_xy_interface <- function(x, y, cl, model) {
   }
 
   df_interface <- !is.null(x) & !is.null(y) && is.data.frame(x)
-
-  if (inherits(model, "surv_reg") && (matrix_interface | df_interface)) {
-    rlang::abort("Survival models must use the formula interface.")
-  }
 
   if (matrix_interface) {
     return("matrix")

--- a/tests/testthat/test_fit_interfaces.R
+++ b/tests/testthat/test_fit_interfaces.R
@@ -8,7 +8,6 @@ hpc <- hpc_data[1:150, c(2:5, 8)]
 
 f <- y ~ x
 
-smod <- surv_reg()
 rmod <- linear_reg()
 
 sprk <- 1:10
@@ -36,7 +35,6 @@ test_that('good args', {
 #
 test_that('wrong args', {
  expect_error(tester_xy(NULL, x = sprk, y = hpc, model = rmod))
- expect_error(tester_xy(NULL, x = hpc, y = hpc$compounds, model = smod))
  expect_error(tester(NULL, f,  data = as.matrix(hpc[, 1:4])))
 })
 


### PR DESCRIPTION
Closes #442 

Models with the new mode "censored regression" can't use `fit_xy()`, they should use `fit()`.

`surv_reg` models have also been forced to use the formula interface `fit()`. The check for that has been moved into `fit_xy()` from `check_xy_interface()` which checks the details of `x` and `y`. The corresponding tests for `check_xy_interface()` were removed. The tests for an error when using `fit_xy()` with a `surv_reg` model are untouched in `test_sruv_reg_survreg.R` and `test_surv_reg_flexsurv.R`.

The corresponding tests for models for censored regression are to be added when we have the corresponding model specs in parsnip (#444). 