### PR TITLE
Fix error message for `multi_predict()`

### DIFF
--- a/R/aaa_multi_predict.R
+++ b/R/aaa_multi_predict.R
@@ -31,7 +31,7 @@ multi_predict.default <- function(object, ...)
   rlang::abort(
     glue::glue(
       "No `multi_predict` method exists for objects with classes ",
-      glue::glue_collapse(glue::glue("'{class()}'"), sep = ", ")
+      glue::glue_collapse(glue::glue("'{class(object)}'"), sep = ", ")
       )
     )
 

--- a/tests/testthat/test_misc.R
+++ b/tests/testthat/test_misc.R
@@ -14,6 +14,10 @@ test_that('parsnip objects', {
   lm_fit <- fit(lm_idea, mpg ~ ., data = mtcars)
   expect_false(has_multi_predict(lm_fit))
   expect_false(has_multi_predict(lm_fit$fit))
+  expect_error(
+    multi_predict(lm_fit, mtcars),
+    "No `multi_predict` method exists"
+  )
 
   mars_fit <-
     mars(mode = "regression") %>%
@@ -21,6 +25,11 @@ test_that('parsnip objects', {
     fit(mpg ~ ., data = mtcars)
   expect_true(has_multi_predict(mars_fit))
   expect_false(has_multi_predict(mars_fit$fit))
+  expect_error(
+    multi_predict(mars_fit$fit, mtcars),
+    "No `multi_predict` method exists"
+  )
+
 })
 
 test_that('other objects', {


### PR DESCRIPTION
Closes #482 

This PR fixes the error message for `multi_predict()` and adds a few small tests for the error message:

``` r
library(tidymodels)
#> Registered S3 method overwritten by 'tune':
#>   method                   from   
#>   required_pkgs.model_spec parsnip
data(attrition)

data_split <- initial_split(attrition, strata = "Attrition")
attrition_train <- training(data_split)
attrition_test  <- testing(data_split)

tree_mod <-
  boost_tree(mode = "classification", trees = 100) %>% 
  set_engine("C5.0") %>% 
  fit_xy(x = attrition_train %>% dplyr::select(-Attrition), y = attrition_train$Attrition)

multi_predict(
  tree_mod, 
  new_data = attrition_test %>% dplyr::select(-Attrition),
  trees = 80:100,
  type = "prob"
)
#> # A tibble: 367 x 1
#>    .pred            
#>    <list>           
#>  1 <tibble [21 × 3]>
#>  2 <tibble [21 × 3]>
#>  3 <tibble [21 × 3]>
#>  4 <tibble [21 × 3]>
#>  5 <tibble [21 × 3]>
#>  6 <tibble [21 × 3]>
#>  7 <tibble [21 × 3]>
#>  8 <tibble [21 × 3]>
#>  9 <tibble [21 × 3]>
#> 10 <tibble [21 × 3]>
#> # … with 357 more rows

glm_mod <-
  logistic_reg(mode = "classification") %>% 
  set_engine("glm") %>% 
  fit(Attrition ~ ., data = attrition)

multi_predict(
  glm_mod, 
  new_data = attrition_test %>% dplyr::select(-Attrition),
  type = "prob"
)
#> Error: No `multi_predict` method exists for objects with classes '_glm', 'model_fit'
```

<sup>Created on 2021-05-06 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>

