### PR TITLE
LiblineaR penalty does *not* allow submodel "trick"

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 * A bug for class predictions of two-class GAM models was fixed (#541)
 
-* Fixed a bug for `logistic_reg()` with the LiblineaR engine ().
+* Fixed a bug for `logistic_reg()` with the LiblineaR engine (#552).
 
 
 # parsnip 0.1.7

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * A bug for class predictions of two-class GAM models was fixed (#541)
 
+* Fixed a bug for `logistic_reg()` with the LiblineaR engine ().
+
 
 # parsnip 0.1.7
 

--- a/R/logistic_reg_data.R
+++ b/R/logistic_reg_data.R
@@ -245,7 +245,7 @@ set_model_arg(
   parsnip = "penalty",
   original = "cost",
   func = list(pkg = "dials", fun = "penalty"),
-  has_submodel = TRUE
+  has_submodel = FALSE
 )
 
 set_model_arg(


### PR DESCRIPTION
Closes #551 

The `penalty` (`cost`) for the LiblineaR engine of `logistic_reg()` does not allow for the [submodel "trick"](https://tune.tidymodels.org/articles/extras/optimizations.html#sub-model-speed-ups-1).

``` r
library(tidymodels)
#> Registered S3 method overwritten by 'tune':
#>   method                   from   
#>   required_pkgs.model_spec parsnip
data(lending_club)
folds <- vfold_cv(lending_club, v = 5)

spec <- logistic_reg(penalty = tune()) %>% 
  set_engine("LiblineaR") %>% 
  set_mode("classification")

tune_grid(
  spec,
  Class ~ int_rate,
  resamples = folds,
  grid = 3
)
#> # Tuning results
#> # 5-fold cross-validation 
#> # A tibble: 5 × 4
#>   splits              id    .metrics         .notes          
#>   <list>              <chr> <list>           <list>          
#> 1 <split [7885/1972]> Fold1 <tibble [6 × 5]> <tibble [0 × 1]>
#> 2 <split [7885/1972]> Fold2 <tibble [6 × 5]> <tibble [0 × 1]>
#> 3 <split [7886/1971]> Fold3 <tibble [6 × 5]> <tibble [0 × 1]>
#> 4 <split [7886/1971]> Fold4 <tibble [6 × 5]> <tibble [0 × 1]>
#> 5 <split [7886/1971]> Fold5 <tibble [6 × 5]> <tibble [0 × 1]>
```

<sup>Created on 2021-09-13 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>