### PR TITLE
Mode specific dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: parsnip
 Title: A Common API to Modeling and Analysis Functions
-Version: 0.1.7.9003
+Version: 0.1.7.9004
 Authors@R: c(
     person("Max", "Kuhn", , "max@rstudio.com", role = c("aut", "cre")),
     person("Davis", "Vaughan", , "davis@rstudio.com", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,8 @@
 
 * Argument `interval` was added for prediction: For types "survival" and "quantile", estimates for the confidence or prediction interval can be added if available (#615).
 
+* `set_dependency()` now allows developers to create package requirements that are specific to the model's mode (604). 
+
 
 # parsnip 0.1.7
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -26,7 +26,7 @@
 
 * Argument `interval` was added for prediction: For types "survival" and "quantile", estimates for the confidence or prediction interval can be added if available (#615).
 
-* `set_dependency()` now allows developers to create package requirements that are specific to the model's mode (604). 
+* `set_dependency()` now allows developers to create package requirements that are specific to the model's mode (#604). 
 
 
 # parsnip 0.1.7

--- a/R/aaa_models.R
+++ b/R/aaa_models.R
@@ -676,7 +676,9 @@ set_dependency <- function(model, eng, pkg = "parsnip", mode = NULL) {
     dplyr::filter(engine == eng) %>%
     nrow()
   if (has_engine != 1) {
-    rlang::abort("The engine '{eng}' has not been registered for model '{model}'.")
+    rlang::abort(
+      glue::glue("The engine '{eng}' has not been registered for model '{model}'.")
+    )
   }
 
   # ----------------------------------------------------------------------------

--- a/R/aaa_models.R
+++ b/R/aaa_models.R
@@ -183,12 +183,21 @@ stop_missing_engine <- function(cls) {
   rlang::abort(msg)
 }
 
+check_mode_for_new_engine <- function(cls, eng, mode) {
+  all_modes <- get_from_env(paste0(cls, "_modes"))
+  if (!(mode %in% all_modes)) {
+    rlang::abort(paste0("'", mode, "' is not a known mode for model `", cls, "()`."))
+  }
+  invisible(NULL)
+}
+
 
 # check if class and mode and engine are compatible
 check_spec_mode_engine_val <- function(cls, eng, mode) {
-  all_modes <- c("unknown", all_modes)
+
+  all_modes <- get_from_env(paste0(cls, "_modes"))
   if (!(mode %in% all_modes)) {
-    rlang::abort(paste0("'", mode, "' is not a known mode."))
+    rlang::abort(paste0("'", mode, "' is not a known mode for model `", cls, "()`."))
   }
 
   model_info <- rlang::env_get(get_model_env(), cls)
@@ -601,6 +610,7 @@ set_model_engine <- function(model, mode, eng) {
   check_mode_val(mode)
   check_eng_val(eng)
   check_mode_val(eng)
+  check_mode_for_new_engine(model, eng, mode)
 
   current <- get_model_env()
 

--- a/R/boost_tree_data.R
+++ b/R/boost_tree_data.R
@@ -217,7 +217,7 @@ set_pred(
 # ------------------------------------------------------------------------------
 
 set_model_engine("boost_tree", "classification", "C5.0")
-set_dependency("boost_tree", "C5.0", "C50")
+set_dependency("boost_tree", "C5.0", "C50", mode = "classification")
 
 set_model_arg(
   model = "boost_tree",

--- a/R/decision_tree_data.R
+++ b/R/decision_tree_data.R
@@ -8,7 +8,8 @@ set_model_mode("decision_tree", "censored regression")
 
 set_model_engine("decision_tree", "classification", "rpart")
 set_model_engine("decision_tree", "regression", "rpart")
-set_dependency("decision_tree", "rpart", "rpart")
+set_dependency("decision_tree", "rpart", "rpart", mode = "classification")
+set_dependency("decision_tree", "rpart", "rpart", mode = "regression")
 
 set_model_arg(
   model = "decision_tree",
@@ -160,7 +161,7 @@ set_pred(
 # ------------------------------------------------------------------------------
 
 set_model_engine("decision_tree", "classification", "C5.0")
-set_dependency("decision_tree", "C5.0", "C50")
+set_dependency("decision_tree", "C5.0", "C50", mode = "classification")
 
 set_model_arg(
   model = "decision_tree",

--- a/R/gen_additive_mod_data.R
+++ b/R/gen_additive_mod_data.R
@@ -6,7 +6,7 @@ set_model_mode("gen_additive_mod", "regression")
 # ------------------------------------------------------------------------------
 #### REGRESION ----
 set_model_engine(model = "gen_additive_mod", mode = "regression", eng = "mgcv")
-set_dependency(model = "gen_additive_mod", eng = "mgcv", pkg = "mgcv")
+set_dependency(model = "gen_additive_mod", eng = "mgcv", pkg = "mgcv", mode = "regression")
 
 #Args
 
@@ -107,8 +107,7 @@ set_pred(
 # ------------------------------------------------------------------------------
 #### CLASSIFICATION
 set_model_engine(model = "gen_additive_mod", mode = "classification", eng = "mgcv")
-set_dependency(model = "gen_additive_mod", eng = "mgcv", pkg = "mgcv")
-
+set_dependency(model = "gen_additive_mod", eng = "mgcv", pkg = "mgcv", mode = "classification")
 
 set_encoding(
   model = "gen_additive_mod",

--- a/R/mlp_data.R
+++ b/R/mlp_data.R
@@ -8,8 +8,11 @@ set_model_mode("mlp", "regression")
 
 set_model_engine("mlp", "classification", "keras")
 set_model_engine("mlp", "regression", "keras")
-set_dependency("mlp", "keras", "keras")
-set_dependency("mlp", "keras", "magrittr")
+set_dependency("mlp", "keras", "keras", mode = "regression")
+set_dependency("mlp", "keras", "magrittr", mode = "regression")
+set_dependency("mlp", "keras", "keras", mode = "classification")
+set_dependency("mlp", "keras", "magrittr", mode = "classification")
+
 
 set_model_arg(
   model = "mlp",
@@ -197,7 +200,8 @@ set_pred(
 
 set_model_engine("mlp", "classification", "nnet")
 set_model_engine("mlp", "regression", "nnet")
-set_dependency("mlp", "nnet", "nnet")
+set_dependency("mlp", "nnet", "nnet", mode = "regression")
+set_dependency("mlp", "nnet", "nnet", mode = "classification")
 
 set_model_arg(
   model = "mlp",

--- a/R/proportional_hazards_data.R
+++ b/R/proportional_hazards_data.R
@@ -1,5 +1,5 @@
 
-# parnip just contains the model specification, the engines are the censored package.
+# parsnip just contains the model specification, the engines are the censored package.
 
 set_new_model("proportional_hazards")
 set_model_mode("proportional_hazards", "censored regression")

--- a/R/rand_forest_data.R
+++ b/R/rand_forest_data.R
@@ -81,6 +81,7 @@ set_new_model("rand_forest")
 
 set_model_mode("rand_forest", "classification")
 set_model_mode("rand_forest", "regression")
+set_model_mode("rand_forest", "censored regression")
 
 # ------------------------------------------------------------------------------
 # ranger components

--- a/R/rand_forest_data.R
+++ b/R/rand_forest_data.R
@@ -87,7 +87,8 @@ set_model_mode("rand_forest", "regression")
 
 set_model_engine("rand_forest", "classification", "ranger")
 set_model_engine("rand_forest", "regression", "ranger")
-set_dependency("rand_forest", "ranger", "ranger")
+set_dependency("rand_forest", "ranger", "ranger", mode = "classification")
+set_dependency("rand_forest", "ranger", "ranger", mode = "regression")
 
 set_model_arg(
   model = "rand_forest",
@@ -321,7 +322,8 @@ set_pred(
 
 set_model_engine("rand_forest", "classification", "randomForest")
 set_model_engine("rand_forest", "regression",     "randomForest")
-set_dependency("rand_forest", "randomForest", "randomForest")
+set_dependency("rand_forest", "randomForest", "randomForest", mode = "regression")
+set_dependency("rand_forest", "randomForest", "randomForest", mode = "classification")
 
 set_model_arg(
   model = "rand_forest",

--- a/R/survival_reg_data.R
+++ b/R/survival_reg_data.R
@@ -4,4 +4,4 @@ set_model_mode("survival_reg", "censored regression")
 
 # ------------------------------------------------------------------------------
 
-# parnip just contains the model specification, the engines are the censored package.
+# parsnip just contains the model specification, the engines are the censored package.

--- a/man/set_new_model.Rd
+++ b/man/set_new_model.Rd
@@ -31,7 +31,7 @@ set_model_engine(model, mode, eng)
 
 set_model_arg(model, eng, parsnip, original, func, has_submodel)
 
-set_dependency(model, eng, pkg = "parsnip")
+set_dependency(model, eng, pkg = "parsnip", mode = NULL)
 
 get_dependency(model)
 

--- a/tests/testthat/test_args_and_modes.R
+++ b/tests/testthat/test_args_and_modes.R
@@ -49,7 +49,7 @@ test_that('pipe engine', {
 test_that("can't set a mode that isn't allowed by the model spec", {
   expect_error(
     set_mode(linear_reg(), "classification"),
-    "Available modes"
+    "'classification' is not a known mode"
   )
 })
 
@@ -85,7 +85,7 @@ test_that("unavailable modes for an engine and vice-versa", {
 
   expect_error(
     proportional_hazards() %>% set_mode("regression"),
-    "Available modes for model type proportional_hazards"
+    "'regression' is not a known mode"
   )
 
   expect_error(

--- a/tests/testthat/test_registration.R
+++ b/tests/testthat/test_registration.R
@@ -72,6 +72,7 @@ test_that('adding a new mode', {
   expect_equal(get_from_env("sponge_modes"), c("unknown", "classification"))
 
   expect_error(set_model_mode("sponge"))
+
 })
 
 
@@ -85,13 +86,14 @@ test_that('adding a new engine', {
     tibble(engine = "gum", mode = "classification")
   )
 
-
   expect_equal(get_from_env("sponge_modes"), c("unknown", "classification"))
 
-  # TODO check for bad mode, check for duplicate
   expect_error(set_model_engine("sponge", eng = "gum"))
   expect_error(set_model_engine("sponge", mode = "classification"))
-
+  expect_error(
+    set_model_engine("sponge", mode = "regression", eng = "gum"),
+    "'regression' is not a known mode"
+  )
 })
 
 
@@ -102,6 +104,7 @@ test_that('adding a new package', {
 
   expect_error(set_dependency("sponge", "gum", letters[1:2]))
   expect_error(set_dependency("sponge", "gummies", "trident"))
+  expect_error(set_dependency("sponge",  "gum", "trident", mode = "regression"))
 
   test_by_col(
     get_from_env("sponge_pkgs"),

--- a/tests/testthat/test_registration.R
+++ b/tests/testthat/test_registration.R
@@ -33,7 +33,7 @@ test_that('adding a new model', {
 
 test_by_col(
   get_from_env("sponge_pkgs"),
-  tibble(engine = character(0), pkg = list())
+  tibble(engine = character(0), pkg = list(), mode = character(0))
 )
 
 expect_equal(
@@ -105,18 +105,22 @@ test_that('adding a new package', {
 
   test_by_col(
     get_from_env("sponge_pkgs"),
-    tibble(engine = "gum", pkg = list("trident"))
+    tibble(engine = "gum", pkg = list("trident"), mode = "classification")
   )
 
-  set_dependency("sponge", "gum", "juicy-fruit")
+  set_dependency("sponge", "gum", "juicy-fruit", mode = "classification")
   test_by_col(
     get_from_env("sponge_pkgs"),
-    tibble(engine = "gum", pkg = list(c("juicy-fruit", "trident")))
+    tibble(engine = "gum",
+           pkg = list(c("trident", "juicy-fruit")),
+           mode = "classification")
   )
 
   test_by_col(
     get_dependency("sponge"),
-    tibble(engine = "gum", pkg = list(c("juicy-fruit", "trident")))
+    tibble(engine = "gum",
+           pkg = list(c("trident", "juicy-fruit")),
+           mode = "classification")
   )
 })
 


### PR DESCRIPTION
Closes #604 

Non-breaking change; fixes issue with vetiver getting package dependencies across _all model modes_. 

Some changes will be made to parsnip extension packages at our leisure (but most importantly to censored). 