### PR TITLE
cleanup after examples article

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,7 @@
 
 * Fix bug in `augment()` when non-predictor, non-outcome variables are included in data (#510).
 
+* New article "Fitting and Predicting with parsnip" which contains examples for various combinations of model type and engine. ( #527)
 
 # parsnip 0.1.6
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -10,8 +10,7 @@ template:
 # https://github.com/tidyverse/tidytemplate for css
 
 development:
-  mode: release
-
+  mode: auto
 
 figures:
   fig.width: 8


### PR DESCRIPTION
as mentioned in #527, the dev mode for pkgdown should go back to `auto` - and I've added the missing bullet in the NEWS file