### PR TITLE
Make predictions respect `event_level` for xgboost

### DIFF
--- a/R/boost_tree.R
+++ b/R/boost_tree.R
@@ -472,6 +472,17 @@ as_xgb_data <- function(x, y, validation = 0, event_level = "first", ...) {
 
   list(data = dat, watchlist = wlist)
 }
+
+get_event_level <- function(model_spec){
+  if ("event_level" %in% names(model_spec$eng_args)) {
+    event_level <- get_expr(model_spec$eng_args$event_level)
+  } else {
+    # "first" is the default for as_xgb_data() and xgb_train()
+    event_level <- "first"
+  }
+  event_level
+}
+
 #' @importFrom purrr map_df
 #' @export
 #' @rdname multi_predict

--- a/R/boost_tree_data.R
+++ b/R/boost_tree_data.R
@@ -158,7 +158,12 @@ set_pred(
     pre = NULL,
     post = function(x, object) {
       if (is.vector(x)) {
-        x <- ifelse(x >= 0.5, object$lvl[2], object$lvl[1])
+        event_level <- get_event_level(object$spec)
+        if (event_level == "first") {
+          x <- ifelse(x >= 0.5, object$lvl[1], object$lvl[2])
+        } else {
+          x <- ifelse(x >= 0.5, object$lvl[2], object$lvl[1])
+        }
       } else {
         x <- object$lvl[apply(x, 1, which.max)]
       }
@@ -178,7 +183,12 @@ set_pred(
     pre = NULL,
     post = function(x, object) {
       if (is.vector(x)) {
-        x <- tibble(v1 = 1 - x, v2 = x)
+        event_level <- get_event_level(object$spec)
+        if (event_level == "first") {
+          x <- tibble(v1 = x, v2 = 1 - x)
+        } else {
+          x <- tibble(v1 = 1 - x, v2 = x)
+        }
       } else {
         x <- as_tibble(x, .name_repair = "minimal")
       }

--- a/man/boost_tree.Rd
+++ b/man/boost_tree.Rd
@@ -185,14 +185,17 @@ For this engine, tuning over \code{trees} is very efficient since the same
 model object can be used to make predictions over multiple values of
 \code{trees}.
 
-Finally, note that \code{xgboost} models require that non-numeric predictors
-(e.g., factors) must be converted to dummy variables or some other
-numeric representation. By default, when using \code{fit()} with \code{xgboost}, a
-one-hot encoding is used to convert factor predictors to indicator
-variables. In the classification mode, non-numeric outcomes (i.e.,
+Note that \code{xgboost} models require that non-numeric predictors (e.g.,
+factors) must be converted to dummy variables or some other numeric
+representation. By default, when using \code{fit()} with \code{xgboost}, a one-hot
+encoding is used to convert factor predictors to indicator variables.
+
+Finally, in the classification mode, non-numeric outcomes (i.e.,
 factors) are converted to numeric. For binary classification, the
 \code{event_level} argument of \code{set_engine()} can be set to either \code{"first"}
-or \code{"second"} to specify which level should be used as the event.
+or \code{"second"} to specify which level should be used as the event. This
+can be helpful when a watchlist is used to monitor performance from with
+the xgboost training process.
 }
 
 \subsection{C5.0}{\if{html}{\out{<div class="r">}}\preformatted{boost_tree() \%>\% 

--- a/tests/testthat/test_boost_tree_xgboost.R
+++ b/tests/testthat/test_boost_tree_xgboost.R
@@ -218,6 +218,37 @@ test_that('submodel prediction', {
   )
 })
 
+test_that('prediction with event_level', {
+
+  skip_if_not_installed("xgboost")
+  library(xgboost)
+
+  vars <- c("female", "tenure", "total_charges", "phone_service", "monthly_charges")
+
+  # event_level = "first"
+  fit_1 <-
+    boost_tree(trees = 20, mode = "classification") %>%
+    set_engine("xgboost") %>%
+    fit(churn ~ ., data = wa_churn[-(1:4), c("churn", vars)])
+
+  x <-  xgboost::xgb.DMatrix(as.matrix(wa_churn[1:4, vars]))
+
+  pred_xgb_1 <- predict(fit_1$fit, x)
+  pred_res_1 <- predict(fit_1, new_data = wa_churn[1:4, vars], type = "prob")
+  expect_equal(pred_res_1[[".pred_Yes"]], pred_xgb_1)
+
+  # event_level = "second"
+  fit_2 <-
+    boost_tree(trees = 20, mode = "classification") %>%
+    set_engine("xgboost", event_level = "second") %>%
+    fit(churn ~ ., data = wa_churn[-(1:4), c("churn", vars)])
+
+  x <-  xgboost::xgb.DMatrix(as.matrix(wa_churn[1:4, vars]))
+
+  pred_xgb_2 <- predict(fit_2$fit, x)
+  pred_res_2 <- predict(fit_2, new_data = wa_churn[1:4, vars], type = "prob")
+  expect_equal(pred_res_2[[".pred_No"]], pred_xgb_2)
+})
 
 test_that('default engine', {
   skip_if_not_installed("xgboost")

--- a/tests/testthat/test_boost_tree_xgboost.R
+++ b/tests/testthat/test_boost_tree_xgboost.R
@@ -210,7 +210,7 @@ test_that('submodel prediction', {
 
   mp_res <- multi_predict(class_fit, new_data = wa_churn[1:4, vars], trees = 5, type = "prob")
   mp_res <- do.call("rbind", mp_res$.pred)
-  expect_equal(mp_res[[".pred_No"]], pred_class)
+  expect_equal(mp_res[[".pred_Yes"]], pred_class)
 
   expect_error(
     multi_predict(class_fit, newdata = wa_churn[1:4, vars], trees = 5, type = "prob"),


### PR DESCRIPTION
Closes #460 

The predictions previously ignored the `event_level`, they respect it now.

``` r
library(tidyverse)
library(tidymodels)
#> Registered S3 method overwritten by 'tune':
#>   method                   from   
#>   required_pkgs.model_spec parsnip
library(mlbench)
library(xgboost)
#> 
#> Attaching package: 'xgboost'
#> The following object is masked from 'package:dplyr':
#> 
#>     slice
library(reprex)


data("PimaIndiansDiabetes")
df <- PimaIndiansDiabetes %>%
  mutate(diabetes = fct_relevel(diabetes, 'pos'))


# xgboost
x <- as.matrix(df[,-ncol(df)])
y <- -as.numeric(df$diabetes)+2

xgbmat <- xgb.DMatrix(data = x, label = y)

set.seed(24)
xgb_model <- xgb.train(params = list(eta = 0.3, max_depth = 3, gamma = 0, 
                                     colsample_bytree = 1, min_child_weight = 1, subsample = 1, 
                                     objective = "binary:logistic"),  watchlist = list('train' = xgbmat),
                       verbose = 1, data = xgbmat, nrounds = 10, eval_metric = "auc", 
                       nthread = 1)
#> [1]  train-auc:0.834787 
#> [2]  train-auc:0.853881 
#> [3]  train-auc:0.873048 
#> [4]  train-auc:0.875000 
#> [5]  train-auc:0.882873 
#> [6]  train-auc:0.891716 
#> [7]  train-auc:0.896067 
#> [8]  train-auc:0.900414 
#> [9]  train-auc:0.904313 
#> [10] train-auc:0.906937

tidy_model <- boost_tree(trees = 10, 
                         tree_depth = 3) %>%
  set_engine('xgboost', 
             eval_metric = 'auc',
             event_level = "first",
             verbose = 1) %>%
  set_mode('classification')

set.seed(24)
tidy_model_fitted <- tidy_model %>% 
  fit(diabetes ~ . , data = df)
#> [1]  training-auc:0.834787 
#> [2]  training-auc:0.853881 
#> [3]  training-auc:0.873048 
#> [4]  training-auc:0.875000 
#> [5]  training-auc:0.882873 
#> [6]  training-auc:0.891716 
#> [7]  training-auc:0.896067 
#> [8]  training-auc:0.900414 
#> [9]  training-auc:0.904313 
#> [10] training-auc:0.906937


# xgboost predictions
predict(xgb_model, newdata = xgbmat) %>%
  as_tibble() %>%
  select(.pred_pos = value) %>%
  mutate(.pred_meg = 1 - .pred_pos)
#> # A tibble: 768 x 2
#>    .pred_pos .pred_meg
#>        <dbl>     <dbl>
#>  1    0.586      0.414
#>  2    0.106      0.894
#>  3    0.778      0.222
#>  4    0.0541     0.946
#>  5    0.613      0.387
#>  6    0.0963     0.904
#>  7    0.163      0.837
#>  8    0.370      0.630
#>  9    0.834      0.166
#> 10    0.344      0.656
#> # … with 758 more rows

# tidy model predicts are associated with the right class now
predict(tidy_model_fitted, new_data = df, type = 'prob')
#> # A tibble: 768 x 2
#>    .pred_pos .pred_neg
#>        <dbl>     <dbl>
#>  1    0.586      0.414
#>  2    0.106      0.894
#>  3    0.778      0.222
#>  4    0.0541     0.946
#>  5    0.613      0.387
#>  6    0.0963     0.904
#>  7    0.163      0.837
#>  8    0.370      0.630
#>  9    0.834      0.166
#> 10    0.344      0.656
#> # … with 758 more rows

xgb_predictions <- 
  predict(xgb_model, newdata = xgbmat) %>%
  as_tibble() %>%
  select(.pred_pos = value) %>%
  mutate(.pred_meg = 1 - .pred_pos)

tidy_predictions <- predict(tidy_model_fitted, new_data = df, type = 'prob')


# Correct prediction to class
roc_auc_vec(df$diabetes, xgb_predictions$.pred_pos)
#> [1] 0.9069366

# now correct prediction to class
roc_auc_vec(df$diabetes, tidy_predictions$.pred_pos)
#> [1] 0.9069366
```

<sup>Created on 2021-04-08 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>