### PR TITLE
make augment() return tibbles

### DIFF
--- a/R/augment.R
+++ b/R/augment.R
@@ -77,5 +77,5 @@ augment.model_fit <- function(x, new_data, ...) {
   } else {
     rlang::abort(paste("Unknown mode:", x$spec$mode))
   }
-  new_data
+  as_tibble(new_data)
 }

--- a/tests/testthat/test-augment.R
+++ b/tests/testthat/test-augment.R
@@ -35,6 +35,8 @@ test_that('regression models', {
   )
   expect_equal(nrow(augment(reg_xy, head(mtcars[, -1]))), 6)
 
+  expect_s3_class(augment(reg_form, head(mtcars)), "tbl_df")
+
   reg_form$spec$mode <- "depeche"
 
   expect_error(augment(reg_form, head(mtcars[, -1])), "Unknown mode: depeche")


### PR DESCRIPTION
This PR makes `augment()` return tibbles even if the input data is just a data.frame

``` r
library(parsnip)

lm_spec <- linear_reg() %>%
  set_engine("lm")

lm_fit <- lm_spec %>% fit(mpg ~ ., data = mtcars)

class(mtcars)
#> [1] "data.frame"

augment(lm_fit, new_data = mtcars) %>% class()
#> [1] "tbl_df"     "tbl"        "data.frame"
```

<sup>Created on 2021-04-23 by the [reprex package](https://reprex.tidyverse.org) (v1.0.0)</sup>

To close #468 