### PR TITLE
Add error for glmnet models if penalty is not exactly 1

### DIFF
--- a/R/linear_reg.R
+++ b/R/linear_reg.R
@@ -112,6 +112,13 @@ translate.linear_reg <- function(x, engine = x$engine, ...) {
     # Since the `fit` information is gone for the penalty, we need to have an
     # evaluated value for the parameter.
     x$args$penalty <- rlang::eval_tidy(x$args$penalty)
+    if (length(x$args$penalty) != 1) {
+      rlang::abort(c(
+        "For the glmnet engine, `penalty` must be a single number.",
+        glue::glue("There are {length(x$args$penalty)} values for `penalty`."),
+        "To try multiple values for total regularization, use the tune package."
+      ))
+    }
   }
 
   x

--- a/R/logistic_reg.R
+++ b/R/logistic_reg.R
@@ -115,6 +115,13 @@ translate.logistic_reg <- function(x, engine = x$engine, ...) {
     # Since the `fit` information is gone for the penalty, we need to have an
     # evaluated value for the parameter.
     x$args$penalty <- rlang::eval_tidy(x$args$penalty)
+    if (length(x$args$penalty) != 1) {
+      rlang::abort(c(
+        "For the glmnet engine, `penalty` must be a single number.",
+        glue::glue("There are {length(x$args$penalty)} values for `penalty`."),
+        "To try multiple values for total regularization, use the tune package."
+      ))
+    }
   }
 
   if (engine == "LiblineaR") {

--- a/tests/testthat/test_linear_reg.R
+++ b/tests/testthat/test_linear_reg.R
@@ -15,7 +15,10 @@ hpc <- hpc_data[1:150, c(2:5, 8)]
 test_that('primary arguments', {
   basic <- linear_reg()
   basic_lm <- translate(basic %>% set_engine("lm"))
-  basic_glmnet <- translate(basic %>% set_engine("glmnet"))
+  expect_error(
+    basic_glmnet <- translate(basic %>% set_engine("glmnet")),
+    "For the glmnet engine, `penalty` must be a single"
+  )
   basic_stan <- translate(basic %>% set_engine("stan"))
   basic_spark <- translate(basic %>% set_engine("spark"))
   expect_equal(basic_lm$method$fit$args,
@@ -23,14 +26,6 @@ test_that('primary arguments', {
                  formula = expr(missing_arg()),
                  data = expr(missing_arg()),
                  weights = expr(missing_arg())
-               )
-  )
-  expect_equal(basic_glmnet$method$fit$args,
-               list(
-                 x = expr(missing_arg()),
-                 y = expr(missing_arg()),
-                 weights = expr(missing_arg()),
-                 family = "gaussian"
                )
   )
   expect_equal(basic_stan$method$fit$args,
@@ -51,17 +46,11 @@ test_that('primary arguments', {
   )
 
   mixture <- linear_reg(mixture = 0.128)
-  mixture_glmnet <- translate(mixture %>% set_engine("glmnet"))
-  mixture_spark <- translate(mixture %>% set_engine("spark"))
-  expect_equal(mixture_glmnet$method$fit$args,
-               list(
-                 x = expr(missing_arg()),
-                 y = expr(missing_arg()),
-                 weights = expr(missing_arg()),
-                 alpha = new_empty_quosure(0.128),
-                 family = "gaussian"
-               )
+  expect_error(
+    mixture_glmnet <- translate(mixture %>% set_engine("glmnet")),
+    "For the glmnet engine, `penalty` must be a single"
   )
+  mixture_spark <- translate(mixture %>% set_engine("spark"))
   expect_equal(mixture_spark$method$fit$args,
                list(
                  x = expr(missing_arg()),
@@ -92,17 +81,11 @@ test_that('primary arguments', {
   )
 
   mixture_v <- linear_reg(mixture = varying())
-  mixture_v_glmnet <- translate(mixture_v %>% set_engine("glmnet"))
-  mixture_v_spark <- translate(mixture_v %>% set_engine("spark"))
-  expect_equal(mixture_v_glmnet$method$fit$args,
-               list(
-                 x = expr(missing_arg()),
-                 y = expr(missing_arg()),
-                 weights = expr(missing_arg()),
-                 alpha = new_empty_quosure(varying()),
-                 family = "gaussian"
-               )
+  expect_error(
+    mixture_v_glmnet <- translate(mixture_v %>% set_engine("glmnet")),
+    "For the glmnet engine, `penalty` must be a single"
   )
+  mixture_v_spark <- translate(mixture_v %>% set_engine("spark"))
   expect_equal(mixture_v_spark$method$fit$args,
                list(
                  x = expr(missing_arg()),
@@ -125,7 +108,7 @@ test_that('engine arguments', {
                )
   )
 
-  glmnet_nlam <- linear_reg() %>% set_engine("glmnet", nlambda = 10)
+  glmnet_nlam <- linear_reg(penalty = 0.1) %>% set_engine("glmnet", nlambda = 10)
   expect_equal(translate(glmnet_nlam)$method$fit$args,
                list(
                  x = expr(missing_arg()),

--- a/tests/testthat/test_logistic_reg.R
+++ b/tests/testthat/test_logistic_reg.R
@@ -16,7 +16,10 @@ hpc <- hpc_data[1:150, c(2:5, 8)]
 test_that('primary arguments', {
   basic <- logistic_reg()
   basic_glm <- translate(basic %>% set_engine("glm"))
-  basic_glmnet <- translate(basic %>% set_engine("glmnet"))
+  expect_error(
+    basic_glmnet <- translate(basic %>% set_engine("glmnet")),
+    "For the glmnet engine, `penalty` must be a single"
+  )
   basic_liblinear <- translate(basic %>% set_engine("LiblineaR"))
   basic_stan <- translate(basic %>% set_engine("stan"))
   basic_spark <- translate(basic %>% set_engine("spark"))
@@ -26,14 +29,6 @@ test_that('primary arguments', {
                  data = expr(missing_arg()),
                  weights = expr(missing_arg()),
                  family = expr(stats::binomial)
-               )
-  )
-  expect_equal(basic_glmnet$method$fit$args,
-               list(
-                 x = expr(missing_arg()),
-                 y = expr(missing_arg()),
-                 weights = expr(missing_arg()),
-                 family = "binomial"
                )
   )
   expect_equal(basic_liblinear$method$fit$args,
@@ -63,17 +58,11 @@ test_that('primary arguments', {
   )
 
   mixture <- logistic_reg(mixture = 0.128)
-  mixture_glmnet <- translate(mixture %>% set_engine("glmnet"))
-  mixture_spark <- translate(mixture %>% set_engine("spark"))
-  expect_equal(mixture_glmnet$method$fit$args,
-               list(
-                 x = expr(missing_arg()),
-                 y = expr(missing_arg()),
-                 weights = expr(missing_arg()),
-                 alpha = new_empty_quosure(0.128),
-                 family = "binomial"
-               )
+  expect_error(
+    mixture_glmnet <- translate(mixture %>% set_engine("glmnet")),
+    "For the glmnet engine, `penalty` must be a single"
   )
+  mixture_spark <- translate(mixture %>% set_engine("spark"))
   expect_equal(mixture_spark$method$fit$args,
                list(
                  x = expr(missing_arg()),
@@ -116,18 +105,12 @@ test_that('primary arguments', {
   )
 
   mixture_v <- logistic_reg(mixture = varying())
-  mixture_v_glmnet <- translate(mixture_v %>% set_engine("glmnet"))
+  expect_error(
+    mixture_v_glmnet <- translate(mixture_v %>% set_engine("glmnet")),
+    "For the glmnet engine, `penalty` must be a single"
+  )
   mixture_v_liblinear <- translate(mixture_v %>% set_engine("LiblineaR"))
   mixture_v_spark <- translate(mixture_v %>% set_engine("spark"))
-  expect_equal(mixture_v_glmnet$method$fit$args,
-               list(
-                 x = expr(missing_arg()),
-                 y = expr(missing_arg()),
-                 weights = expr(missing_arg()),
-                 alpha = new_empty_quosure(varying()),
-                 family = "binomial"
-               )
-  )
   expect_equal(mixture_v_liblinear$method$fit$args,
                list(
                  x = expr(missing_arg()),
@@ -194,7 +177,7 @@ test_that('engine arguments', {
       )
     )
 
-  glmnet_nlam <- logistic_reg()
+  glmnet_nlam <- logistic_reg(penalty = 0.1)
   expect_equal(
     translate(glmnet_nlam %>% set_engine("glmnet", nlambda = 10))$method$fit$args,
     list(

--- a/tests/testthat/test_multinom_reg.R
+++ b/tests/testthat/test_multinom_reg.R
@@ -13,17 +13,11 @@ hpc <- hpc_data[1:150, c(2:5, 8)]
 
 test_that('primary arguments', {
   basic <- multinom_reg()
-  basic_glmnet <- translate(basic %>% set_engine("glmnet"))
-  expect_equal(basic_glmnet$method$fit$args,
-               list(
-                 x = expr(missing_arg()),
-                 y = expr(missing_arg()),
-                 weights = expr(missing_arg()),
-                 family = "multinomial"
-               )
+  expect_error(
+    basic_glmnet <- translate(basic %>% set_engine("glmnet")),
+    "For the glmnet engine, `penalty` must be a single"
   )
-
-  mixture <- multinom_reg(mixture = 0.128)
+  mixture <- multinom_reg(penalty = 0.1, mixture = 0.128)
   mixture_glmnet <- translate(mixture %>% set_engine("glmnet"))
   expect_equal(mixture_glmnet$method$fit$args,
                list(
@@ -46,7 +40,7 @@ test_that('primary arguments', {
                )
   )
 
-  mixture_v <- multinom_reg(mixture = varying())
+  mixture_v <- multinom_reg(penalty = 0.01, mixture = varying())
   mixture_v_glmnet <- translate(mixture_v %>% set_engine("glmnet"))
   expect_equal(mixture_v_glmnet$method$fit$args,
                list(
@@ -61,7 +55,7 @@ test_that('primary arguments', {
 })
 
 test_that('engine arguments', {
-  glmnet_nlam <- multinom_reg()
+  glmnet_nlam <- multinom_reg(penalty = 0.01)
   expect_equal(
     translate(glmnet_nlam %>% set_engine("glmnet", nlambda = 10))$method$fit$args,
     list(
@@ -117,5 +111,5 @@ test_that('bad input', {
   expect_error(multinom_reg(mode = "regression"))
   expect_error(translate(multinom_reg() %>% set_engine("wat?")))
   expect_error(translate(multinom_reg() %>% set_engine()))
-  expect_warning(translate(multinom_reg() %>% set_engine("glmnet", x = hpc[,1:3], y = hpc$class)))
+  expect_warning(translate(multinom_reg(penalty = 0.01) %>% set_engine("glmnet", x = hpc[,1:3], y = hpc$class)))
 })


### PR DESCRIPTION
Closes #481 

This PR adds a new error for glmnet models, checking if the `length()` of penalty is exactly one in the `translate()` functions. Here is what I have as the error message for now:

``` r
library(tidymodels)
#> Registered S3 method overwritten by 'tune':
#>   method                   from   
#>   required_pkgs.model_spec parsnip
data("two_class_dat")


logistic_reg(penalty = c(0.01, 0.1)) %>% 
  set_engine("glmnet") %>% 
  fit(Class ~ ., data = two_class_dat)
#> Error: For the glmnet engine, `penalty` must be a single number.
#> * There are 2 values for `penalty`.
#> * To try multiple values for total regularization, use the tune package.


logistic_reg() %>% 
  set_engine("glmnet") %>% 
  fit(Class ~ ., data = two_class_dat)
#> Error: For the glmnet engine, `penalty` must be a single number.
#> * There are 0 values for `penalty`.
#> * To try multiple values for total regularization, use the tune package.
```

<sup>Created on 2021-05-06 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>

Thoughts? I have it saying to try tune even for the no-penalty case because people are probably thinking it will just go do something automatic.