### PR TITLE
Fix `augment` bug 🐛 related to `bind_cols()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * The helper functions `.convert_form_to_xy_fit()`, `.convert_form_to_xy_new()`, `.convert_xy_to_form_fit()`, and  `.convert_xy_to_form_new()` for converting between formula and matrix interface are now exported for developer use (#508).
 
+* Fix bug in `augment()` when non-predictor, non-outcome variables are included in data (#510).
+
 # parsnip 0.1.6
 
 ## Model Specification Changes
@@ -19,7 +21,6 @@
 
 * For xgboost, `mtry` and `colsample_bytree` can be passed as integer counts or proportions, while `subsample` and `validation` should always be proportions. `xgb_train()` now has a new option `counts` (`TRUE` or `FALSE`) that states which scale for `mtry` and `colsample_bytree` is being used. (#461)  
 
-r
 ## Other Changes
 
 * Re-licensed package from GPL-2 to MIT. See [consent from copyright holders here](https://github.com/tidymodels/parsnip/issues/462).

--- a/R/augment.R
+++ b/R/augment.R
@@ -56,34 +56,35 @@
 #' augment(cls_xy, cls_tst[, -3])
 #'
 augment.model_fit <- function(x, new_data, ...) {
+  ret <- new_data
   if (x$spec$mode == "regression") {
     check_spec_pred_type(x, "numeric")
-    new_data <-
-      new_data %>%
+    ret <-
+      ret %>%
       dplyr::bind_cols(
         predict(x, new_data = new_data)
       )
     if (length(x$preproc$y_var) > 0) {
       y_nm <- x$preproc$y_var
       if (any(names(new_data) == y_nm)) {
-        new_data <- dplyr::mutate(new_data, .resid = !!rlang::sym(y_nm) - .pred)
+        ret <- dplyr::mutate(ret, .resid = !!rlang::sym(y_nm) - .pred)
       }
     }
   } else if (x$spec$mode == "classification") {
     if (spec_has_pred_type(x, "class")) {
-      new_data <- dplyr::bind_cols(
-        new_data,
+      ret <- dplyr::bind_cols(
+        ret,
         predict(x, new_data = new_data, type = "class")
       )
     }
     if (spec_has_pred_type(x, "prob")) {
-      new_data <- dplyr::bind_cols(
-        new_data,
+      ret <- dplyr::bind_cols(
+        ret,
         predict(x, new_data = new_data, type = "prob")
       )
     }
   } else {
     rlang::abort(paste("Unknown mode:", x$spec$mode))
   }
-  as_tibble(new_data)
+  as_tibble(ret)
 }


### PR DESCRIPTION
Closes #506 

This PR fixes the bug in `augment()` related to how predictions were being bound on, then fed back into `predict()`. Should be all working now:

``` r
library(tidymodels)
#> Registered S3 method overwritten by 'tune':
#>   method                   from   
#>   required_pkgs.model_spec parsnip
data(two_class_dat, package = "modeldata")

two_class_df <- two_class_dat %>% mutate(id = row_number())

rec <- recipe(Class ~ ., data = two_class_df) %>%
  update_role(id, new_role = "id")

tree_spec <- boost_tree() %>%
  set_mode("classification") %>%
  set_engine("xgboost") 

tree_fit <- workflow() %>%
  add_model(tree_spec) %>%
  add_recipe(rec) %>%
  fit(data = two_class_df)
#> [10:21:15] WARNING: amalgamation/../src/learner.cc:1095: Starting in XGBoost 1.3.0, the default evaluation metric used with the objective 'binary:logistic' was changed from 'error' to 'logloss'. Explicitly set eval_metric if you'd like to restore the old behavior.

augment(tree_fit, two_class_df[22,])
#> # A tibble: 1 x 7
#>       A     B Class     id .pred_class .pred_Class1 .pred_Class2
#>   <dbl> <dbl> <fct>  <int> <fct>              <dbl>        <dbl>
#> 1  1.56  1.10 Class2    22 Class1             0.793        0.207
```

<sup>Created on 2021-06-07 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>