### PR TITLE
Update tensorflow setup

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -9,6 +9,7 @@ on:
     branches: [main, master]
   pull_request:
     branches: [main, master]
+  workflow_dispatch:
 
 name: R-CMD-check
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -23,8 +23,7 @@ jobs:
       matrix:
         config:
           - {os: macOS-latest,   r: 'release'}
-          # disable until tensorflow install is worked out
-          # - {os: windows-latest, r: 'release'}
+          - {os: windows-latest, r: 'release'}
           # Use older ubuntu to maximise backward compatibility
           - {os: ubuntu-18.04,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-18.04,   r: 'release'}
@@ -53,20 +52,17 @@ jobs:
         with:
           extra-packages: rcmdcheck
 
-      - name: Install Miniconda
-        run: |
-          pak::pkg_install('rstudio/reticulate')
-          reticulate::install_miniconda()
+      - name: Install dev reticulate
+        run: pak::pkg_install('rstudio/reticulate')
         shell: Rscript {0}
 
-      - name: Find Miniconda on macOS
-        if: runner.os == 'macOS'
-        run: echo "options(reticulate.conda_binary = reticulate:::miniconda_conda())" >> .Rprofile
+      - name: Install Miniconda
+        run: reticulate::install_miniconda() # creates r-reticulate conda env by default
+        shell: Rscript {0}
 
       - name: Install TensorFlow
         run: |
-          reticulate::conda_create('r-reticulate', packages = c('python==3.6.9'))
-          tensorflow::install_tensorflow(version='1.14.0')
+          tensorflow::install_tensorflow(version='1.15', conda_python_version = '3.7')
         shell: Rscript {0}
 
       - uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -58,12 +58,15 @@ jobs:
         shell: Rscript {0}
 
       - name: Install Miniconda
+        # conda can fail at downgrading python, so we specify python version in advance
+        env: 
+          RETICULATE_MINICONDA_PYTHON_VERSION: "3.7"  
         run: reticulate::install_miniconda() # creates r-reticulate conda env by default
         shell: Rscript {0}
 
       - name: Install TensorFlow
         run: |
-          tensorflow::install_tensorflow(version='1.15', conda_python_version = '3.7')
+          tensorflow::install_tensorflow(version='1.15', conda_python_version = NULL)
         shell: Rscript {0}
 
       - uses: r-lib/actions/check-r-package@v2


### PR DESCRIPTION
Some minor updates to the GHA tensorflow setup:

- Skip manually creating r-reticulate conda env (it's auto created by `install_miniconda()`
- Remove workaround for reticulate not finding miniconda on macOS (fixed in reticulate already).
- Bump TF version to latest patch release of TF v1 (1.15.5 today)
- Specify required Python version in `install_tensorflow()` call.
- Bump Python version to 3.7, latest supported by TF 1