### PR TITLE
Remove ability to pass `offset` through `...`

### DIFF
--- a/R/fit_helpers.R
+++ b/R/fit_helpers.R
@@ -138,7 +138,7 @@ form_xy <- function(object, control, env,
 
   res <- xy_xy(
     object = object,
-    env = env, #weights! offsets!
+    env = env, #weights!
     control = control,
     target = target
   )
@@ -146,6 +146,7 @@ form_xy <- function(object, control, env,
   data_obj$x <- NULL
   data_obj$y <- NULL
   data_obj$weights <- NULL
+  # TODO: Should we be using the offset that we remove here?
   data_obj$offset <- NULL
   res$preproc <- data_obj
   res

--- a/tests/testthat/test_convert_data.R
+++ b/tests/testthat/test_convert_data.R
@@ -86,35 +86,6 @@ test_that("numeric x and y, weights", {
   expect_null(observed$offset)
 })
 
-test_that("numeric x and y, offset", {
-  expected <- lm(
-    mpg ~ . - disp,
-    data = mtcars,
-    offset = disp,
-    x = TRUE,
-    y = TRUE
-  )
-  observed <-
-    .convert_form_to_xy_fit(
-      mpg ~ . - disp,
-      data = mtcars,
-      offset = log(disp),
-      indicators = "traditional",
-      remove_intercept = TRUE
-    )
-  expect_equal(format_x_for_test(expected$x), observed$x)
-  expect_equivalent(mtcars$mpg, observed$y)
-  expect_equal(expected$terms, observed$terms)
-  expect_equal(expected$xlevels, observed$xlevels)
-  expect_equal(log(mtcars$disp), observed$offset)
-  expect_null(observed$weights)
-
-  new_obs <-
-    .convert_form_to_xy_new(observed, new_data = mtcars[1:6, ])
-  expect_equal(mtcars[1:6, -c(1, 3)], new_obs$x)
-  expect_equal(log(mtcars$disp)[1:6], new_obs$offset)
-})
-
 test_that("numeric x and y, offset in-line", {
   expected <- lm(mpg ~ cyl + hp +  offset(log(disp)),
                  data = mtcars,
@@ -398,14 +369,6 @@ test_that("bad args", {
     .convert_form_to_xy_fit(
       mpg ~ ., data = mtcars,
       weights = letters[1:nrow(mtcars)],
-      indicators = "traditional",
-      remove_intercept = TRUE
-    )
-  )
-  expect_error(
-    .convert_form_to_xy_fit(
-      mpg ~ ., data = mtcars,
-      offset = 1:10,
       indicators = "traditional",
       remove_intercept = TRUE
     )


### PR DESCRIPTION
Follow up to #569 

This PR removes the ability to specify `offset` through the `...` of the converter functions. Instead, you have to supply it inline in the formula.

That said, while the `.convert_*()` functions seem to be working right, I think that offsets are pretty broken in parsnip right now. If you supply an `+ offset(col)` in the formula of `fit()`, I don't think it ever gets to the model call. Similarly, I don't think the offset is ever used at prediction time. Fixing that is out of scope for this PR, but I added a few TODOs in places where I think this issue is relevant.