### PR TITLE
Fix bulleted list for `model_spec()`

### DIFF
--- a/R/model_object_docs.R
+++ b/R/model_object_docs.R
@@ -18,24 +18,24 @@
 #'  As discussed below, the arguments in `args` are captured as
 #'  quosures and are not immediately executed.
 #'
-#'   * `...`: Optional model-function-specific
+#' * `...`: Optional model-function-specific
 #'  parameters. As with `args`, these will be quosures and can be
 #'  `varying()`.
 #'
-#'   * `mode`: The type of model, such as "regression" or
+#' * `mode`: The type of model, such as "regression" or
 #'  "classification". Other modes will be added once the package
 #'  adds more functionality.
 #'
-#'   * `method`: This is a slot that is filled in later by the
+#' * `method`: This is a slot that is filled in later by the
 #'  model's constructor function. It generally contains lists of
 #'  information that are used to create the fit and prediction code
 #'  as well as required packages and similar data.
 #'
-#'   * `engine`: This character string declares exactly what
+#' * `engine`: This character string declares exactly what
 #'  software will be used. It can be a package name or a technology
 #'  type.
 #'
-#'   This class and structure is the basis for how \pkg{parsnip}
+#' This class and structure is the basis for how \pkg{parsnip}
 #'  stores model objects prior to seeing the data.
 #'
 #' @section Argument Details:

--- a/man/model_spec.Rd
+++ b/man/model_spec.Rd
@@ -21,7 +21,6 @@ can \code{varying()}. If left to their defaults (\code{NULL}), the
 arguments will use the underlying model functions default value.
 As discussed below, the arguments in \code{args} are captured as
 quosures and are not immediately executed.
-\itemize{
 \item \code{...}: Optional model-function-specific
 parameters. As with \code{args}, these will be quosures and can be
 \code{varying()}.
@@ -39,7 +38,6 @@ type.
 
 This class and structure is the basis for how \pkg{parsnip}
 stores model objects prior to seeing the data.
-}
 }
 \section{Argument Details}{
 


### PR DESCRIPTION
Closes #554 

This PR fixes the formatting on the bulleted list for `model_spec()`