### PR TITLE
`augment()` for models without class probabilities

### DIFF
--- a/R/aaa_models.R
+++ b/R/aaa_models.R
@@ -286,9 +286,13 @@ check_pred_info <- function(pred_obj, type) {
   invisible(NULL)
 }
 
-check_spec_pred_type <- function(object, type) {
+spec_has_pred_type <- function(object, type) {
   possible_preds <- names(object$spec$method$pred)
-  if (!any(possible_preds == type)) {
+  any(possible_preds == type)
+}
+check_spec_pred_type <- function(object, type) {
+  if (!spec_has_pred_type(object, type)) {
+    possible_preds <- names(object$spec$method$pred)
     rlang::abort(c(
       glue::glue("No {type} prediction method available for this model."),
       glue::glue("Value for `type` should be one of: ",

--- a/R/augment.R
+++ b/R/augment.R
@@ -68,19 +68,28 @@ augment.model_fit <- function(x, new_data, ...) {
       }
     }
   } else if (x$spec$mode == "classification") {
-    new_data <- dplyr::bind_cols(
-      new_data,
-      predict(x, new_data = new_data, type = "class")
-    )
-    tryCatch(
+    if (has_class_preds(x)) {
+      new_data <- dplyr::bind_cols(
+        new_data,
+        predict(x, new_data = new_data, type = "class")
+      )
+    }
+    if (has_class_probs(x)) {
       new_data <- dplyr::bind_cols(
         new_data,
         predict(x, new_data = new_data, type = "prob")
-      ),
-      error = function(cnd) cnd
-    )
+      )
+    }
   } else {
     rlang::abort(paste("Unknown mode:", x$spec$mode))
   }
   as_tibble(new_data)
+}
+
+has_class_preds <- function(x) {
+  any(names(x$spec$method$pred) == "class")
+}
+
+has_class_probs <- function(x) {
+  any(names(x$spec$method$pred) == "prob")
 }

--- a/R/augment.R
+++ b/R/augment.R
@@ -68,12 +68,17 @@ augment.model_fit <- function(x, new_data, ...) {
       }
     }
   } else if (x$spec$mode == "classification") {
-    new_data <-
-      new_data %>%
-      dplyr::bind_cols(
-        predict(x, new_data = new_data, type = "class"),
+    new_data <- dplyr::bind_cols(
+      new_data,
+      predict(x, new_data = new_data, type = "class")
+    )
+    tryCatch(
+      new_data <- dplyr::bind_cols(
+        new_data,
         predict(x, new_data = new_data, type = "prob")
-      )
+      ),
+      error = function(cnd) cnd
+    )
   } else {
     rlang::abort(paste("Unknown mode:", x$spec$mode))
   }

--- a/man/augment.Rd
+++ b/man/augment.Rd
@@ -21,8 +21,9 @@ For regression models, a \code{.pred} column is added. If \code{x} was created u
 \code{\link[=fit]{fit()}} and \code{new_data} contains the outcome column, a \code{.resid} column is
 also added.
 
-For classification models, the results include a column called \code{.pred_class}
-as well as class probability columns named \verb{.pred_\{level\}}.
+For classification models, the results can include a column called
+\code{.pred_class} as well as class probability columns named \verb{.pred_\{level\}}.
+This depends on what type of prediction types are available for the model.
 }
 \examples{
 car_trn <- mtcars[11:32,]

--- a/tests/testthat/test-augment.R
+++ b/tests/testthat/test-augment.R
@@ -76,3 +76,18 @@ test_that('classification models', {
 
 })
 
+
+test_that('augment for model without class probabilities', {
+  skip_if_not_installed("LiblineaR")
+
+  data(two_class_dat, package = "modeldata")
+  x <- svm_linear(mode = "classification") %>% set_engine("LiblineaR")
+  cls_form <- x %>% fit(Class ~ ., data = two_class_dat)
+
+  expect_equal(
+    colnames(augment(cls_form, head(two_class_dat))),
+    c("A", "B", "Class", ".pred_class")
+  )
+  expect_equal(nrow(augment(cls_form, head(two_class_dat))), 6)
+
+})


### PR DESCRIPTION
Closes #435 

This PR adds a `tryCatch()` for making the `type = "prob"` predictions in `augment()`, so that it only returns the class predictions if the class probability predictions fail:

``` r
library(parsnip)

svm_spec <- svm_linear() %>%
  set_mode("classification") %>%
  set_engine("LiblineaR")

svm_fit <- fit(svm_spec, Species ~ ., data = iris)

augment(svm_fit, iris)
#> # A tibble: 150 x 6
#>    Sepal.Length Sepal.Width Petal.Length Petal.Width Species .pred_class
#>           <dbl>       <dbl>        <dbl>       <dbl> <fct>   <fct>      
#>  1          5.1         3.5          1.4         0.2 setosa  setosa     
#>  2          4.9         3            1.4         0.2 setosa  setosa     
#>  3          4.7         3.2          1.3         0.2 setosa  setosa     
#>  4          4.6         3.1          1.5         0.2 setosa  setosa     
#>  5          5           3.6          1.4         0.2 setosa  setosa     
#>  6          5.4         3.9          1.7         0.4 setosa  setosa     
#>  7          4.6         3.4          1.4         0.3 setosa  setosa     
#>  8          5           3.4          1.5         0.2 setosa  setosa     
#>  9          4.4         2.9          1.4         0.2 setosa  setosa     
#> 10          4.9         3.1          1.5         0.1 setosa  setosa     
#> # … with 140 more rows

data(two_class_dat, package = "modeldata")

cls_form <-
  logistic_reg() %>%
  set_engine("glm") %>%
  fit(Class ~ ., data = two_class_dat)

augment(cls_form, two_class_dat)
#> # A tibble: 791 x 6
#>        A     B Class  .pred_class .pred_Class1 .pred_Class2
#>    <dbl> <dbl> <fct>  <fct>              <dbl>        <dbl>
#>  1  2.07 1.63  Class1 Class1             0.513      0.487  
#>  2  2.02 1.04  Class1 Class1             0.906      0.0940 
#>  3  1.69 1.37  Class2 Class1             0.645      0.355  
#>  4  3.43 1.98  Class2 Class1             0.599      0.401  
#>  5  2.88 1.98  Class1 Class2             0.435      0.565  
#>  6  3.31 2.41  Class2 Class2             0.201      0.799  
#>  7  2.50 1.56  Class2 Class1             0.701      0.299  
#>  8  1.98 1.55  Class2 Class1             0.563      0.437  
#>  9  2.88 0.580 Class1 Class1             0.994      0.00622
#> 10  3.74 2.74  Class2 Class2             0.105      0.895  
#> # … with 781 more rows
```

<sup>Created on 2021-05-11 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>