### PR TITLE
Rename `predict(.time =)` to `predict(time =)`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: parsnip
-Version: 0.1.5.9002
+Version: 0.1.5.9003
 Title: A Common API to Modeling and Analysis Functions
 Description: A common interface is provided to allow users to specify a model without having to remember the different argument names across different functions or computational engines (e.g. 'R', 'Spark', 'Stan', etc). 
 Authors@R: c(

--- a/R/predict.R
+++ b/R/predict.R
@@ -28,7 +28,7 @@
 #'            and "pred_int". Default value is `FALSE`.
 #'     \item `quantile`: the quantile(s) for quantile regression
 #'            (not implemented yet)
-#'     \item `.time`: the time(s) for hazard and survival probability estimates.
+#'     \item `time`: the time(s) for hazard and survival probability estimates.
 #'  }
 #' @details If "type" is not supplied to `predict()`, then a choice
 #'  is made:
@@ -48,7 +48,7 @@
 #'
 #'  ## Censored regression predictions
 #'
-#' For censored regression, a numeric vector for `.time` is required when
+#' For censored regression, a numeric vector for `time` is required when
 #' survival or hazard probabilities are requested. Also, when
 #' `type = "linear_pred"`, censored regression models will be formatted such
 #' that the linear predictor _increases_ with time. This may have the opposite
@@ -309,7 +309,7 @@ check_pred_type_dots <- function(type, ...) {
 
   # ----------------------------------------------------------------------------
 
-  other_args <- c("level", "std_error", "quantile", ".time")
+  other_args <- c("level", "std_error", "quantile", "time")
   is_pred_arg <- names(the_dots) %in% other_args
   if (any(!is_pred_arg)) {
     bad_args <- names(the_dots)[!is_pred_arg]
@@ -323,21 +323,21 @@ check_pred_type_dots <- function(type, ...) {
   }
 
   # ----------------------------------------------------------------------------
-  # places where .time should not be given
-  if (any(nms == ".time") & !type %in% c("survival", "hazard")) {
+  # places where time should not be given
+  if (any(nms == "time") & !type %in% c("survival", "hazard")) {
     rlang::abort(
       paste(
-        ".time should only be passed to `predict()` when 'type' is one of:",
+        "'time' should only be passed to `predict()` when 'type' is one of:",
         paste0("'", c("survival", "hazard"), "'", collapse = ", ")
       )
     )
   }
-  # when .time should be passed
-  if (!any(nms == ".time") & type %in% c("survival", "hazard")) {
+  # when time should be passed
+  if (!any(nms == "time") & type %in% c("survival", "hazard")) {
     rlang::abort(
       paste(
         "When using 'type' values of 'survival' or 'hazard' are given,",
-        "a numeric vector '.time' should also be given."
+        "a numeric vector 'time' should also be given."
       )
     )
   }

--- a/R/predict_hazard.R
+++ b/R/predict_hazard.R
@@ -5,7 +5,7 @@
 #' @export predict_hazard.model_fit
 #' @export
 predict_hazard.model_fit <-
-  function(object, new_data, .time, ...) {
+  function(object, new_data, time, ...) {
 
     check_spec_pred_type(object, "hazard")
 
@@ -21,7 +21,7 @@ predict_hazard.model_fit <-
       new_data <- object$spec$method$pred$hazard$pre(new_data, object)
 
     # Pass some extra arguments to be used in post-processor
-    object$spec$method$pred$hazard$args$.time <- .time
+    object$spec$method$pred$hazard$args$time <- time
     pred_call <- make_pred_call(object$spec$method$pred$hazard)
 
     res <- eval_tidy(pred_call)

--- a/R/predict_survival.R
+++ b/R/predict_survival.R
@@ -5,7 +5,7 @@
 #' @export predict_survival.model_fit
 #' @export
 predict_survival.model_fit <-
-  function(object, new_data, .time, ...) {
+  function(object, new_data, time, ...) {
 
     check_spec_pred_type(object, "survival")
 
@@ -21,7 +21,7 @@ predict_survival.model_fit <-
       new_data <- object$spec$method$pred$survival$pre(new_data, object)
 
     # Pass some extra arguments to be used in post-processor
-    object$spec$method$pred$survival$args$.time <- .time
+    object$spec$method$pred$survival$args$time <- time
     pred_call <- make_pred_call(object$spec$method$pred$survival)
 
     res <- eval_tidy(pred_call)

--- a/man/other_predict.Rd
+++ b/man/other_predict.Rd
@@ -23,7 +23,7 @@
 
 \method{predict_classprob}{model_fit}(object, new_data, ...)
 
-\method{predict_hazard}{model_fit}(object, new_data, .time, ...)
+\method{predict_hazard}{model_fit}(object, new_data, time, ...)
 
 \method{predict_confint}{model_fit}(object, new_data, level = 0.95, std_error = FALSE, ...)
 
@@ -37,7 +37,7 @@ predict_numeric(object, ...)
 
 \method{predict_quantile}{model_fit}(object, new_data, quantile = (1:9)/10, ...)
 
-\method{predict_survival}{model_fit}(object, new_data, .time, ...)
+\method{predict_survival}{model_fit}(object, new_data, time, ...)
 
 predict_survival(object, ...)
 
@@ -64,7 +64,7 @@ the scale of the linear predictors) for \code{type}s of "conf_int"
 and "pred_int". Default value is \code{FALSE}.
 \item \code{quantile}: the quantile(s) for quantile regression
 (not implemented yet)
-\item \code{.time}: the time(s) for hazard and survival probability estimates.
+\item \code{time}: the time(s) for hazard and survival probability estimates.
 }}
 
 \item{level}{A single numeric value between zero and one for the

--- a/man/predict.model_fit.Rd
+++ b/man/predict.model_fit.Rd
@@ -41,7 +41,7 @@ the scale of the linear predictors) for \code{type}s of "conf_int"
 and "pred_int". Default value is \code{FALSE}.
 \item \code{quantile}: the quantile(s) for quantile regression
 (not implemented yet)
-\item \code{.time}: the time(s) for hazard and survival probability estimates.
+\item \code{time}: the time(s) for hazard and survival probability estimates.
 }}
 }
 \value{
@@ -114,7 +114,7 @@ extra column of standard error values (if available).
 
 \subsection{Censored regression predictions}{
 
-For censored regression, a numeric vector for \code{.time} is required when
+For censored regression, a numeric vector for \code{time} is required when
 survival or hazard probabilities are requested. Also, when
 \code{type = "linear_pred"}, censored regression models will be formatted such
 that the linear predictor \emph{increases} with time. This may have the opposite


### PR DESCRIPTION
Joint PR with https://github.com/tidymodels/censored/pull/56 (merge this parsnip one first)

This PR renames the `.time` argument of `predict()` to `time`. This is more consistent with our other arguments that get passed through the dots, like `level` and `quantile`.