### PR TITLE
Set mode "censored regression"

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: parsnip
 Title: A Common API to Modeling and Analysis Functions
-Version: 0.1.7.9001
+Version: 0.1.7.9002
 Authors@R: c(
     person("Max", "Kuhn", , "max@rstudio.com", role = c("aut", "cre")),
     person("Davis", "Vaughan", , "davis@rstudio.com", role = "aut"),

--- a/R/aaa_models.R
+++ b/R/aaa_models.R
@@ -467,7 +467,7 @@ check_interface_val <- function(x) {
 #'  prediction objects.
 #' @keywords internal
 #' @details These functions are available for users to add their
-#'  own models or engines (in package or otherwise) so that they can
+#'  own models or engines (in a package or otherwise) so that they can
 #'  be accessed using `parsnip`. This is more thoroughly documented
 #'  on the package web site (see references below).
 #'
@@ -659,7 +659,7 @@ set_model_arg <- function(model, eng, parsnip, original, func, has_submodel) {
 #' @rdname set_new_model
 #' @keywords internal
 #' @export
-set_dependency <- function(model, eng, pkg= "parsnip") {
+set_dependency <- function(model, eng, pkg = "parsnip") {
   check_model_exists(model)
   check_eng_val(eng)
   check_pkg_val(pkg)

--- a/R/bag_tree.R
+++ b/R/bag_tree.R
@@ -122,3 +122,4 @@ check_args.bag_tree <- function(object) {
 set_new_model("bag_tree")
 set_model_mode("bag_tree", "classification")
 set_model_mode("bag_tree", "regression")
+set_model_mode("bag_tree", "censored regression")

--- a/R/boost_tree_data.R
+++ b/R/boost_tree_data.R
@@ -2,6 +2,7 @@ set_new_model("boost_tree")
 
 set_model_mode("boost_tree", "classification")
 set_model_mode("boost_tree", "regression")
+set_model_mode("boost_tree", "censored regression")
 
 # ------------------------------------------------------------------------------
 

--- a/R/decision_tree_data.R
+++ b/R/decision_tree_data.R
@@ -2,6 +2,7 @@ set_new_model("decision_tree")
 
 set_model_mode("decision_tree", "classification")
 set_model_mode("decision_tree", "regression")
+set_model_mode("decision_tree", "censored regression")
 
 # ------------------------------------------------------------------------------
 

--- a/man/set_new_model.Rd
+++ b/man/set_new_model.Rd
@@ -109,7 +109,7 @@ package.
 }
 \details{
 These functions are available for users to add their
-own models or engines (in package or otherwise) so that they can
+own models or engines (in a package or otherwise) so that they can
 be accessed using \code{parsnip}. This is more thoroughly documented
 on the package web site (see references below).
 


### PR DESCRIPTION
closes #603

Sets the mode "censored regression" for bag_tree, boost_tree, and decision_tree here instead of in censored.