### PR TITLE
`ntreelimit` has been `deprecated` in favour of iteration_range

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -29,12 +29,20 @@ jobs:
           extra-packages: r-lib/pkgdown
           needs: website
 
-      - name: Install Miniconda + TensorFlow
+      - name: Install dev reticulate
+        run: pak::pkg_install('rstudio/reticulate')
+        shell: Rscript {0}
+
+      - name: Install Miniconda
+        # conda can fail at downgrading python, so we specify python version in advance
+        env:
+          RETICULATE_MINICONDA_PYTHON_VERSION: "3.7"
+        run: reticulate::install_miniconda() # creates r-reticulate conda env by default
+        shell: Rscript {0}
+
+      - name: Install TensorFlow
         run: |
-          pak::pkg_install('rstudio/reticulate')
-          reticulate::install_miniconda()
-          reticulate::conda_create('r-reticulate', packages = c('python==3.6.9'))
-          tensorflow::install_tensorflow(version='2.7.0')
+          tensorflow::install_tensorflow(version='2.7', conda_python_version = NULL)
         shell: Rscript {0}
 
       - name: Install package

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -26,12 +26,20 @@ jobs:
           extra-packages: any::covr
           needs: coverage
 
-      - name: Install Miniconda + TensorFlow
+      - name: Install dev reticulate
+        run: pak::pkg_install('rstudio/reticulate')
+        shell: Rscript {0}
+
+      - name: Install Miniconda
+        # conda can fail at downgrading python, so we specify python version in advance
+        env:
+          RETICULATE_MINICONDA_PYTHON_VERSION: "3.7"
+        run: reticulate::install_miniconda() # creates r-reticulate conda env by default
+        shell: Rscript {0}
+
+      - name: Install TensorFlow
         run: |
-          pak::pkg_install('rstudio/reticulate')
-          reticulate::install_miniconda()
-          reticulate::conda_create('r-reticulate', packages = c('python==3.6.9'))
-          tensorflow::install_tensorflow(version='2.7.0')
+          tensorflow::install_tensorflow(version='2.7', conda_python_version = NULL)
         shell: Rscript {0}
 
       - name: Test coverage

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -59,7 +59,7 @@ Suggests:
     sparklyr (>= 1.0.0),
     survival,
     testthat,
-    xgboost
+    xgboost (>= 1.5.0.1)
 VignetteBuilder: 
     knitr
 ByteCompile: true

