### PR TITLE
use .pred instead of .pred_survival at highest level

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: parsnip
 Title: A Common API to Modeling and Analysis Functions
-Version: 0.1.7.9000
+Version: 0.1.7.9001
 Authors@R: 
     c(person(given = "Max",
              family = "Kuhn",

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 
 * Fixed a bug for `logistic_reg()` with the LiblineaR engine (#552).
 
+* The list column produced when creating survival probability predictions is now always called `.pred` (with `.pred_survival` being used inside of the list column). 
 
 # parsnip 0.1.7
 

--- a/R/predict.R
+++ b/R/predict.R
@@ -83,7 +83,8 @@
 #'
 #'  * `type = "time"` produces a column `.pred_time`.
 #'  * `type = "hazard"` results in a column `.pred_hazard`.
-#'  * `type = "survival"` results in a column `.pred_survival`.
+#'  * `type = "survival"` results in a list column containing tibbles with a
+#'     `.pred_survival` column.
 #'
 #'  For the last two types, the results are a nested tibble with an overall
 #'  column called `.pred` with sub-tibbles with the above format.
@@ -255,7 +256,7 @@ format_survival <- function(x) {
     x <- as_tibble(x, .name_repair = "minimal")
     names(x) <- ".pred"
   } else {
-    x <- tibble(.pred_survival = unname(x))
+    x <- tibble(.pred = unname(x))
   }
 
   x

--- a/man/bart-internal.Rd
+++ b/man/bart-internal.Rd
@@ -55,7 +55,8 @@ For censored regression:
 \itemize{
 \item \code{type = "time"} produces a column \code{.pred_time}.
 \item \code{type = "hazard"} results in a column \code{.pred_hazard}.
-\item \code{type = "survival"} results in a column \code{.pred_survival}.
+\item \code{type = "survival"} results in a list column containing tibbles with a
+\code{.pred_survival} column.
 }
 
 For the last two types, the results are a nested tibble with an overall

--- a/man/predict.model_fit.Rd
+++ b/man/predict.model_fit.Rd
@@ -73,7 +73,8 @@ For censored regression:
 \itemize{
 \item \code{type = "time"} produces a column \code{.pred_time}.
 \item \code{type = "hazard"} results in a column \code{.pred_hazard}.
-\item \code{type = "survival"} results in a column \code{.pred_survival}.
+\item \code{type = "survival"} results in a list column containing tibbles with a
+\code{.pred_survival} column.
 }
 
 For the last two types, the results are a nested tibble with an overall


### PR DESCRIPTION
_All_ prediction types with list columns should name the list column `.pred`. 

For tidymodels/censored#100