### PR TITLE
Allow multinom_reg() using nnet engine to work with 1 row prob predictions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,7 @@
 
 * New `extract_parameter_dials()` method to extract a single parameter from model specs.
 
+* Prediction using `multinom_reg()` with the `nnet` engine with a single row no longer fails (#612).
 
 ## Other Changes
 

--- a/R/multinom_reg.R
+++ b/R/multinom_reg.R
@@ -5,8 +5,8 @@
 #' `multinom_reg()` defines a model that uses linear predictors to predict
 #' multiclass data using the multinomial distribution.
 #'
-#' There are different ways to fit this model. The method of estimation is 
-#' chosen by setting the model _engine_. 
+#' There are different ways to fit this model. The method of estimation is
+#' chosen by setting the model _engine_.
 #'
 #' \Sexpr[stage=render,results=rd]{parsnip:::make_engine_list("multinom_reg")}
 #'
@@ -157,6 +157,11 @@ organize_multnet_prob <- function(x, object) {
 }
 
 organize_nnet_prob <- function(x, object) {
+  if (is.null(nrow(x))) {
+    x_names <- names(x)
+    x <- matrix(x, nrow = 1)
+    colnames(x) <- x_names
+  }
   format_classprobs(x)
 }
 

--- a/tests/testthat/test_multinom_reg_nnet.R
+++ b/tests/testthat/test_multinom_reg_nnet.R
@@ -115,4 +115,28 @@ test_that('classification probabilities', {
 
 })
 
+test_that('prob prediction with 1 row', {
+  # For issue 612
+  skip_if_not_installed("nnet")
+
+  set.seed(257)
+  lr_fit <-
+    fit_xy(
+      basic_mod,
+      control = ctrl,
+      x = tr_dat[, -5],
+      y = tr_dat$class
+    )
+
+  nnet_pred <-
+    predict(lr_fit$fit, as.matrix(te_dat[1, -5]), type = "prob") %>%
+    as_tibble(.name_repair = "minimal") %>%
+    setNames(paste0(".pred_", lr_fit$lvl))
+
+  parsnip_pred <- predict(lr_fit, te_dat[1, -5], type = "prob")
+
+  expect_equal(nnet_pred[[1]], as.numeric(parsnip_pred))
+  expect_identical(dim(parsnip_pred), c(1L, 4L))
+})
+
 


### PR DESCRIPTION
This PR aims to close https://github.com/tidymodels/parsnip/issues/612

`organize_nnet_prob()` is only used in [one place](https://github.com/tidymodels/parsnip/search?q=organize_nnet_prob) so it is small scope fix.