--- a/NEWS.md
+++ b/NEWS.md
@@ -42,7 +42,7 @@
 
 * parsnip is now more robust working with keras and tensorflow for a larger range of versions (#596).
 
-* xgboost engines now use the new `iteration_range` parameter instead of the deprecated `ntreelimit` (#656).  
+* xgboost engines now use the new `iterationrange` parameter instead of the deprecated `ntreelimit` (#656).  
 
 # parsnip 0.1.7
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -42,6 +42,8 @@
 
 * parsnip is now more robust working with keras and tensorflow for a larger range of versions (#596).
 
+* xgboost engines now use the new `iteration_range` parameter instead of the deprecated `ntreelimit` (#656).  
+
 # parsnip 0.1.7
 
 ## Model Specification Changes

--- a/R/boost_tree.R
+++ b/R/boost_tree.R
@@ -482,7 +482,7 @@ multi_predict._xgb.Booster <-
   }
 
 xgb_by_tree <- function(tree, object, new_data, type, ...) {
-  pred <- xgb_pred(object$fit, newdata = new_data, ntreelimit = tree)
+  pred <- xgb_pred(object$fit, newdata = new_data, iterationrange = c(1,tree+1), ntreelimit = NULL)
 
   # switch based on prediction type
   if (object$spec$mode == "regression") {

--- a/R/boost_tree.R
+++ b/R/boost_tree.R
@@ -482,7 +482,12 @@ multi_predict._xgb.Booster <-
   }
 
 xgb_by_tree <- function(tree, object, new_data, type, ...) {
-  pred <- xgb_pred(object$fit, newdata = new_data, iterationrange = c(1,tree+1), ntreelimit = NULL)
+  pred <- xgb_pred(
+    object$fit,
+    newdata = new_data,
+    iterationrange = c(1, tree + 1),
+    ntreelimit = NULL
+  )
 
   # switch based on prediction type
   if (object$spec$mode == "regression") {

--- a/R/boost_tree.R
+++ b/R/boost_tree.R
@@ -485,7 +485,7 @@ xgb_by_tree <- function(tree, object, new_data, type, ...) {
   pred <- xgb_pred(
     object$fit,
     newdata = new_data,
-    iterationrange = c(1, tree + 1),
+    iteration_range = c(1, tree + 1),
     ntreelimit = NULL
   )
 

--- a/R/boost_tree.R
+++ b/R/boost_tree.R
@@ -485,7 +485,7 @@ xgb_by_tree <- function(tree, object, new_data, type, ...) {
   pred <- xgb_pred(
     object$fit,
     newdata = new_data,
-    iteration_range = c(1, tree + 1),
+    iterationrange = c(1, tree + 1),
     ntreelimit = NULL
   )
 

--- a/tests/testthat/test_boost_tree_xgboost.R
+++ b/tests/testthat/test_boost_tree_xgboost.R
@@ -191,7 +191,7 @@ test_that('submodel prediction', {
 
   x <-  xgboost::xgb.DMatrix(as.matrix(mtcars[1:4, -1]))
 
-  pruned_pred <- predict(reg_fit$fit, x, ntreelimit = 5)
+  pruned_pred <- predict(reg_fit$fit, x, iteration_range = 5)
 
   mp_res <- multi_predict(reg_fit, new_data = mtcars[1:4, -1], trees = 5)
   mp_res <- do.call("rbind", mp_res$.pred)
@@ -206,7 +206,7 @@ test_that('submodel prediction', {
 
   x <-  xgboost::xgb.DMatrix(as.matrix(wa_churn[1:4, vars]))
 
-  pred_class <- predict(class_fit$fit, x, ntreelimit = 5)
+  pred_class <- predict(class_fit$fit, x, iteration_range = 5)
 
   mp_res <- multi_predict(class_fit, new_data = wa_churn[1:4, vars], trees = 5, type = "prob")
   mp_res <- do.call("rbind", mp_res$.pred)

--- a/tests/testthat/test_boost_tree_xgboost.R
+++ b/tests/testthat/test_boost_tree_xgboost.R
@@ -191,7 +191,7 @@ test_that('submodel prediction', {
 
   x <-  xgboost::xgb.DMatrix(as.matrix(mtcars[1:4, -1]))
 
-  pruned_pred <- predict(reg_fit$fit, x, iteration_range = 5)
+  pruned_pred <- predict(reg_fit$fit, x, iterationrange = c(1, 6))
 
   mp_res <- multi_predict(reg_fit, new_data = mtcars[1:4, -1], trees = 5)
   mp_res <- do.call("rbind", mp_res$.pred)
@@ -206,7 +206,7 @@ test_that('submodel prediction', {
 
   x <-  xgboost::xgb.DMatrix(as.matrix(wa_churn[1:4, vars]))
 
-  pred_class <- predict(class_fit$fit, x, iteration_range = 5)
+  pred_class <- predict(class_fit$fit, x, iterationrange = c(1, 6))
 
   mp_res <- multi_predict(class_fit, new_data = wa_churn[1:4, vars], trees = 5, type = "prob")
   mp_res <- do.call("rbind", mp_res$.pred)


### PR DESCRIPTION
This is a fix for issue #655 

As `ntreelimit` as been deprecated, adding `iterationrange` to the
`xgb_pred` call with the correct modifications to fit the current use case.

Further work is needed at a later stage to extend the new functionality of `iterationrange`.