### PR TITLE
default engine changes for #513

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # parsnip (development version)
 
-* Each model now has a default engine that is used when the model is defined. The default for each model is listed in the help documents. This also adds functionality to change to declare an engine in the model specification function. `set_engine()` is still required if engine-specific arguments need to be added. (#513)
+* Each model now has a default engine that is used when the model is defined. The default for each model is listed in the help documents. This also adds functionality to declare an engine in the model specification function. `set_engine()` is still required if engine-specific arguments need to be added. (#513)
 
 * The default engine for `multinom_reg()` was changed to `nnet`. 
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # parsnip (development version)
 
+* Each model now has a default engine that is used when the model is defined. The default for each model is listed in the help documents. This also adds functionality to change to declare an engine in the model specification function. `set_engine()` is still required if engine-specific arguments need to be added. (#513)
+
+* The default engine for `multinom_reg()` was changed to `nnet`. 
+
 * The helper functions `.convert_form_to_xy_fit()`, `.convert_form_to_xy_new()`, `.convert_xy_to_form_fit()`, and  `.convert_xy_to_form_new()` for converting between formula and matrix interface are now exported for developer use (#508).
 
 * Fix bug in `augment()` when non-predictor, non-outcome variables are included in data (#510).

--- a/R/boost_tree.R
+++ b/R/boost_tree.R
@@ -32,6 +32,8 @@
 #' @param mode A single character string for the type of model.
 #'  Possible values for this model are "unknown", "regression", or
 #'  "classification".
+#' @param engine A character string for the method of fitting. Possible engines
+#' are listed above. The default for this model is `"xgboost"`.
 #' @param mtry A number for the number (or proportion) of predictors that will
 #'  be randomly sampled at each split when creating the tree models (`xgboost`
 #'  only).
@@ -92,6 +94,7 @@
 
 boost_tree <-
   function(mode = "unknown",
+           engine = "xgboost",
            mtry = NULL, trees = NULL, min_n = NULL,
            tree_depth = NULL, learn_rate = NULL,
            loss_reduction = NULL,
@@ -114,7 +117,7 @@ boost_tree <-
       eng_args = NULL,
       mode,
       method = NULL,
-      engine = NULL
+      engine = engine
     )
   }
 

--- a/R/boost_tree.R
+++ b/R/boost_tree.R
@@ -29,11 +29,12 @@
 #'  functions. If parameters need to be modified, `update()` can be used
 #'  in lieu of recreating the object from scratch.
 #'
-#' @param mode A single character string for the type of model.
+#' @param mode A single character string for the prediction outcome mode.
 #'  Possible values for this model are "unknown", "regression", or
 #'  "classification".
-#' @param engine A character string for the method of fitting. Possible engines
-#' are listed above. The default for this model is `"xgboost"`.
+#' @param engine A single character string specifying what computational engine
+#'  to use for fitting. Possible engines are listed below. The default for this
+#'  model is `"xgboost"`.
 #' @param mtry A number for the number (or proportion) of predictors that will
 #'  be randomly sampled at each split when creating the tree models (`xgboost`
 #'  only).

--- a/R/decision_tree.R
+++ b/R/decision_tree.R
@@ -21,11 +21,12 @@
 #'  functions. If parameters need to be modified, `update()` can be used
 #'  in lieu of recreating the object from scratch.
 #'
-#' @param mode A single character string for the type of model.
+#' @param mode A single character string for the prediction outcome mode.
 #'  Possible values for this model are "unknown", "regression", or
 #'  "classification".
-#' @param engine A character string for the method of fitting. Possible engines
-#' are listed above. The default for this model is `"rpart"`.
+#' @param engine A single character string specifying what computational engine
+#'  to use for fitting. Possible engines are listed below. The default for this
+#'  model is `"rpart"`.
 #' @param cost_complexity A positive number for the the cost/complexity
 #'   parameter (a.k.a. `Cp`) used by CART models (`rpart` only).
 #' @param tree_depth An integer for maximum depth of the tree.

--- a/R/decision_tree.R
+++ b/R/decision_tree.R
@@ -24,6 +24,8 @@
 #' @param mode A single character string for the type of model.
 #'  Possible values for this model are "unknown", "regression", or
 #'  "classification".
+#' @param engine A character string for the method of fitting. Possible engines
+#' are listed above. The default for this model is `"rpart"`.
 #' @param cost_complexity A positive number for the the cost/complexity
 #'   parameter (a.k.a. `Cp`) used by CART models (`rpart` only).
 #' @param tree_depth An integer for maximum depth of the tree.
@@ -69,7 +71,8 @@
 #' @export
 
 decision_tree <-
-  function(mode = "unknown", cost_complexity = NULL, tree_depth = NULL, min_n = NULL) {
+  function(mode = "unknown", engine = "rpart", cost_complexity = NULL,
+           tree_depth = NULL, min_n = NULL) {
 
     args <- list(
       cost_complexity   = enquo(cost_complexity),
@@ -83,7 +86,7 @@ decision_tree <-
       eng_args = NULL,
       mode = mode,
       method = NULL,
-      engine = NULL
+      engine = engine
     )
   }
 

--- a/R/linear_reg.R
+++ b/R/linear_reg.R
@@ -16,10 +16,11 @@
 #'  here (`NULL`), the values are taken from the underlying model
 #'  functions. If parameters need to be modified, `update()` can be used
 #'  in lieu of recreating the object from scratch.
-#' @param mode A single character string for the type of model.
+#' @param mode A single character string for the prediction outcome mode.
 #'  The only possible value for this model is "regression".
-#' @param engine A character string for the method of fitting. Possible engines
-#' are listed above. The default for this model is `"lm"`.
+#' @param engine A single character string specifying what computational engine
+#'  to use for fitting. Possible engines are listed below. The default for this
+#'  model is `"lm"`.
 #' @param penalty A non-negative number representing the total
 #'  amount of regularization (`glmnet`, `keras`, and `spark` only).
 #'  For `keras` models, this corresponds to purely L2 regularization

--- a/R/linear_reg.R
+++ b/R/linear_reg.R
@@ -18,6 +18,8 @@
 #'  in lieu of recreating the object from scratch.
 #' @param mode A single character string for the type of model.
 #'  The only possible value for this model is "regression".
+#' @param engine A character string for the method of fitting. Possible engines
+#' are listed above. The default for this model is `"lm"`.
 #' @param penalty A non-negative number representing the total
 #'  amount of regularization (`glmnet`, `keras`, and `spark` only).
 #'  For `keras` models, this corresponds to purely L2 regularization
@@ -70,6 +72,7 @@
 #' @importFrom purrr map_lgl
 linear_reg <-
   function(mode = "regression",
+           engine = "lm",
            penalty = NULL,
            mixture = NULL) {
 
@@ -84,7 +87,7 @@ linear_reg <-
       eng_args = NULL,
       mode = mode,
       method = NULL,
-      engine = NULL
+      engine = engine
     )
   }
 

--- a/R/logistic_reg.R
+++ b/R/logistic_reg.R
@@ -18,6 +18,8 @@
 #'  in lieu of recreating the object from scratch.
 #' @param mode A single character string for the type of model.
 #'  The only possible value for this model is "classification".
+#' @param engine A character string for the method of fitting. Possible engines
+#' are listed above. The default for this model is `"glm"`.
 #' @param penalty A non-negative number representing the total
 #'  amount of regularization (`glmnet`, `LiblineaR`, `keras`, and `spark` only).
 #'  For `keras` models, this corresponds to purely L2 regularization
@@ -69,6 +71,7 @@
 #' @importFrom purrr map_lgl
 logistic_reg <-
   function(mode = "classification",
+           engine = "glm",
            penalty = NULL,
            mixture = NULL) {
 
@@ -83,7 +86,7 @@ logistic_reg <-
       eng_args = NULL,
       mode = mode,
       method = NULL,
-      engine = NULL
+      engine = engine
     )
   }
 

--- a/R/logistic_reg.R
+++ b/R/logistic_reg.R
@@ -16,10 +16,11 @@
 #'  here (`NULL`), the values are taken from the underlying model
 #'  functions. If parameters need to be modified, `update()` can be used
 #'  in lieu of recreating the object from scratch.
-#' @param mode A single character string for the type of model.
+#' @param mode A single character string for the prediction outcome mode.
 #'  The only possible value for this model is "classification".
-#' @param engine A character string for the method of fitting. Possible engines
-#' are listed above. The default for this model is `"glm"`.
+#' @param engine A single character string specifying what computational engine
+#'  to use for fitting. Possible engines are listed below. The default for this
+#'  model is `"glm"`.
 #' @param penalty A non-negative number representing the total
 #'  amount of regularization (`glmnet`, `LiblineaR`, `keras`, and `spark` only).
 #'  For `keras` models, this corresponds to purely L2 regularization

--- a/R/mars.R
+++ b/R/mars.R
@@ -22,11 +22,12 @@
 #'  functions. If parameters need to be modified, `update()` can be used
 #'  in lieu of recreating the object from scratch.
 #'
-#' @param mode A single character string for the type of model.
+#' @param mode A single character string for the prediction outcome mode.
 #'  Possible values for this model are "unknown", "regression", or
 #'  "classification".
-#' @param engine A character string for the method of fitting. Possible engines
-#' are listed above. The default for this model is `"earth"`.
+#' @param engine A single character string specifying what computational engine
+#'  to use for fitting. Possible engines are listed below. The default for this
+#'  model is `"earth"`.
 #' @param num_terms The number of features that will be retained in the
 #'    final model, including the intercept.
 #' @param prod_degree The highest possible interaction degree.

--- a/R/mars.R
+++ b/R/mars.R
@@ -25,6 +25,8 @@
 #' @param mode A single character string for the type of model.
 #'  Possible values for this model are "unknown", "regression", or
 #'  "classification".
+#' @param engine A character string for the method of fitting. Possible engines
+#' are listed above. The default for this model is `"earth"`.
 #' @param num_terms The number of features that will be retained in the
 #'    final model, including the intercept.
 #' @param prod_degree The highest possible interaction degree.
@@ -45,7 +47,7 @@
 #' mars(mode = "regression", num_terms = 5)
 #' @export
 mars <-
-  function(mode = "unknown",
+  function(mode = "unknown", engine = "earth",
            num_terms = NULL, prod_degree = NULL, prune_method = NULL) {
 
     args <- list(
@@ -60,7 +62,7 @@ mars <-
       eng_args = NULL,
       mode = mode,
       method = NULL,
-      engine = NULL
+      engine = engine
     )
   }
 

--- a/R/mlp.R
+++ b/R/mlp.R
@@ -30,6 +30,8 @@
 #' @param mode A single character string for the type of model.
 #'  Possible values for this model are "unknown", "regression", or
 #'  "classification".
+#' @param engine A character string for the method of fitting. Possible engines
+#' are listed above. The default for this model is `"nnet"`.
 #' @param hidden_units An integer for the number of units in the hidden model.
 #' @param penalty A non-negative numeric value for the amount of weight
 #'  decay.
@@ -63,7 +65,7 @@
 #' @export
 
 mlp <-
-  function(mode = "unknown",
+  function(mode = "unknown", engine = "nnet",
            hidden_units = NULL, penalty = NULL, dropout = NULL, epochs = NULL,
            activation = NULL) {
 
@@ -81,7 +83,7 @@ mlp <-
       eng_args = NULL,
       mode = mode,
       method = NULL,
-      engine = NULL
+      engine = engine
     )
   }
 

--- a/R/mlp.R
+++ b/R/mlp.R
@@ -27,11 +27,12 @@
 #'  If parameters need to be modified, `update()` can be used
 #'  in lieu of recreating the object from scratch.
 #'
-#' @param mode A single character string for the type of model.
+#' @param mode A single character string for the prediction outcome mode.
 #'  Possible values for this model are "unknown", "regression", or
 #'  "classification".
-#' @param engine A character string for the method of fitting. Possible engines
-#' are listed above. The default for this model is `"nnet"`.
+#' @param engine A single character string specifying what computational engine
+#'  to use for fitting. Possible engines are listed below. The default for this
+#'  model is `"nnet"`.
 #' @param hidden_units An integer for the number of units in the hidden model.
 #' @param penalty A non-negative numeric value for the amount of weight
 #'  decay.

--- a/R/multinom_reg.R
+++ b/R/multinom_reg.R
@@ -16,10 +16,11 @@
 #'  here (`NULL`), the values are taken from the underlying model
 #'  functions. If parameters need to be modified, `update()` can be used
 #'  in lieu of recreating the object from scratch.
-#' @param mode A single character string for the type of model.
+#' @param mode A single character string for the prediction outcome mode.
 #'  The only possible value for this model is "classification".
-#' @param engine A character string for the method of fitting. Possible engines
-#' are listed above. The default for this model is `"nnet"`.
+#' @param engine A single character string specifying what computational engine
+#'  to use for fitting. Possible engines are listed below. The default for this
+#'  model is `"nnet"`.
 #' @param penalty A non-negative number representing the total
 #'  amount of regularization (`glmnet`, `keras`, and `spark` only).
 #'  For `keras` models, this corresponds to purely L2 regularization
@@ -35,7 +36,7 @@
 #' The model can be created using the `fit()` function using the
 #'  following _engines_:
 #' \itemize{
-#' \item \pkg{R}:   `"glmnet"`, `"nnet"` (the default)
+#' \item \pkg{R}:   `"nnet"` (the default), `"glmnet"`
 #' \item \pkg{Spark}: `"spark"`
 #' \item \pkg{keras}: `"keras"`
 #' }

--- a/R/multinom_reg.R
+++ b/R/multinom_reg.R
@@ -18,6 +18,8 @@
 #'  in lieu of recreating the object from scratch.
 #' @param mode A single character string for the type of model.
 #'  The only possible value for this model is "classification".
+#' @param engine A character string for the method of fitting. Possible engines
+#' are listed above. The default for this model is `"nnet"`.
 #' @param penalty A non-negative number representing the total
 #'  amount of regularization (`glmnet`, `keras`, and `spark` only).
 #'  For `keras` models, this corresponds to purely L2 regularization
@@ -33,7 +35,7 @@
 #' The model can be created using the `fit()` function using the
 #'  following _engines_:
 #' \itemize{
-#' \item \pkg{R}:   `"glmnet"`  (the default), `"nnet"`
+#' \item \pkg{R}:   `"glmnet"`, `"nnet"` (the default)
 #' \item \pkg{Spark}: `"spark"`
 #' \item \pkg{keras}: `"keras"`
 #' }
@@ -64,6 +66,7 @@
 #' @importFrom purrr map_lgl
 multinom_reg <-
   function(mode = "classification",
+           engine = "nnet",
            penalty = NULL,
            mixture = NULL) {
 
@@ -78,7 +81,7 @@ multinom_reg <-
       eng_args = NULL,
       mode = mode,
       method = NULL,
-      engine = NULL
+      engine = engine
     )
   }
 

--- a/R/nearest_neighbor.R
+++ b/R/nearest_neighbor.R
@@ -23,11 +23,12 @@
 #'  here (`NULL`), the values are taken from the underlying model
 #'  functions. If parameters need to be modified, `update()` can be used
 #'  in lieu of recreating the object from scratch.
-#' @param mode A single character string for the type of model.
+#' @param mode A single character string for the prediction outcome mode.
 #' Possible values for this model are `"unknown"`, `"regression"`, or
 #' `"classification"`.
-#' @param engine A character string for the method of fitting. Possible engines
-#' are listed above. The default for this model is `"kknn"`.
+#' @param engine A single character string specifying what computational engine
+#'  to use for fitting. Possible engines are listed below. The default for this
+#'  model is `"kknn"`.
 #' @param neighbors A single integer for the number of neighbors
 #' to consider (often called `k`). For \pkg{kknn}, a value of 5
 #' is used if `neighbors` is not specified.

--- a/R/nearest_neighbor.R
+++ b/R/nearest_neighbor.R
@@ -26,7 +26,8 @@
 #' @param mode A single character string for the type of model.
 #' Possible values for this model are `"unknown"`, `"regression"`, or
 #' `"classification"`.
-#'
+#' @param engine A character string for the method of fitting. Possible engines
+#' are listed above. The default for this model is `"kknn"`.
 #' @param neighbors A single integer for the number of neighbors
 #' to consider (often called `k`). For \pkg{kknn}, a value of 5
 #' is used if `neighbors` is not specified.
@@ -57,6 +58,7 @@
 #'
 #' @export
 nearest_neighbor <- function(mode = "unknown",
+                             engine = "kknn",
                              neighbors = NULL,
                              weight_func = NULL,
                              dist_power = NULL) {
@@ -72,7 +74,7 @@ nearest_neighbor <- function(mode = "unknown",
     eng_args = NULL,
     mode = mode,
     method = NULL,
-    engine = NULL
+    engine = engine
   )
 }
 

--- a/R/proportional_hazards.R
+++ b/R/proportional_hazards.R
@@ -16,10 +16,11 @@
 #'  functions. If parameters need to be modified, `update()` can be used
 #'  in lieu of recreating the object from scratch.
 #'
-#' @param mode A single character string for the type of model.
+#' @param mode A single character string for the prediction outcome mode.
 #'  Possible values for this model are "unknown", or "censored regression".
-#' @param engine A character string for the method of fitting. Possible engines
-#' are listed above. The default for this model is `"survival"`.
+#' @param engine A single character string specifying what computational engine
+#'  to use for fitting. Possible engines are listed below. The default for this
+#'  model is `"survival"`.
 #' @inheritParams linear_reg
 #'
 #' @details

--- a/R/proportional_hazards.R
+++ b/R/proportional_hazards.R
@@ -18,6 +18,8 @@
 #'
 #' @param mode A single character string for the type of model.
 #'  Possible values for this model are "unknown", or "censored regression".
+#' @param engine A character string for the method of fitting. Possible engines
+#' are listed above. The default for this model is `"survival"`.
 #' @inheritParams linear_reg
 #'
 #' @details
@@ -29,9 +31,11 @@
 #' show_engines("proportional_hazards")
 #' @keywords internal
 #' @export
-proportional_hazards <- function(mode = "censored regression",
-                    penalty = NULL,
-                    mixture = NULL) {
+proportional_hazards <- function(
+  mode = "censored regression",
+  engine = "survival",
+  penalty = NULL,
+  mixture = NULL) {
 
     args <- list(
       penalty = enquo(penalty),
@@ -44,7 +48,7 @@ proportional_hazards <- function(mode = "censored regression",
       eng_args = NULL,
       mode = mode,
       method = NULL,
-      engine = NULL
+      engine = engine
     )
   }
 

--- a/R/rand_forest.R
+++ b/R/rand_forest.R
@@ -23,6 +23,8 @@
 #' @param mode A single character string for the type of model.
 #'  Possible values for this model are "unknown", "regression", or
 #'  "classification".
+#' @param engine A character string for the method of fitting. Possible engines
+#' are listed above. The default for this model is `"ranger"`.
 #' @param mtry An integer for the number of predictors that will
 #'  be randomly sampled at each split when creating the tree models.
 #' @param trees An integer for the number of trees contained in
@@ -63,7 +65,7 @@
 #' @export
 
 rand_forest <-
-  function(mode = "unknown", mtry = NULL, trees = NULL, min_n = NULL) {
+  function(mode = "unknown", engine = "ranger", mtry = NULL, trees = NULL, min_n = NULL) {
 
     args <- list(
       mtry   = enquo(mtry),
@@ -77,7 +79,7 @@ rand_forest <-
       eng_args = NULL,
       mode = mode,
       method = NULL,
-      engine = NULL
+      engine = engine
     )
   }
 

--- a/R/rand_forest.R
+++ b/R/rand_forest.R
@@ -20,11 +20,12 @@
 #'  functions. If parameters need to be modified, `update()` can be used
 #'  in lieu of recreating the object from scratch.
 #'
-#' @param mode A single character string for the type of model.
+#' @param mode A single character string for the prediction outcome mode.
 #'  Possible values for this model are "unknown", "regression", or
 #'  "classification".
-#' @param engine A character string for the method of fitting. Possible engines
-#' are listed above. The default for this model is `"ranger"`.
+#' @param engine A single character string specifying what computational engine
+#'  to use for fitting. Possible engines are listed below. The default for this
+#'  model is `"ranger"`.
 #' @param mtry An integer for the number of predictors that will
 #'  be randomly sampled at each split when creating the tree models.
 #' @param trees An integer for the number of trees contained in

--- a/R/surv_reg.R
+++ b/R/surv_reg.R
@@ -31,10 +31,11 @@
 #'  `strata` function cannot be used. To achieve the same effect,
 #'  the extra parameter roles can be used (as described above).
 #'
-#' @param mode A single character string for the type of model.
+#' @param mode A single character string for the prediction outcome mode.
 #'  The only possible value for this model is "regression".
-#'  @param engine A character string for the method of fitting. Possible engines
-#' are listed above. The default for this model is `"survival"`.
+#'  @param engine A single character string specifying what computational engine
+#'  to use for fitting. Possible engines are listed below. The default for this
+#'  model is `"survival"`.
 #' @param dist A character string for the outcome distribution. "weibull" is
 #'  the default.
 #' @details

--- a/R/surv_reg.R
+++ b/R/surv_reg.R
@@ -33,6 +33,8 @@
 #'
 #' @param mode A single character string for the type of model.
 #'  The only possible value for this model is "regression".
+#'  @param engine A character string for the method of fitting. Possible engines
+#' are listed above. The default for this model is `"survival"`.
 #' @param dist A character string for the outcome distribution. "weibull" is
 #'  the default.
 #' @details
@@ -65,7 +67,7 @@
 #'
 #' @keywords internal
 #' @export
-surv_reg <- function(mode = "regression", dist = NULL) {
+surv_reg <- function(mode = "regression", engine = "survival", dist = NULL) {
 
   lifecycle::deprecate_soft("0.1.6", "surv_reg()", "survival_reg()")
 
@@ -79,7 +81,7 @@ surv_reg <- function(mode = "regression", dist = NULL) {
       eng_args = NULL,
       mode = mode,
       method = NULL,
-      engine = NULL
+      engine = engine
     )
   }
 

--- a/R/survival_reg.R
+++ b/R/survival_reg.R
@@ -14,10 +14,11 @@
 #'  functions. If parameters need to be modified, `update()` can be used
 #'  in lieu of recreating the object from scratch.
 #'
-#' @param mode A single character string for the type of model.
+#' @param mode A single character string for the prediction outcome mode.
 #'  The only possible value for this model is "censored regression".
-#' @param engine A character string for the method of fitting. Possible engines
-#' are listed above. The default for this model is `"survival"`.
+#' @param engine A single character string specifying what computational engine
+#'  to use for fitting. Possible engines are listed below. The default for this
+#'  model is `"survival"`.
 #' @param dist A character string for the outcome distribution. "weibull" is
 #'  the default.
 #' @details

--- a/R/survival_reg.R
+++ b/R/survival_reg.R
@@ -16,6 +16,8 @@
 #'
 #' @param mode A single character string for the type of model.
 #'  The only possible value for this model is "censored regression".
+#' @param engine A character string for the method of fitting. Possible engines
+#' are listed above. The default for this model is `"survival"`.
 #' @param dist A character string for the outcome distribution. "weibull" is
 #'  the default.
 #' @details
@@ -34,7 +36,7 @@
 #' survival_reg(dist = varying())
 #' @keywords internal
 #' @export
-survival_reg <- function(mode = "censored regression", dist = NULL) {
+survival_reg <- function(mode = "censored regression", engine = "survival", dist = NULL) {
 
   args <- list(
     dist = enquo(dist)
@@ -46,7 +48,7 @@ survival_reg <- function(mode = "censored regression", dist = NULL) {
     eng_args = NULL,
     mode = mode,
     method = NULL,
-    engine = NULL
+    engine = engine
   )
 }
 

--- a/R/svm_linear.R
+++ b/R/svm_linear.R
@@ -20,6 +20,8 @@
 #' @param mode A single character string for the type of model.
 #'  Possible values for this model are "unknown", "regression", or
 #'  "classification".
+#' @param engine A character string for the method of fitting. Possible engines
+#' are listed above. The default for this model is `"LiblineaR"`.
 #' @param cost A positive number for the cost of predicting a sample within
 #'  or on the wrong side of the margin
 #' @param margin A positive number for the epsilon in the SVM insensitive
@@ -45,7 +47,7 @@
 #' @export
 
 svm_linear <-
-  function(mode = "unknown",
+  function(mode = "unknown", engine = "LiblineaR",
            cost = NULL, margin = NULL) {
 
     args <- list(
@@ -59,7 +61,7 @@ svm_linear <-
       eng_args = NULL,
       mode = mode,
       method = NULL,
-      engine = NULL
+      engine = engine
     )
   }
 

--- a/R/svm_linear.R
+++ b/R/svm_linear.R
@@ -17,11 +17,12 @@
 #'  functions. If parameters need to be modified, `update()` can be used
 #'  in lieu of recreating the object from scratch.
 #'
-#' @param mode A single character string for the type of model.
+#' @param mode A single character string for the prediction outcome mode.
 #'  Possible values for this model are "unknown", "regression", or
 #'  "classification".
-#' @param engine A character string for the method of fitting. Possible engines
-#' are listed above. The default for this model is `"LiblineaR"`.
+#' @param engine A single character string specifying what computational engine
+#'  to use for fitting. Possible engines are listed below. The default for this
+#'  model is `"LiblineaR"`.
 #' @param cost A positive number for the cost of predicting a sample within
 #'  or on the wrong side of the margin
 #' @param margin A positive number for the epsilon in the SVM insensitive

--- a/R/svm_poly.R
+++ b/R/svm_poly.R
@@ -22,6 +22,8 @@
 #' @param mode A single character string for the type of model.
 #'  Possible values for this model are "unknown", "regression", or
 #'  "classification".
+#' @param engine A character string for the method of fitting. Possible engines
+#' are listed above. The default for this model is `"kernlab"`.
 #' @param cost A positive number for the cost of predicting a sample within
 #'  or on the wrong side of the margin
 #' @param degree A positive number for polynomial degree.
@@ -48,7 +50,7 @@
 #' @export
 
 svm_poly <-
-  function(mode = "unknown",
+  function(mode = "unknown", engine = "kernlab",
            cost = NULL, degree = NULL, scale_factor = NULL, margin = NULL) {
 
     args <- list(
@@ -64,7 +66,7 @@ svm_poly <-
       eng_args = NULL,
       mode = mode,
       method = NULL,
-      engine = NULL
+      engine = engine
     )
   }
 

--- a/R/svm_poly.R
+++ b/R/svm_poly.R
@@ -19,11 +19,12 @@
 #'  functions. If parameters need to be modified, `update()` can be used
 #'  in lieu of recreating the object from scratch.
 #'
-#' @param mode A single character string for the type of model.
+#' @param mode A single character string for the prediction outcome mode.
 #'  Possible values for this model are "unknown", "regression", or
 #'  "classification".
-#' @param engine A character string for the method of fitting. Possible engines
-#' are listed above. The default for this model is `"kernlab"`.
+#' @param engine A single character string specifying what computational engine
+#'  to use for fitting. Possible engines are listed below. The default for this
+#'  model is `"kernlab"`.
 #' @param cost A positive number for the cost of predicting a sample within
 #'  or on the wrong side of the margin
 #' @param degree A positive number for polynomial degree.

--- a/R/svm_rbf.R
+++ b/R/svm_rbf.R
@@ -19,11 +19,12 @@
 #'  functions. If parameters need to be modified, `update()` can be used
 #'  in lieu of recreating the object from scratch.
 #'
-#' @param mode A single character string for the type of model.
+#' @param mode A single character string for the prediction outcome mode.
 #'  Possible values for this model are "unknown", "regression", or
 #'  "classification".
-#' @param engine A character string for the method of fitting. Possible engines
-#' are listed above. The default for this model is `"kernlab"`.
+#' @param engine A single character string specifying what computational engine
+#'  to use for fitting. Possible engines are listed below. The default for this
+#'  model is `"kernlab"`.
 #' @param cost A positive number for the cost of predicting a sample within
 #'  or on the wrong side of the margin
 #' @param rbf_sigma A positive number for radial basis function.

--- a/R/svm_rbf.R
+++ b/R/svm_rbf.R
@@ -22,6 +22,8 @@
 #' @param mode A single character string for the type of model.
 #'  Possible values for this model are "unknown", "regression", or
 #'  "classification".
+#' @param engine A character string for the method of fitting. Possible engines
+#' are listed above. The default for this model is `"kernlab"`.
 #' @param cost A positive number for the cost of predicting a sample within
 #'  or on the wrong side of the margin
 #' @param rbf_sigma A positive number for radial basis function.
@@ -48,7 +50,7 @@
 #' @export
 
 svm_rbf <-
-  function(mode = "unknown",
+  function(mode = "unknown", engine = "kernlab",
            cost = NULL, rbf_sigma = NULL, margin = NULL) {
 
     args <- list(
@@ -63,7 +65,7 @@ svm_rbf <-
       eng_args = NULL,
       mode = mode,
       method = NULL,
-      engine = NULL
+      engine = engine
     )
   }
 

--- a/man/boost_tree.Rd
+++ b/man/boost_tree.Rd
@@ -18,12 +18,13 @@ boost_tree(
 )
 }
 \arguments{
-\item{mode}{A single character string for the type of model.
+\item{mode}{A single character string for the prediction outcome mode.
 Possible values for this model are "unknown", "regression", or
 "classification".}
 
-\item{engine}{A character string for the method of fitting. Possible engines
-are listed above. The default for this model is \code{"xgboost"}.}
+\item{engine}{A single character string specifying what computational engine
+to use for fitting. Possible engines are listed below. The default for this
+model is \code{"xgboost"}.}
 
 \item{mtry}{A number for the number (or proportion) of predictors that will
 be randomly sampled at each split when creating the tree models (\code{xgboost}

--- a/man/boost_tree.Rd
+++ b/man/boost_tree.Rd
@@ -6,6 +6,7 @@
 \usage{
 boost_tree(
   mode = "unknown",
+  engine = "xgboost",
   mtry = NULL,
   trees = NULL,
   min_n = NULL,
@@ -20,6 +21,9 @@ boost_tree(
 \item{mode}{A single character string for the type of model.
 Possible values for this model are "unknown", "regression", or
 "classification".}
+
+\item{engine}{A character string for the method of fitting. Possible engines
+are listed above. The default for this model is \code{"xgboost"}.}
 
 \item{mtry}{A number for the number (or proportion) of predictors that will
 be randomly sampled at each split when creating the tree models (\code{xgboost}

--- a/man/contr_one_hot.Rd
+++ b/man/contr_one_hot.Rd
@@ -39,16 +39,14 @@ levels(penguins$species)
 }\if{html}{\out{</div>}}\preformatted{## [1] "Biscoe"    "Dream"     "Torgersen"
 }\if{html}{\out{<div class="r">}}\preformatted{model.matrix(~ species + island, data = penguins) \%>\% 
   colnames()
-}\if{html}{\out{</div>}}\preformatted{## [1] "(Intercept)"      "speciesChinstrap" "speciesGentoo"    "islandDream"     
-## [5] "islandTorgersen"
+}\if{html}{\out{</div>}}\preformatted{## [1] "(Intercept)"      "speciesChinstrap" "speciesGentoo"    "islandDream"      "islandTorgersen"
 }
 
 For a formula with no intercept, the first factor is expanded to
 indicators for \emph{all} factor levels but all other factors are expanded to
 all but one (as above):\if{html}{\out{<div class="r">}}\preformatted{model.matrix(~ 0 + species + island, data = penguins) \%>\% 
   colnames()
-}\if{html}{\out{</div>}}\preformatted{## [1] "speciesAdelie"    "speciesChinstrap" "speciesGentoo"    "islandDream"     
-## [5] "islandTorgersen"
+}\if{html}{\out{</div>}}\preformatted{## [1] "speciesAdelie"    "speciesChinstrap" "speciesGentoo"    "islandDream"      "islandTorgersen"
 }
 
 For inference, this hybrid encoding can be problematic.
@@ -61,8 +59,8 @@ options(contrasts = new_contr)
 
 model.matrix(~ species + island, data = penguins) \%>\% 
   colnames()
-}\if{html}{\out{</div>}}\preformatted{## [1] "(Intercept)"      "speciesAdelie"    "speciesChinstrap" "speciesGentoo"   
-## [5] "islandBiscoe"     "islandDream"      "islandTorgersen"
+}\if{html}{\out{</div>}}\preformatted{## [1] "(Intercept)"      "speciesAdelie"    "speciesChinstrap" "speciesGentoo"    "islandBiscoe"    
+## [6] "islandDream"      "islandTorgersen"
 }\if{html}{\out{<div class="r">}}\preformatted{options(contrasts = old_contr)
 }\if{html}{\out{</div>}}
 

--- a/man/decision_tree.Rd
+++ b/man/decision_tree.Rd
@@ -13,12 +13,13 @@ decision_tree(
 )
 }
 \arguments{
-\item{mode}{A single character string for the type of model.
+\item{mode}{A single character string for the prediction outcome mode.
 Possible values for this model are "unknown", "regression", or
 "classification".}
 
-\item{engine}{A character string for the method of fitting. Possible engines
-are listed above. The default for this model is \code{"rpart"}.}
+\item{engine}{A single character string specifying what computational engine
+to use for fitting. Possible engines are listed below. The default for this
+model is \code{"rpart"}.}
 
 \item{cost_complexity}{A positive number for the the cost/complexity
 parameter (a.k.a. \code{Cp}) used by CART models (\code{rpart} only).}

--- a/man/decision_tree.Rd
+++ b/man/decision_tree.Rd
@@ -6,6 +6,7 @@
 \usage{
 decision_tree(
   mode = "unknown",
+  engine = "rpart",
   cost_complexity = NULL,
   tree_depth = NULL,
   min_n = NULL
@@ -15,6 +16,9 @@ decision_tree(
 \item{mode}{A single character string for the type of model.
 Possible values for this model are "unknown", "regression", or
 "classification".}
+
+\item{engine}{A character string for the method of fitting. Possible engines
+are listed above. The default for this model is \code{"rpart"}.}
 
 \item{cost_complexity}{A positive number for the the cost/complexity
 parameter (a.k.a. \code{Cp}) used by CART models (\code{rpart} only).}

--- a/man/linear_reg.Rd
+++ b/man/linear_reg.Rd
@@ -4,11 +4,14 @@
 \alias{linear_reg}
 \title{General Interface for Linear Regression Models}
 \usage{
-linear_reg(mode = "regression", penalty = NULL, mixture = NULL)
+linear_reg(mode = "regression", engine = "lm", penalty = NULL, mixture = NULL)
 }
 \arguments{
 \item{mode}{A single character string for the type of model.
 The only possible value for this model is "regression".}
+
+\item{engine}{A character string for the method of fitting. Possible engines
+are listed above. The default for this model is \code{"lm"}.}
 
 \item{penalty}{A non-negative number representing the total
 amount of regularization (\code{glmnet}, \code{keras}, and \code{spark} only).

--- a/man/linear_reg.Rd
+++ b/man/linear_reg.Rd
@@ -7,11 +7,12 @@
 linear_reg(mode = "regression", engine = "lm", penalty = NULL, mixture = NULL)
 }
 \arguments{
-\item{mode}{A single character string for the type of model.
+\item{mode}{A single character string for the prediction outcome mode.
 The only possible value for this model is "regression".}
 
-\item{engine}{A character string for the method of fitting. Possible engines
-are listed above. The default for this model is \code{"lm"}.}
+\item{engine}{A single character string specifying what computational engine
+to use for fitting. Possible engines are listed below. The default for this
+model is \code{"lm"}.}
 
 \item{penalty}{A non-negative number representing the total
 amount of regularization (\code{glmnet}, \code{keras}, and \code{spark} only).

--- a/man/logistic_reg.Rd
+++ b/man/logistic_reg.Rd
@@ -12,11 +12,12 @@ logistic_reg(
 )
 }
 \arguments{
-\item{mode}{A single character string for the type of model.
+\item{mode}{A single character string for the prediction outcome mode.
 The only possible value for this model is "classification".}
 
-\item{engine}{A character string for the method of fitting. Possible engines
-are listed above. The default for this model is \code{"glm"}.}
+\item{engine}{A single character string specifying what computational engine
+to use for fitting. Possible engines are listed below. The default for this
+model is \code{"glm"}.}
 
 \item{penalty}{A non-negative number representing the total
 amount of regularization (\code{glmnet}, \code{LiblineaR}, \code{keras}, and \code{spark} only).

--- a/man/logistic_reg.Rd
+++ b/man/logistic_reg.Rd
@@ -4,11 +4,19 @@
 \alias{logistic_reg}
 \title{General Interface for Logistic Regression Models}
 \usage{
-logistic_reg(mode = "classification", penalty = NULL, mixture = NULL)
+logistic_reg(
+  mode = "classification",
+  engine = "glm",
+  penalty = NULL,
+  mixture = NULL
+)
 }
 \arguments{
 \item{mode}{A single character string for the type of model.
 The only possible value for this model is "classification".}
+
+\item{engine}{A character string for the method of fitting. Possible engines
+are listed above. The default for this model is \code{"glm"}.}
 
 \item{penalty}{A non-negative number representing the total
 amount of regularization (\code{glmnet}, \code{LiblineaR}, \code{keras}, and \code{spark} only).

--- a/man/mars.Rd
+++ b/man/mars.Rd
@@ -6,6 +6,7 @@
 \usage{
 mars(
   mode = "unknown",
+  engine = "earth",
   num_terms = NULL,
   prod_degree = NULL,
   prune_method = NULL
@@ -15,6 +16,9 @@ mars(
 \item{mode}{A single character string for the type of model.
 Possible values for this model are "unknown", "regression", or
 "classification".}
+
+\item{engine}{A character string for the method of fitting. Possible engines
+are listed above. The default for this model is \code{"earth"}.}
 
 \item{num_terms}{The number of features that will be retained in the
 final model, including the intercept.}

--- a/man/mars.Rd
+++ b/man/mars.Rd
@@ -13,12 +13,13 @@ mars(
 )
 }
 \arguments{
-\item{mode}{A single character string for the type of model.
+\item{mode}{A single character string for the prediction outcome mode.
 Possible values for this model are "unknown", "regression", or
 "classification".}
 
-\item{engine}{A character string for the method of fitting. Possible engines
-are listed above. The default for this model is \code{"earth"}.}
+\item{engine}{A single character string specifying what computational engine
+to use for fitting. Possible engines are listed below. The default for this
+model is \code{"earth"}.}
 
 \item{num_terms}{The number of features that will be retained in the
 final model, including the intercept.}

--- a/man/mlp.Rd
+++ b/man/mlp.Rd
@@ -6,6 +6,7 @@
 \usage{
 mlp(
   mode = "unknown",
+  engine = "nnet",
   hidden_units = NULL,
   penalty = NULL,
   dropout = NULL,
@@ -17,6 +18,9 @@ mlp(
 \item{mode}{A single character string for the type of model.
 Possible values for this model are "unknown", "regression", or
 "classification".}
+
+\item{engine}{A character string for the method of fitting. Possible engines
+are listed above. The default for this model is \code{"nnet"}.}
 
 \item{hidden_units}{An integer for the number of units in the hidden model.}
 

--- a/man/mlp.Rd
+++ b/man/mlp.Rd
@@ -15,12 +15,13 @@ mlp(
 )
 }
 \arguments{
-\item{mode}{A single character string for the type of model.
+\item{mode}{A single character string for the prediction outcome mode.
 Possible values for this model are "unknown", "regression", or
 "classification".}
 
-\item{engine}{A character string for the method of fitting. Possible engines
-are listed above. The default for this model is \code{"nnet"}.}
+\item{engine}{A single character string specifying what computational engine
+to use for fitting. Possible engines are listed below. The default for this
+model is \code{"nnet"}.}
 
 \item{hidden_units}{An integer for the number of units in the hidden model.}
 

--- a/man/multinom_reg.Rd
+++ b/man/multinom_reg.Rd
@@ -12,11 +12,12 @@ multinom_reg(
 )
 }
 \arguments{
-\item{mode}{A single character string for the type of model.
+\item{mode}{A single character string for the prediction outcome mode.
 The only possible value for this model is "classification".}
 
-\item{engine}{A character string for the method of fitting. Possible engines
-are listed above. The default for this model is \code{"nnet"}.}
+\item{engine}{A single character string specifying what computational engine
+to use for fitting. Possible engines are listed below. The default for this
+model is \code{"nnet"}.}
 
 \item{penalty}{A non-negative number representing the total
 amount of regularization (\code{glmnet}, \code{keras}, and \code{spark} only).
@@ -53,7 +54,7 @@ For \code{multinom_reg()}, the mode will always be "classification".
 The model can be created using the \code{fit()} function using the
 following \emph{engines}:
 \itemize{
-\item \pkg{R}:   \code{"glmnet"}, \code{"nnet"} (the default)
+\item \pkg{R}:   \code{"nnet"} (the default), \code{"glmnet"}
 \item \pkg{Spark}: \code{"spark"}
 \item \pkg{keras}: \code{"keras"}
 }

--- a/man/multinom_reg.Rd
+++ b/man/multinom_reg.Rd
@@ -4,11 +4,19 @@
 \alias{multinom_reg}
 \title{General Interface for Multinomial Regression Models}
 \usage{
-multinom_reg(mode = "classification", penalty = NULL, mixture = NULL)
+multinom_reg(
+  mode = "classification",
+  engine = "nnet",
+  penalty = NULL,
+  mixture = NULL
+)
 }
 \arguments{
 \item{mode}{A single character string for the type of model.
 The only possible value for this model is "classification".}
+
+\item{engine}{A character string for the method of fitting. Possible engines
+are listed above. The default for this model is \code{"nnet"}.}
 
 \item{penalty}{A non-negative number representing the total
 amount of regularization (\code{glmnet}, \code{keras}, and \code{spark} only).
@@ -45,7 +53,7 @@ For \code{multinom_reg()}, the mode will always be "classification".
 The model can be created using the \code{fit()} function using the
 following \emph{engines}:
 \itemize{
-\item \pkg{R}:   \code{"glmnet"}  (the default), \code{"nnet"}
+\item \pkg{R}:   \code{"glmnet"}, \code{"nnet"} (the default)
 \item \pkg{Spark}: \code{"spark"}
 \item \pkg{keras}: \code{"keras"}
 }

--- a/man/nearest_neighbor.Rd
+++ b/man/nearest_neighbor.Rd
@@ -6,6 +6,7 @@
 \usage{
 nearest_neighbor(
   mode = "unknown",
+  engine = "kknn",
   neighbors = NULL,
   weight_func = NULL,
   dist_power = NULL
@@ -15,6 +16,9 @@ nearest_neighbor(
 \item{mode}{A single character string for the type of model.
 Possible values for this model are \code{"unknown"}, \code{"regression"}, or
 \code{"classification"}.}
+
+\item{engine}{A character string for the method of fitting. Possible engines
+are listed above. The default for this model is \code{"kknn"}.}
 
 \item{neighbors}{A single integer for the number of neighbors
 to consider (often called \code{k}). For \pkg{kknn}, a value of 5

--- a/man/nearest_neighbor.Rd
+++ b/man/nearest_neighbor.Rd
@@ -13,12 +13,13 @@ nearest_neighbor(
 )
 }
 \arguments{
-\item{mode}{A single character string for the type of model.
+\item{mode}{A single character string for the prediction outcome mode.
 Possible values for this model are \code{"unknown"}, \code{"regression"}, or
 \code{"classification"}.}
 
-\item{engine}{A character string for the method of fitting. Possible engines
-are listed above. The default for this model is \code{"kknn"}.}
+\item{engine}{A single character string specifying what computational engine
+to use for fitting. Possible engines are listed below. The default for this
+model is \code{"kknn"}.}
 
 \item{neighbors}{A single integer for the number of neighbors
 to consider (often called \code{k}). For \pkg{kknn}, a value of 5

--- a/man/proportional_hazards.Rd
+++ b/man/proportional_hazards.Rd
@@ -6,6 +6,7 @@
 \usage{
 proportional_hazards(
   mode = "censored regression",
+  engine = "survival",
   penalty = NULL,
   mixture = NULL
 )
@@ -13,6 +14,9 @@ proportional_hazards(
 \arguments{
 \item{mode}{A single character string for the type of model.
 Possible values for this model are "unknown", or "censored regression".}
+
+\item{engine}{A character string for the method of fitting. Possible engines
+are listed above. The default for this model is \code{"survival"}.}
 
 \item{penalty}{A non-negative number representing the total
 amount of regularization (\code{glmnet}, \code{keras}, and \code{spark} only).

--- a/man/proportional_hazards.Rd
+++ b/man/proportional_hazards.Rd
@@ -12,11 +12,12 @@ proportional_hazards(
 )
 }
 \arguments{
-\item{mode}{A single character string for the type of model.
+\item{mode}{A single character string for the prediction outcome mode.
 Possible values for this model are "unknown", or "censored regression".}
 
-\item{engine}{A character string for the method of fitting. Possible engines
-are listed above. The default for this model is \code{"survival"}.}
+\item{engine}{A single character string specifying what computational engine
+to use for fitting. Possible engines are listed below. The default for this
+model is \code{"survival"}.}
 
 \item{penalty}{A non-negative number representing the total
 amount of regularization (\code{glmnet}, \code{keras}, and \code{spark} only).

--- a/man/rand_forest.Rd
+++ b/man/rand_forest.Rd
@@ -13,12 +13,13 @@ rand_forest(
 )
 }
 \arguments{
-\item{mode}{A single character string for the type of model.
+\item{mode}{A single character string for the prediction outcome mode.
 Possible values for this model are "unknown", "regression", or
 "classification".}
 
-\item{engine}{A character string for the method of fitting. Possible engines
-are listed above. The default for this model is \code{"ranger"}.}
+\item{engine}{A single character string specifying what computational engine
+to use for fitting. Possible engines are listed below. The default for this
+model is \code{"ranger"}.}
 
 \item{mtry}{An integer for the number of predictors that will
 be randomly sampled at each split when creating the tree models.}

--- a/man/rand_forest.Rd
+++ b/man/rand_forest.Rd
@@ -4,12 +4,21 @@
 \alias{rand_forest}
 \title{General Interface for Random Forest Models}
 \usage{
-rand_forest(mode = "unknown", mtry = NULL, trees = NULL, min_n = NULL)
+rand_forest(
+  mode = "unknown",
+  engine = "ranger",
+  mtry = NULL,
+  trees = NULL,
+  min_n = NULL
+)
 }
 \arguments{
 \item{mode}{A single character string for the type of model.
 Possible values for this model are "unknown", "regression", or
 "classification".}
+
+\item{engine}{A character string for the method of fitting. Possible engines
+are listed above. The default for this model is \code{"ranger"}.}
 
 \item{mtry}{An integer for the number of predictors that will
 be randomly sampled at each split when creating the tree models.}

--- a/man/surv_reg.Rd
+++ b/man/surv_reg.Rd
@@ -4,11 +4,13 @@
 \alias{surv_reg}
 \title{General Interface for Parametric Survival Models}
 \usage{
-surv_reg(mode = "regression", dist = NULL)
+surv_reg(mode = "regression", engine = "survival", dist = NULL)
 }
 \arguments{
 \item{mode}{A single character string for the type of model.
-The only possible value for this model is "regression".}
+The only possible value for this model is "regression".
+@param engine A character string for the method of fitting. Possible engines
+are listed above. The default for this model is \code{"survival"}.}
 
 \item{dist}{A character string for the outcome distribution. "weibull" is
 the default.}

--- a/man/surv_reg.Rd
+++ b/man/surv_reg.Rd
@@ -7,10 +7,11 @@
 surv_reg(mode = "regression", engine = "survival", dist = NULL)
 }
 \arguments{
-\item{mode}{A single character string for the type of model.
+\item{mode}{A single character string for the prediction outcome mode.
 The only possible value for this model is "regression".
-@param engine A character string for the method of fitting. Possible engines
-are listed above. The default for this model is \code{"survival"}.}
+@param engine A single character string specifying what computational engine
+to use for fitting. Possible engines are listed below. The default for this
+model is \code{"survival"}.}
 
 \item{dist}{A character string for the outcome distribution. "weibull" is
 the default.}

--- a/man/survival_reg.Rd
+++ b/man/survival_reg.Rd
@@ -7,11 +7,12 @@
 survival_reg(mode = "censored regression", engine = "survival", dist = NULL)
 }
 \arguments{
-\item{mode}{A single character string for the type of model.
+\item{mode}{A single character string for the prediction outcome mode.
 The only possible value for this model is "censored regression".}
 
-\item{engine}{A character string for the method of fitting. Possible engines
-are listed above. The default for this model is \code{"survival"}.}
+\item{engine}{A single character string specifying what computational engine
+to use for fitting. Possible engines are listed below. The default for this
+model is \code{"survival"}.}
 
 \item{dist}{A character string for the outcome distribution. "weibull" is
 the default.}

--- a/man/survival_reg.Rd
+++ b/man/survival_reg.Rd
@@ -4,7 +4,7 @@
 \alias{survival_reg}
 \title{General Interface for Parametric Survival Models}
 \usage{
-survival_reg(mode = "censored regression", dist = NULL)
+survival_reg(mode = "censored regression", enigne = "survival", dist = NULL)
 }
 \arguments{
 \item{mode}{A single character string for the type of model.
@@ -12,6 +12,9 @@ The only possible value for this model is "censored regression".}
 
 \item{dist}{A character string for the outcome distribution. "weibull" is
 the default.}
+
+\item{engine}{A character string for the method of fitting. Possible engines
+are listed above. The default for this model is \code{"survival"}.}
 }
 \description{
 \code{survival_reg()} is a way to generate a \emph{specification} of a model

--- a/man/survival_reg.Rd
+++ b/man/survival_reg.Rd
@@ -4,17 +4,17 @@
 \alias{survival_reg}
 \title{General Interface for Parametric Survival Models}
 \usage{
-survival_reg(mode = "censored regression", enigne = "survival", dist = NULL)
+survival_reg(mode = "censored regression", engine = "survival", dist = NULL)
 }
 \arguments{
 \item{mode}{A single character string for the type of model.
 The only possible value for this model is "censored regression".}
 
-\item{dist}{A character string for the outcome distribution. "weibull" is
-the default.}
-
 \item{engine}{A character string for the method of fitting. Possible engines
 are listed above. The default for this model is \code{"survival"}.}
+
+\item{dist}{A character string for the outcome distribution. "weibull" is
+the default.}
 }
 \description{
 \code{survival_reg()} is a way to generate a \emph{specification} of a model

--- a/man/svm_linear.Rd
+++ b/man/svm_linear.Rd
@@ -4,12 +4,15 @@
 \alias{svm_linear}
 \title{General interface for linear support vector machines}
 \usage{
-svm_linear(mode = "unknown", cost = NULL, margin = NULL)
+svm_linear(mode = "unknown", engine = "LiblineaR", cost = NULL, margin = NULL)
 }
 \arguments{
 \item{mode}{A single character string for the type of model.
 Possible values for this model are "unknown", "regression", or
 "classification".}
+
+\item{engine}{A character string for the method of fitting. Possible engines
+are listed above. The default for this model is \code{"LiblineaR"}.}
 
 \item{cost}{A positive number for the cost of predicting a sample within
 or on the wrong side of the margin}

--- a/man/svm_linear.Rd
+++ b/man/svm_linear.Rd
@@ -7,12 +7,13 @@
 svm_linear(mode = "unknown", engine = "LiblineaR", cost = NULL, margin = NULL)
 }
 \arguments{
-\item{mode}{A single character string for the type of model.
+\item{mode}{A single character string for the prediction outcome mode.
 Possible values for this model are "unknown", "regression", or
 "classification".}
 
-\item{engine}{A character string for the method of fitting. Possible engines
-are listed above. The default for this model is \code{"LiblineaR"}.}
+\item{engine}{A single character string specifying what computational engine
+to use for fitting. Possible engines are listed below. The default for this
+model is \code{"LiblineaR"}.}
 
 \item{cost}{A positive number for the cost of predicting a sample within
 or on the wrong side of the margin}

--- a/man/svm_poly.Rd
+++ b/man/svm_poly.Rd
@@ -14,12 +14,13 @@ svm_poly(
 )
 }
 \arguments{
-\item{mode}{A single character string for the type of model.
+\item{mode}{A single character string for the prediction outcome mode.
 Possible values for this model are "unknown", "regression", or
 "classification".}
 
-\item{engine}{A character string for the method of fitting. Possible engines
-are listed above. The default for this model is \code{"kernlab"}.}
+\item{engine}{A single character string specifying what computational engine
+to use for fitting. Possible engines are listed below. The default for this
+model is \code{"kernlab"}.}
 
 \item{cost}{A positive number for the cost of predicting a sample within
 or on the wrong side of the margin}

--- a/man/svm_poly.Rd
+++ b/man/svm_poly.Rd
@@ -6,6 +6,7 @@
 \usage{
 svm_poly(
   mode = "unknown",
+  engine = "kernlab",
   cost = NULL,
   degree = NULL,
   scale_factor = NULL,
@@ -16,6 +17,9 @@ svm_poly(
 \item{mode}{A single character string for the type of model.
 Possible values for this model are "unknown", "regression", or
 "classification".}
+
+\item{engine}{A character string for the method of fitting. Possible engines
+are listed above. The default for this model is \code{"kernlab"}.}
 
 \item{cost}{A positive number for the cost of predicting a sample within
 or on the wrong side of the margin}

--- a/man/svm_rbf.Rd
+++ b/man/svm_rbf.Rd
@@ -13,12 +13,13 @@ svm_rbf(
 )
 }
 \arguments{
-\item{mode}{A single character string for the type of model.
+\item{mode}{A single character string for the prediction outcome mode.
 Possible values for this model are "unknown", "regression", or
 "classification".}
 
-\item{engine}{A character string for the method of fitting. Possible engines
-are listed above. The default for this model is \code{"kernlab"}.}
+\item{engine}{A single character string specifying what computational engine
+to use for fitting. Possible engines are listed below. The default for this
+model is \code{"kernlab"}.}
 
 \item{cost}{A positive number for the cost of predicting a sample within
 or on the wrong side of the margin}

--- a/man/svm_rbf.Rd
+++ b/man/svm_rbf.Rd
@@ -4,12 +4,21 @@
 \alias{svm_rbf}
 \title{General interface for radial basis function support vector machines}
 \usage{
-svm_rbf(mode = "unknown", cost = NULL, rbf_sigma = NULL, margin = NULL)
+svm_rbf(
+  mode = "unknown",
+  engine = "kernlab",
+  cost = NULL,
+  rbf_sigma = NULL,
+  margin = NULL
+)
 }
 \arguments{
 \item{mode}{A single character string for the type of model.
 Possible values for this model are "unknown", "regression", or
 "classification".}
+
+\item{engine}{A character string for the method of fitting. Possible engines
+are listed above. The default for this model is \code{"kernlab"}.}
 
 \item{cost}{A positive number for the cost of predicting a sample within
 or on the wrong side of the margin}

--- a/tests/testthat/test_boost_tree_xgboost.R
+++ b/tests/testthat/test_boost_tree_xgboost.R
@@ -218,15 +218,6 @@ test_that('submodel prediction', {
   )
 })
 
-test_that('default engine', {
-  skip_if_not_installed("xgboost")
-  expect_warning(
-    fit <- boost_tree(mode = "regression") %>% fit(mpg ~ ., data = mtcars),
-    "Engine set to"
-  )
-  expect_true(inherits(fit$fit, "xgb.Booster"))
-})
-
 # ------------------------------------------------------------------------------
 
 test_that('validation sets', {

--- a/tests/testthat/test_decision_tree.R
+++ b/tests/testthat/test_decision_tree.R
@@ -139,20 +139,6 @@ test_that('bad input', {
 
 # ------------------------------------------------------------------------------
 
-
-test_that('default engine', {
-  skip_if_not_installed("rpart")
-  expect_warning(
-    fit <- decision_tree(mode = "regression") %>% fit(mpg ~ ., data = mtcars),
-    "Engine set to"
-  )
-  expect_true(inherits(fit$fit, "rpart"))
-})
-
-
-
-## -----------------------------------------------------------------------------
-
 test_that('argument checks for data dimensions', {
 
   data(penguins, package = "modeldata")

--- a/tests/testthat/test_default_engines.R
+++ b/tests/testthat/test_default_engines.R
@@ -1,0 +1,24 @@
+library(dplyr)
+
+# ------------------------------------------------------------------------------
+
+context("default engines")
+
+# ------------------------------------------------------------------------------
+
+test_that('check default engines', {
+  expect_equal(boost_tree()$engine, "xgboost")
+  expect_equal(decision_tree()$engine, "rpart")
+  expect_equal(linear_reg()$engine, "lm")
+  expect_equal(logistic_reg()$engine, "glm")
+  expect_equal(mars()$engine, "earth")
+  expect_equal(mlp()$engine, "nnet")
+  expect_equal(multinom_reg()$engine, "nnet")
+  expect_equal(nearest_neighbor()$engine, "kknn")
+  expect_equal(proportional_hazards()$engine, "survival")
+  expect_equal(rand_forest()$engine, "ranger")
+  expect_equal(survival_reg()$engine, "survival")
+  expect_equal(svm_linear()$engine, "LiblineaR")
+  expect_equal(svm_poly()$engine, "kernlab")
+  expect_equal(svm_rbf()$engine, "kernlab")
+})

--- a/tests/testthat/test_linear_reg.R
+++ b/tests/testthat/test_linear_reg.R
@@ -371,14 +371,6 @@ test_that('newdata error trapping', {
   expect_error(predict(res_xy, newdata = hpc[1:3, num_pred]), "Did you mean")
 })
 
-test_that('default engine', {
-  expect_warning(
-    fit <- linear_reg() %>% fit(mpg ~ ., data = mtcars),
-    "Engine set to"
-  )
-  expect_true(inherits(fit$fit, "lm"))
-})
-
 test_that('show engine', {
   res <- show_engines("linear_reg")
   expt <- get_from_env("linear_reg")

--- a/tests/testthat/test_logistic_reg.R
+++ b/tests/testthat/test_logistic_reg.R
@@ -514,11 +514,3 @@ test_that('liblinear probabilities', {
 
 })
 
-
-test_that('default engine', {
-  expect_warning(
-    fit <- logistic_reg() %>% fit(Class ~ log(funded_amnt) + int_rate, data = lending_club),
-    "Engine set to"
-  )
-  expect_true(inherits(fit$fit, "glm"))
-})

--- a/tests/testthat/test_packages.R
+++ b/tests/testthat/test_packages.R
@@ -6,9 +6,6 @@ load(test_path("mars_model.RData"))
 
 test_that('required packages', {
 
-  expect_error(req_pkgs(linear_reg()), "Please set an engine")
-  expect_error(required_pkgs(linear_reg()), "Please set an engine")
-
   glmn <-
     linear_reg() %>%
     set_engine("glmnet")


### PR DESCRIPTION
Each model now has a default engine that is used when the model is defined. The default for each model is listed in the help documents. 

This also adds functionality to change to declare an engine in the model specification function. 

`set_engine()` is still required if engine-specific arguments need to be added