### PR TITLE
Some clean up of docs

### DIFF
--- a/man/details_C5_rules_C5.0.Rd
+++ b/man/details_C5_rules_C5.0.Rd
@@ -25,8 +25,7 @@ less iterations of boosting are performed than the number requested.
 
 \subsection{Translation from parsnip to the underlying model call (classification)}{
 
-There is a parsnip extension package required to fit this model to this
-mode: \strong{rules}.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(rules)
+The \strong{rules} extension package is required to fit this model.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(rules)
 
 C5_rules(
   trees = integer(1),
@@ -62,7 +61,7 @@ are not required for this model.
 \item Quinlan R (1992). “Learning with Continuous Classes.” Proceedings of
 the 5th Australian Joint Conference On Artificial Intelligence,
 pp. 343-348.
-\item Quinlan R (1993).”Combining Instance-Based and Model-Based
+\item Quinlan R (1993).“Combining Instance-Based and Model-Based
 Learning.” Proceedings of the Tenth International Conference on
 Machine Learning, pp. 236-243.
 \item Kuhn M and Johnson K (2013). \emph{Applied Predictive Modeling}.

--- a/man/details_bag_mars_earth.Rd
+++ b/man/details_bag_mars_earth.Rd
@@ -27,8 +27,7 @@ columns. For a data frame \code{x}, the default is
 
 \subsection{Translation from parsnip to the original package (regression)}{
 
-There is a parsnip extension package required to fit this model to this
-mode: \strong{baguette}.\if{html}{\out{<div class="sourceCode r">}}\preformatted{bag_mars(num_terms = integer(1), prod_degree = integer(1), prune_method = character(1)) \%>\% 
+The \strong{baguette} extension package is required to fit this model.\if{html}{\out{<div class="sourceCode r">}}\preformatted{bag_mars(num_terms = integer(1), prod_degree = integer(1), prune_method = character(1)) \%>\% 
   set_engine("earth") \%>\% 
   set_mode("regression") \%>\% 
   translate()
@@ -50,8 +49,7 @@ mode: \strong{baguette}.\if{html}{\out{<div class="sourceCode r">}}\preformatted
 
 \subsection{Translation from parsnip to the original package (classification)}{
 
-There is a parsnip extension package required to fit this model to this
-mode: \strong{baguette}.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(baguette)
+The \strong{baguette} extension package is required to fit this model.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(baguette)
 
 bag_mars(
   num_terms = integer(1),
@@ -81,8 +79,8 @@ bag_mars(
 
 Factor/categorical predictors need to be converted to numeric values
 (e.g., dummy or indicator variables) for this engine. When using the
-formula method via \code{\link[=fit.model_spec]{fit.model_spec()}},
-parsnip will convert factor columns to indicators.
+formula method via \code{\link[=fit.model_spec]{fit()}}, parsnip
+will convert factor columns to indicators.
 }
 
 \subsection{References}{

--- a/man/details_bag_tree_C5.0.Rd
+++ b/man/details_bag_tree_C5.0.Rd
@@ -19,8 +19,7 @@ This model has 1 tuning parameters:
 
 \subsection{Translation from parsnip to the original package (classification)}{
 
-There is a parsnip extension package required to fit this model to this
-mode: \strong{baguette}.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(baguette)
+The \strong{baguette} extension package is required to fit this model.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(baguette)
 
 bag_tree(min_n = integer()) \%>\% 
   set_engine("C5.0") \%>\% 

--- a/man/details_bag_tree_rpart.Rd
+++ b/man/details_bag_tree_rpart.Rd
@@ -31,8 +31,7 @@ the second level of the factor.
 
 \subsection{Translation from parsnip to the original package (classification)}{
 
-There is a parsnip extension package required to fit this model to this
-mode: \strong{baguette}.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(baguette)
+The \strong{baguette} extension package is required to fit this model.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(baguette)
 
 bag_tree(tree_depth = integer(1), min_n = integer(1), cost_complexity = double(1)) \%>\% 
   set_engine("rpart") \%>\% 
@@ -56,8 +55,7 @@ bag_tree(tree_depth = integer(1), min_n = integer(1), cost_complexity = double(1
 
 \subsection{Translation from parsnip to the original package (regression)}{
 
-There is a parsnip extension package required to fit this model to this
-mode: \strong{baguette}.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(baguette)
+The \strong{baguette} extension package is required to fit this model.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(baguette)
 
 bag_tree(tree_depth = integer(1), min_n = integer(1), cost_complexity = double(1)) \%>\% 
   set_engine("rpart") \%>\% 
@@ -81,8 +79,7 @@ bag_tree(tree_depth = integer(1), min_n = integer(1), cost_complexity = double(1
 
 \subsection{Translation from parsnip to the original package (censored regression)}{
 
-There is a parsnip extension package required to fit this model to this
-mode: \strong{censored}.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(censored)
+The \strong{censored} extension package is required to fit this model.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(censored)
 
 bag_tree(tree_depth = integer(1), min_n = integer(1), cost_complexity = double(1)) \%>\% 
   set_engine("rpart") \%>\% 

--- a/man/details_bart_dbarts.Rd
+++ b/man/details_bart_dbarts.Rd
@@ -103,8 +103,8 @@ times number of observations.
 
 Factor/categorical predictors need to be converted to numeric values
 (e.g., dummy or indicator variables) for this engine. When using the
-formula method via \code{\link[=fit.model_spec]{fit.model_spec()}},
-parsnip will convert factor columns to indicators.
+formula method via \code{\link[=fit.model_spec]{fit()}}, parsnip
+will convert factor columns to indicators.
 
 \code{\link[dbarts:bart]{dbarts::bart()}} will also convert the factors to
 indicators if the user does not create them first.

--- a/man/details_boost_tree_C5.0.Rd
+++ b/man/details_boost_tree_C5.0.Rd
@@ -59,8 +59,8 @@ are not required for this model.
 
 By default, early stopping is used. To use the complete set of boosting
 iterations, pass \code{earlyStopping = FALSE} to
-\code{\link[=set_engine]{set_engine()}}. Also, it is unlikely that early stopping
-will occur if \code{sample_size = 1}.
+\code{\link[=set_engine]{set_engine()}}. Also, it is unlikely that early
+stopping will occur if \code{sample_size = 1}.
 }
 
 }

--- a/man/details_boost_tree_mboost.Rd
+++ b/man/details_boost_tree_mboost.Rd
@@ -28,8 +28,7 @@ is to use all predictors.
 
 \subsection{Translation from parsnip to the original package (censored regression)}{
 
-There is a parsnip extension package required to fit this model to this
-mode: \strong{censored}.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(censored)
+The \strong{censored} extension package is required to fit this model.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(censored)
 
 boost_tree() \%>\% 
   set_engine("mboost") \%>\% 

--- a/man/details_cubist_rules_Cubist.Rd
+++ b/man/details_cubist_rules_Cubist.Rd
@@ -22,8 +22,7 @@ This model has 3 tuning parameters:
 
 \subsection{Translation from parsnip to the underlying model call (regression)}{
 
-There is a parsnip extension package required to fit this model to this
-mode: \strong{rules}.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(rules)
+The \strong{rules} extension package is required to fit this model.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(rules)
 
 cubist_rules(
   committees = integer(1),
@@ -44,8 +43,7 @@ cubist_rules(
 ## 
 ## Model fit template:
 ## rules::cubist_fit(x = missing_arg(), y = missing_arg(), weights = missing_arg(), 
-##     committees = integer(1), neighbors = integer(1), max_rules = integer(1), 
-##     composite = TRUE)
+##     committees = integer(1), neighbors = integer(1), max_rules = integer(1))
 }
 }
 
@@ -62,7 +60,7 @@ are not required for this model.
 \item Quinlan R (1992). “Learning with Continuous Classes.” Proceedings of
 the 5th Australian Joint Conference On Artificial Intelligence,
 pp. 343-348.
-\item Quinlan R (1993).”Combining Instance-Based and Model-Based
+\item Quinlan R (1993).“Combining Instance-Based and Model-Based
 Learning.” Proceedings of the Tenth International Conference on
 Machine Learning, pp. 236-243.
 \item Kuhn M and Johnson K (2013). \emph{Applied Predictive Modeling}.

--- a/man/details_decision_tree_party.Rd
+++ b/man/details_decision_tree_party.Rd
@@ -29,8 +29,7 @@ evaluated for splitting. The default is to use all predictors.
 
 \subsection{Translation from parsnip to the original package (censored regression)}{
 
-There is a parsnip extension package required to fit this model to this
-mode: \strong{censored}.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(censored)
+The \strong{censored} extension package is required to fit this model.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(censored)
 
 decision_tree(tree_depth = integer(1), min_n = integer(1)) \%>\% 
   set_engine("party") \%>\% 

--- a/man/details_decision_tree_rpart.Rd
+++ b/man/details_decision_tree_rpart.Rd
@@ -63,8 +63,7 @@ This model has 3 tuning parameters:
 
 \subsection{Translation from parsnip to the original package (censored regression)}{
 
-There is a parsnip extension package required to fit this model to this
-mode: \strong{censored}.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(censored)
+The \strong{censored} extension package is required to fit this model.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(censored)
 
 decision_tree(
   tree_depth = integer(1),

--- a/man/details_discrim_flexible_earth.Rd
+++ b/man/details_discrim_flexible_earth.Rd
@@ -28,8 +28,7 @@ intercept-only model.
 
 \subsection{Translation from parsnip to the original package}{
 
-There is a parsnip extension package required to fit this model to this
-mode: \strong{discrim}.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(discrim)
+The \strong{discrim} extension package is required to fit this model.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(discrim)
 
 discrim_flexible(
   num_terms = integer(0),
@@ -56,8 +55,8 @@ discrim_flexible(
 
 Factor/categorical predictors need to be converted to numeric values
 (e.g., dummy or indicator variables) for this engine. When using the
-formula method via \code{\link[=fit.model_spec]{fit.model_spec()}},
-parsnip will convert factor columns to indicators.
+formula method via \code{\link[=fit.model_spec]{fit()}}, parsnip
+will convert factor columns to indicators.
 }
 
 \subsection{References}{

--- a/man/details_discrim_linear_MASS.Rd
+++ b/man/details_discrim_linear_MASS.Rd
@@ -18,8 +18,7 @@ This engine has no tuning parameters.
 
 \subsection{Translation from parsnip to the original package}{
 
-There is a parsnip extension package required to fit this model to this
-mode: \strong{discrim}.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(discrim)
+The \strong{discrim} extension package is required to fit this model.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(discrim)
 
 discrim_linear() \%>\% 
   set_engine("MASS") \%>\% 
@@ -37,8 +36,8 @@ discrim_linear() \%>\%
 
 Factor/categorical predictors need to be converted to numeric values
 (e.g., dummy or indicator variables) for this engine. When using the
-formula method via \code{\link[=fit.model_spec]{fit.model_spec()}},
-parsnip will convert factor columns to indicators.
+formula method via \code{\link[=fit.model_spec]{fit()}}, parsnip
+will convert factor columns to indicators.
 
 Variance calculations are used in these computations so \emph{zero-variance}
 predictors (i.e., with a single unique value) should be eliminated

--- a/man/details_discrim_linear_mda.Rd
+++ b/man/details_discrim_linear_mda.Rd
@@ -20,8 +20,7 @@ This model has 1 tuning parameter:
 
 \subsection{Translation from parsnip to the original package}{
 
-There is a parsnip extension package required to fit this model to this
-mode: \strong{discrim}.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(discrim)
+The \strong{discrim} extension package is required to fit this model.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(discrim)
 
 discrim_linear(penalty = numeric(0)) \%>\% 
   set_engine("mda") \%>\% 
@@ -43,8 +42,8 @@ discrim_linear(penalty = numeric(0)) \%>\%
 
 Factor/categorical predictors need to be converted to numeric values
 (e.g., dummy or indicator variables) for this engine. When using the
-formula method via \code{\link[=fit.model_spec]{fit.model_spec()}},
-parsnip will convert factor columns to indicators.
+formula method via \code{\link[=fit.model_spec]{fit()}}, parsnip
+will convert factor columns to indicators.
 
 Variance calculations are used in these computations so \emph{zero-variance}
 predictors (i.e., with a single unique value) should be eliminated

--- a/man/details_discrim_linear_sda.Rd
+++ b/man/details_discrim_linear_sda.Rd
@@ -34,8 +34,7 @@ This maps to
 
 \subsection{Translation from parsnip to the original package}{
 
-There is a parsnip extension package required to fit this model to this
-mode: \strong{discrim}.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(discrim)
+The \strong{discrim} extension package is required to fit this model.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(discrim)
 
 discrim_linear() \%>\% 
   set_engine("sda") \%>\% 
@@ -53,8 +52,8 @@ discrim_linear() \%>\%
 
 Factor/categorical predictors need to be converted to numeric values
 (e.g., dummy or indicator variables) for this engine. When using the
-formula method via \code{\link[=fit.model_spec]{fit.model_spec()}},
-parsnip will convert factor columns to indicators.
+formula method via \code{\link[=fit.model_spec]{fit()}}, parsnip
+will convert factor columns to indicators.
 
 Variance calculations are used in these computations so \emph{zero-variance}
 predictors (i.e., with a single unique value) should be eliminated

--- a/man/details_discrim_linear_sparsediscrim.Rd
+++ b/man/details_discrim_linear_sparsediscrim.Rd
@@ -34,8 +34,7 @@ execute, are:
 
 \subsection{Translation from parsnip to the original package}{
 
-There is a parsnip extension package required to fit this model to this
-mode: \strong{discrim}.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(discrim)
+The \strong{discrim} extension package is required to fit this model.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(discrim)
 
 discrim_linear(regularization_method = character(0)) \%>\% 
   set_engine("sparsediscrim") \%>\% 
@@ -57,8 +56,8 @@ discrim_linear(regularization_method = character(0)) \%>\%
 
 Factor/categorical predictors need to be converted to numeric values
 (e.g., dummy or indicator variables) for this engine. When using the
-formula method via \code{\link[=fit.model_spec]{fit.model_spec()}},
-parsnip will convert factor columns to indicators.
+formula method via \code{\link[=fit.model_spec]{fit()}}, parsnip
+will convert factor columns to indicators.
 
 Variance calculations are used in these computations so \emph{zero-variance}
 predictors (i.e., with a single unique value) should be eliminated

--- a/man/details_discrim_quad_MASS.Rd
+++ b/man/details_discrim_quad_MASS.Rd
@@ -18,8 +18,7 @@ This engine has no tuning parameters.
 
 \subsection{Translation from parsnip to the original package}{
 
-There is a parsnip extension package required to fit this model to this
-mode: \strong{discrim}.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(discrim)
+The \strong{discrim} extension package is required to fit this model.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(discrim)
 
 discrim_quad() \%>\% 
   set_engine("MASS") \%>\% 
@@ -37,8 +36,8 @@ discrim_quad() \%>\%
 
 Factor/categorical predictors need to be converted to numeric values
 (e.g., dummy or indicator variables) for this engine. When using the
-formula method via \code{\link[=fit.model_spec]{fit.model_spec()}},
-parsnip will convert factor columns to indicators.
+formula method via \code{\link[=fit.model_spec]{fit()}}, parsnip
+will convert factor columns to indicators.
 
 Variance calculations are used in these computations within each outcome
 class. For this reason, \emph{zero-variance} predictors (i.e., with a single

--- a/man/details_discrim_quad_sparsediscrim.Rd
+++ b/man/details_discrim_quad_sparsediscrim.Rd
@@ -32,8 +32,7 @@ execute, are:
 
 \subsection{Translation from parsnip to the original package}{
 
-There is a parsnip extension package required to fit this model to this
-mode: \strong{discrim}.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(discrim)
+The \strong{discrim} extension package is required to fit this model.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(discrim)
 
 discrim_quad(regularization_method = character(0)) \%>\% 
   set_engine("sparsediscrim") \%>\% 
@@ -55,8 +54,8 @@ discrim_quad(regularization_method = character(0)) \%>\%
 
 Factor/categorical predictors need to be converted to numeric values
 (e.g., dummy or indicator variables) for this engine. When using the
-formula method via \code{\link[=fit.model_spec]{fit.model_spec()}},
-parsnip will convert factor columns to indicators.
+formula method via \code{\link[=fit.model_spec]{fit()}}, parsnip
+will convert factor columns to indicators.
 
 Variance calculations are used in these computations within each outcome
 class. For this reason, \emph{zero-variance} predictors (i.e., with a single

--- a/man/details_discrim_regularized_klaR.Rd
+++ b/man/details_discrim_regularized_klaR.Rd
@@ -33,8 +33,7 @@ discriminant analysis (QDA) model.
 
 \subsection{Translation from parsnip to the original package}{
 
-There is a parsnip extension package required to fit this model to this
-mode: \strong{discrim}.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(discrim)
+The \strong{discrim} extension package is required to fit this model.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(discrim)
 
 discrim_regularized(frac_identity = numeric(0), frac_common_cov = numeric(0)) \%>\% 
   set_engine("klaR") \%>\% 
@@ -57,8 +56,8 @@ discrim_regularized(frac_identity = numeric(0), frac_common_cov = numeric(0)) \%
 
 Factor/categorical predictors need to be converted to numeric values
 (e.g., dummy or indicator variables) for this engine. When using the
-formula method via \code{\link[=fit.model_spec]{fit.model_spec()}},
-parsnip will convert factor columns to indicators.
+formula method via \code{\link[=fit.model_spec]{fit()}}, parsnip
+will convert factor columns to indicators.
 
 Variance calculations are used in these computations within each outcome
 class. For this reason, \emph{zero-variance} predictors (i.e., with a single

--- a/man/details_gen_additive_mod_mgcv.Rd
+++ b/man/details_gen_additive_mod_mgcv.Rd
@@ -87,8 +87,8 @@ the \code{adjust_deg_free} parameter.
 
 Factor/categorical predictors need to be converted to numeric values
 (e.g., dummy or indicator variables) for this engine. When using the
-formula method via \code{\link[=fit.model_spec]{fit.model_spec()}},
-parsnip will convert factor columns to indicators.
+formula method via \code{\link[=fit.model_spec]{fit()}}, parsnip
+will convert factor columns to indicators.
 }
 
 \subsection{References}{

--- a/man/details_linear_reg_brulee.Rd
+++ b/man/details_linear_reg_brulee.Rd
@@ -59,8 +59,8 @@ no improvement before stopping. (default: 5L).
 
 Factor/categorical predictors need to be converted to numeric values
 (e.g., dummy or indicator variables) for this engine. When using the
-formula method via \code{\link[=fit.model_spec]{fit.model_spec()}},
-parsnip will convert factor columns to indicators.
+formula method via \code{\link[=fit.model_spec]{fit()}}, parsnip
+will convert factor columns to indicators.
 
 Predictors should have the same scale. One way to achieve this is to
 center and scale each so that each predictor has mean zero and a

--- a/man/details_linear_reg_gee.Rd
+++ b/man/details_linear_reg_gee.Rd
@@ -20,8 +20,7 @@ values.
 
 \subsection{Translation from parsnip to the original package}{
 
-There is a parsnip extension package required to fit this model to this
-mode: \strong{multilevelmod}.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(multilevelmod)
+The \strong{multilevelmod} extension package is required to fit this model.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(multilevelmod)
 
 linear_reg() \%>\% 
   set_engine("gee") \%>\% 
@@ -83,7 +82,7 @@ fit(gee_wflow, data = warpbreaks)
 }\if{html}{\out{</div>}}
 
 The \code{gee::gee()} function always prints out warnings and output even
-when \code{silent = TRUE}. The parsnip “gee” engine, by contrast, silences
+when \code{silent = TRUE}. The parsnip \code{"gee"} engine, by contrast, silences
 all console output coming from \code{gee::gee()}, even if \code{silent = FALSE}.
 
 Also, because of issues with the \code{gee()} function, a supplementary call

--- a/man/details_linear_reg_glm.Rd
+++ b/man/details_linear_reg_glm.Rd
@@ -49,8 +49,8 @@ To use a non-default \code{family} and/or \code{link}, pass in as an argument to
 
 Factor/categorical predictors need to be converted to numeric values
 (e.g., dummy or indicator variables) for this engine. When using the
-formula method via \code{\link[=fit.model_spec]{fit.model_spec()}},
-parsnip will convert factor columns to indicators.
+formula method via \code{\link[=fit.model_spec]{fit()}}, parsnip
+will convert factor columns to indicators.
 }
 
 \subsection{Examples}{

--- a/man/details_linear_reg_glmnet.Rd
+++ b/man/details_linear_reg_glmnet.Rd
@@ -46,8 +46,8 @@ see \link{glmnet-details}.
 
 Factor/categorical predictors need to be converted to numeric values
 (e.g., dummy or indicator variables) for this engine. When using the
-formula method via \code{\link[=fit.model_spec]{fit.model_spec()}},
-parsnip will convert factor columns to indicators.
+formula method via \code{\link[=fit.model_spec]{fit()}}, parsnip
+will convert factor columns to indicators.
 
 Predictors should have the same scale. One way to achieve this is to
 center and scale each so that each predictor has mean zero and a

--- a/man/details_linear_reg_gls.Rd
+++ b/man/details_linear_reg_gls.Rd
@@ -16,8 +16,7 @@ This model has no tuning parameters.
 
 \subsection{Translation from parsnip to the original package}{
 
-There is a parsnip extension package required to fit this model to this
-mode: \strong{multilevelmod}.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(multilevelmod)
+The \strong{multilevelmod} extension package is required to fit this model.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(multilevelmod)
 
 linear_reg() \%>\% 
   set_engine("gls") \%>\% 

--- a/man/details_linear_reg_keras.Rd
+++ b/man/details_linear_reg_keras.Rd
@@ -43,8 +43,8 @@ single hidden unit.
 
 Factor/categorical predictors need to be converted to numeric values
 (e.g., dummy or indicator variables) for this engine. When using the
-formula method via \code{\link[=fit.model_spec]{fit.model_spec()}},
-parsnip will convert factor columns to indicators.
+formula method via \code{\link[=fit.model_spec]{fit()}}, parsnip
+will convert factor columns to indicators.
 
 Predictors should have the same scale. One way to achieve this is to
 center and scale each so that each predictor has mean zero and a

--- a/man/details_linear_reg_lm.Rd
+++ b/man/details_linear_reg_lm.Rd
@@ -29,8 +29,8 @@ This engine has no tuning parameters.
 
 Factor/categorical predictors need to be converted to numeric values
 (e.g., dummy or indicator variables) for this engine. When using the
-formula method via \code{\link[=fit.model_spec]{fit.model_spec()}},
-parsnip will convert factor columns to indicators.
+formula method via \code{\link[=fit.model_spec]{fit()}}, parsnip
+will convert factor columns to indicators.
 }
 
 \subsection{Examples}{

--- a/man/details_linear_reg_lme.Rd
+++ b/man/details_linear_reg_lme.Rd
@@ -16,8 +16,7 @@ This model has no tuning parameters.
 
 \subsection{Translation from parsnip to the original package}{
 
-There is a parsnip extension package required to fit this model to this
-mode: \strong{multilevelmod}.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(multilevelmod)
+The \strong{multilevelmod} extension package is required to fit this model.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(multilevelmod)
 
 linear_reg() \%>\% 
   set_engine("lme") \%>\% 
@@ -38,7 +37,7 @@ This model can use subject-specific coefficient estimates to make
 predictions (i.e. partial pooling). For example, this equation shows the
 linear predictor (\emph{η}) for a random intercept:
 
-\emph{η}\if{html}{\out{<sub>}}\emph{i}\if{html}{\out{</sub>}} = (\emph{β}\if{html}{\out{<sub>}}0\if{html}{\out{</sub>}}+\emph{b}\if{html}{\out{<sub>}}0\emph{i}\if{html}{\out{</sub>}}) + \emph{β}\if{html}{\out{<sub>}}1\if{html}{\out{</sub>}}\emph{x}\if{html}{\out{<sub>}}\emph{i}1\if{html}{\out{</sub>}}
+\emph{η}\if{html}{\out{<sub>}}\emph{i}\if{html}{\out{</sub>}} = (\emph{β}\if{html}{\out{<sub>}}0\if{html}{\out{</sub>}} + \emph{b}\if{html}{\out{<sub>}}0\emph{i}\if{html}{\out{</sub>}}) + \emph{β}\if{html}{\out{<sub>}}1\if{html}{\out{</sub>}}\emph{x}\if{html}{\out{<sub>}}\emph{i}1\if{html}{\out{</sub>}}
 
 where \emph{i} denotes the \code{i}th independent experimental unit
 (e.g. subject). When the model has seen subject \code{i}, it can use that

--- a/man/details_linear_reg_lmer.Rd
+++ b/man/details_linear_reg_lmer.Rd
@@ -16,8 +16,7 @@ This model has no tuning parameters.
 
 \subsection{Translation from parsnip to the original package}{
 
-There is a parsnip extension package required to fit this model to this
-mode: \strong{multilevelmod}.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(multilevelmod)
+The \strong{multilevelmod} extension package is required to fit this model.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(multilevelmod)
 
 linear_reg() \%>\% 
   set_engine("lmer") \%>\% 
@@ -38,7 +37,7 @@ This model can use subject-specific coefficient estimates to make
 predictions (i.e. partial pooling). For example, this equation shows the
 linear predictor (\emph{η}) for a random intercept:
 
-\emph{η}\if{html}{\out{<sub>}}\emph{i}\if{html}{\out{</sub>}} = (\emph{β}\if{html}{\out{<sub>}}0\if{html}{\out{</sub>}}+\emph{b}\if{html}{\out{<sub>}}0\emph{i}\if{html}{\out{</sub>}}) + \emph{β}\if{html}{\out{<sub>}}1\if{html}{\out{</sub>}}\emph{x}\if{html}{\out{<sub>}}\emph{i}1\if{html}{\out{</sub>}}
+\emph{η}\if{html}{\out{<sub>}}\emph{i}\if{html}{\out{</sub>}} = (\emph{β}\if{html}{\out{<sub>}}0\if{html}{\out{</sub>}} + \emph{b}\if{html}{\out{<sub>}}0\emph{i}\if{html}{\out{</sub>}}) + \emph{β}\if{html}{\out{<sub>}}1\if{html}{\out{</sub>}}\emph{x}\if{html}{\out{<sub>}}\emph{i}1\if{html}{\out{</sub>}}
 
 where \emph{i} denotes the \code{i}th independent experimental unit
 (e.g. subject). When the model has seen subject \code{i}, it can use that

--- a/man/details_linear_reg_spark.Rd
+++ b/man/details_linear_reg_spark.Rd
@@ -45,8 +45,8 @@ A value of \code{mixture = 1} corresponds to a pure lasso model, while
 
 Factor/categorical predictors need to be converted to numeric values
 (e.g., dummy or indicator variables) for this engine. When using the
-formula method via \code{\link[=fit.model_spec]{fit.model_spec()}},
-parsnip will convert factor columns to indicators.
+formula method via \code{\link[=fit.model_spec]{fit()}}, parsnip
+will convert factor columns to indicators.
 
 Predictors should have the same scale. One way to achieve this is to
 center and scale each so that each predictor has mean zero and a

--- a/man/details_linear_reg_stan.Rd
+++ b/man/details_linear_reg_stan.Rd
@@ -57,8 +57,8 @@ process. Change this value in \code{set_engine()} to show the MCMC logs.
 
 Factor/categorical predictors need to be converted to numeric values
 (e.g., dummy or indicator variables) for this engine. When using the
-formula method via \code{\link[=fit.model_spec]{fit.model_spec()}},
-parsnip will convert factor columns to indicators.
+formula method via \code{\link[=fit.model_spec]{fit()}}, parsnip
+will convert factor columns to indicators.
 }
 
 \subsection{Other details}{

--- a/man/details_linear_reg_stan_glmer.Rd
+++ b/man/details_linear_reg_stan_glmer.Rd
@@ -36,8 +36,7 @@ See \code{?rstanarm::stan_glmer} and \code{?rstan::sampling} for more informatio
 
 \subsection{Translation from parsnip to the original package}{
 
-There is a parsnip extension package required to fit this model to this
-mode: \strong{multilevelmod}.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(multilevelmod)
+The \strong{multilevelmod} extension package is required to fit this model.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(multilevelmod)
 
 linear_reg() \%>\% 
   set_engine("stan_glmer") \%>\% 
@@ -59,7 +58,7 @@ This model can use subject-specific coefficient estimates to make
 predictions (i.e. partial pooling). For example, this equation shows the
 linear predictor (\emph{η}) for a random intercept:
 
-\emph{η}\if{html}{\out{<sub>}}\emph{i}\if{html}{\out{</sub>}} = (\emph{β}\if{html}{\out{<sub>}}0\if{html}{\out{</sub>}}+\emph{b}\if{html}{\out{<sub>}}0\emph{i}\if{html}{\out{</sub>}}) + \emph{β}\if{html}{\out{<sub>}}1\if{html}{\out{</sub>}}\emph{x}\if{html}{\out{<sub>}}\emph{i}1\if{html}{\out{</sub>}}
+\emph{η}\if{html}{\out{<sub>}}\emph{i}\if{html}{\out{</sub>}} = (\emph{β}\if{html}{\out{<sub>}}0\if{html}{\out{</sub>}} + \emph{b}\if{html}{\out{<sub>}}0\emph{i}\if{html}{\out{</sub>}}) + \emph{β}\if{html}{\out{<sub>}}1\if{html}{\out{</sub>}}\emph{x}\if{html}{\out{<sub>}}\emph{i}1\if{html}{\out{</sub>}}
 
 where \emph{i} denotes the \code{i}th independent experimental unit
 (e.g. subject). When the model has seen subject \code{i}, it can use that

--- a/man/details_logistic_reg_LiblineaR.Rd
+++ b/man/details_logistic_reg_LiblineaR.Rd
@@ -50,8 +50,8 @@ parameter estimates.
 
 Factor/categorical predictors need to be converted to numeric values
 (e.g., dummy or indicator variables) for this engine. When using the
-formula method via \code{\link[=fit.model_spec]{fit.model_spec()}},
-parsnip will convert factor columns to indicators.
+formula method via \code{\link[=fit.model_spec]{fit()}}, parsnip
+will convert factor columns to indicators.
 
 Predictors should have the same scale. One way to achieve this is to
 center and scale each so that each predictor has mean zero and a

--- a/man/details_logistic_reg_brulee.Rd
+++ b/man/details_logistic_reg_brulee.Rd
@@ -59,8 +59,8 @@ no improvement before stopping. (default: 5L).
 
 Factor/categorical predictors need to be converted to numeric values
 (e.g., dummy or indicator variables) for this engine. When using the
-formula method via \code{\link[=fit.model_spec]{fit.model_spec()}},
-parsnip will convert factor columns to indicators.
+formula method via \code{\link[=fit.model_spec]{fit()}}, parsnip
+will convert factor columns to indicators.
 
 Predictors should have the same scale. One way to achieve this is to
 center and scale each so that each predictor has mean zero and a

--- a/man/details_logistic_reg_gee.Rd
+++ b/man/details_logistic_reg_gee.Rd
@@ -20,8 +20,7 @@ values.
 
 \subsection{Translation from parsnip to the original package}{
 
-There is a parsnip extension package required to fit this model to this
-mode: \strong{multilevelmod}.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(multilevelmod)
+The \strong{multilevelmod} extension package is required to fit this model.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(multilevelmod)
 
 logistic_reg() \%>\% 
   set_engine("gee") \%>\% 
@@ -83,7 +82,7 @@ fit(gee_wflow, data = toenail)
 }\if{html}{\out{</div>}}
 
 The \code{gee::gee()} function always prints out warnings and output even
-when \code{silent = TRUE}. The parsnip “gee” engine, by contrast, silences
+when \code{silent = TRUE}. The parsnip \code{"gee"} engine, by contrast, silences
 all console output coming from \code{gee::gee()}, even if \code{silent = FALSE}.
 
 Also, because of issues with the \code{gee()} function, a supplementary call

--- a/man/details_logistic_reg_glm.Rd
+++ b/man/details_logistic_reg_glm.Rd
@@ -49,8 +49,8 @@ To use a non-default \code{family} and/or \code{link}, pass in as an argument to
 
 Factor/categorical predictors need to be converted to numeric values
 (e.g., dummy or indicator variables) for this engine. When using the
-formula method via \code{\link[=fit.model_spec]{fit.model_spec()}},
-parsnip will convert factor columns to indicators.
+formula method via \code{\link[=fit.model_spec]{fit()}}, parsnip
+will convert factor columns to indicators.
 }
 
 \subsection{Examples}{

--- a/man/details_logistic_reg_glmer.Rd
+++ b/man/details_logistic_reg_glmer.Rd
@@ -16,8 +16,7 @@ This model has no tuning parameters.
 
 \subsection{Translation from parsnip to the original package}{
 
-There is a parsnip extension package required to fit this model to this
-mode: \strong{multilevelmod}.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(multilevelmod)
+The \strong{multilevelmod} extension package is required to fit this model.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(multilevelmod)
 
 logistic_reg() \%>\% 
   set_engine("glmer") \%>\% 
@@ -37,7 +36,7 @@ This model can use subject-specific coefficient estimates to make
 predictions (i.e. partial pooling). For example, this equation shows the
 linear predictor (\emph{η}) for a random intercept:
 
-\emph{η}\if{html}{\out{<sub>}}\emph{i}\if{html}{\out{</sub>}} = (\emph{β}\if{html}{\out{<sub>}}0\if{html}{\out{</sub>}}+\emph{b}\if{html}{\out{<sub>}}0\emph{i}\if{html}{\out{</sub>}}) + \emph{β}\if{html}{\out{<sub>}}1\if{html}{\out{</sub>}}\emph{x}\if{html}{\out{<sub>}}\emph{i}1\if{html}{\out{</sub>}}
+\emph{η}\if{html}{\out{<sub>}}\emph{i}\if{html}{\out{</sub>}} = (\emph{β}\if{html}{\out{<sub>}}0\if{html}{\out{</sub>}} + \emph{b}\if{html}{\out{<sub>}}0\emph{i}\if{html}{\out{</sub>}}) + \emph{β}\if{html}{\out{<sub>}}1\if{html}{\out{</sub>}}\emph{x}\if{html}{\out{<sub>}}\emph{i}1\if{html}{\out{</sub>}}
 
 where \emph{i} denotes the \code{i}th independent experimental unit
 (e.g. subject). When the model has seen subject \code{i}, it can use that

--- a/man/details_logistic_reg_glmnet.Rd
+++ b/man/details_logistic_reg_glmnet.Rd
@@ -48,8 +48,8 @@ see \link{glmnet-details}.
 
 Factor/categorical predictors need to be converted to numeric values
 (e.g., dummy or indicator variables) for this engine. When using the
-formula method via \code{\link[=fit.model_spec]{fit.model_spec()}},
-parsnip will convert factor columns to indicators.
+formula method via \code{\link[=fit.model_spec]{fit()}}, parsnip
+will convert factor columns to indicators.
 
 Predictors should have the same scale. One way to achieve this is to
 center and scale each so that each predictor has mean zero and a

--- a/man/details_logistic_reg_keras.Rd
+++ b/man/details_logistic_reg_keras.Rd
@@ -45,8 +45,8 @@ single hidden unit.
 
 Factor/categorical predictors need to be converted to numeric values
 (e.g., dummy or indicator variables) for this engine. When using the
-formula method via \code{\link[=fit.model_spec]{fit.model_spec()}},
-parsnip will convert factor columns to indicators.
+formula method via \code{\link[=fit.model_spec]{fit()}}, parsnip
+will convert factor columns to indicators.
 
 Predictors should have the same scale. One way to achieve this is to
 center and scale each so that each predictor has mean zero and a

--- a/man/details_logistic_reg_spark.Rd
+++ b/man/details_logistic_reg_spark.Rd
@@ -47,8 +47,8 @@ A value of \code{mixture = 1} corresponds to a pure lasso model, while
 
 Factor/categorical predictors need to be converted to numeric values
 (e.g., dummy or indicator variables) for this engine. When using the
-formula method via \code{\link[=fit.model_spec]{fit.model_spec()}},
-parsnip will convert factor columns to indicators.
+formula method via \code{\link[=fit.model_spec]{fit()}}, parsnip
+will convert factor columns to indicators.
 
 Predictors should have the same scale. One way to achieve this is to
 center and scale each so that each predictor has mean zero and a

--- a/man/details_logistic_reg_stan.Rd
+++ b/man/details_logistic_reg_stan.Rd
@@ -58,8 +58,8 @@ process. Change this value in \code{set_engine()} to show the MCMC logs.
 
 Factor/categorical predictors need to be converted to numeric values
 (e.g., dummy or indicator variables) for this engine. When using the
-formula method via \code{\link[=fit.model_spec]{fit.model_spec()}},
-parsnip will convert factor columns to indicators.
+formula method via \code{\link[=fit.model_spec]{fit()}}, parsnip
+will convert factor columns to indicators.
 }
 
 \subsection{Other details}{

--- a/man/details_logistic_reg_stan_glmer.Rd
+++ b/man/details_logistic_reg_stan_glmer.Rd
@@ -36,8 +36,7 @@ See \code{?rstanarm::stan_glmer} and \code{?rstan::sampling} for more informatio
 
 \subsection{Translation from parsnip to the original package}{
 
-There is a parsnip extension package required to fit this model to this
-mode: \strong{multilevelmod}.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(multilevelmod)
+The \strong{multilevelmod} extension package is required to fit this model.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(multilevelmod)
 
 logistic_reg() \%>\% 
   set_engine("stan_glmer") \%>\% 
@@ -58,7 +57,7 @@ This model can use subject-specific coefficient estimates to make
 predictions (i.e. partial pooling). For example, this equation shows the
 linear predictor (\emph{η}) for a random intercept:
 
-\emph{η}\if{html}{\out{<sub>}}\emph{i}\if{html}{\out{</sub>}} = (\emph{β}\if{html}{\out{<sub>}}0\if{html}{\out{</sub>}}+\emph{b}\if{html}{\out{<sub>}}0\emph{i}\if{html}{\out{</sub>}}) + \emph{β}\if{html}{\out{<sub>}}1\if{html}{\out{</sub>}}\emph{x}\if{html}{\out{<sub>}}\emph{i}1\if{html}{\out{</sub>}}
+\emph{η}\if{html}{\out{<sub>}}\emph{i}\if{html}{\out{</sub>}} = (\emph{β}\if{html}{\out{<sub>}}0\if{html}{\out{</sub>}} + \emph{b}\if{html}{\out{<sub>}}0\emph{i}\if{html}{\out{</sub>}}) + \emph{β}\if{html}{\out{<sub>}}1\if{html}{\out{</sub>}}\emph{x}\if{html}{\out{<sub>}}\emph{i}1\if{html}{\out{</sub>}}
 
 where \emph{i} denotes the \code{i}th independent experimental unit
 (e.g. subject). When the model has seen subject \code{i}, it can use that

--- a/man/details_mars_earth.Rd
+++ b/man/details_mars_earth.Rd
@@ -76,8 +76,8 @@ in \code{\link[=discrim_flexible]{discrim_flexible()}}.
 
 Factor/categorical predictors need to be converted to numeric values
 (e.g., dummy or indicator variables) for this engine. When using the
-formula method via \code{\link[=fit.model_spec]{fit.model_spec()}},
-parsnip will convert factor columns to indicators.
+formula method via \code{\link[=fit.model_spec]{fit()}}, parsnip
+will convert factor columns to indicators.
 }
 
 \subsection{Examples}{

--- a/man/details_mlp_brulee.Rd
+++ b/man/details_mlp_brulee.Rd
@@ -108,8 +108,8 @@ layer.
 
 Factor/categorical predictors need to be converted to numeric values
 (e.g., dummy or indicator variables) for this engine. When using the
-formula method via \code{\link[=fit.model_spec]{fit.model_spec()}},
-parsnip will convert factor columns to indicators.
+formula method via \code{\link[=fit.model_spec]{fit()}}, parsnip
+will convert factor columns to indicators.
 
 Predictors should have the same scale. One way to achieve this is to
 center and scale each so that each predictor has mean zero and a

--- a/man/details_mlp_keras.Rd
+++ b/man/details_mlp_keras.Rd
@@ -81,8 +81,8 @@ This model has 5 tuning parameters:
 
 Factor/categorical predictors need to be converted to numeric values
 (e.g., dummy or indicator variables) for this engine. When using the
-formula method via \code{\link[=fit.model_spec]{fit.model_spec()}},
-parsnip will convert factor columns to indicators.
+formula method via \code{\link[=fit.model_spec]{fit()}}, parsnip
+will convert factor columns to indicators.
 
 Predictors should have the same scale. One way to achieve this is to
 center and scale each so that each predictor has mean zero and a

--- a/man/details_mlp_nnet.Rd
+++ b/man/details_mlp_nnet.Rd
@@ -78,8 +78,8 @@ layer.
 
 Factor/categorical predictors need to be converted to numeric values
 (e.g., dummy or indicator variables) for this engine. When using the
-formula method via \code{\link[=fit.model_spec]{fit.model_spec()}},
-parsnip will convert factor columns to indicators.
+formula method via \code{\link[=fit.model_spec]{fit()}}, parsnip
+will convert factor columns to indicators.
 
 Predictors should have the same scale. One way to achieve this is to
 center and scale each so that each predictor has mean zero and a

--- a/man/details_multinom_reg_brulee.Rd
+++ b/man/details_multinom_reg_brulee.Rd
@@ -58,8 +58,8 @@ no improvement before stopping. (default: 5L).
 
 Factor/categorical predictors need to be converted to numeric values
 (e.g., dummy or indicator variables) for this engine. When using the
-formula method via \code{\link[=fit.model_spec]{fit.model_spec()}},
-parsnip will convert factor columns to indicators.
+formula method via \code{\link[=fit.model_spec]{fit()}}, parsnip
+will convert factor columns to indicators.
 
 Predictors should have the same scale. One way to achieve this is to
 center and scale each so that each predictor has mean zero and a

--- a/man/details_multinom_reg_glmnet.Rd
+++ b/man/details_multinom_reg_glmnet.Rd
@@ -47,8 +47,8 @@ see \link{glmnet-details}.
 
 Factor/categorical predictors need to be converted to numeric values
 (e.g., dummy or indicator variables) for this engine. When using the
-formula method via \code{\link[=fit.model_spec]{fit.model_spec()}},
-parsnip will convert factor columns to indicators.
+formula method via \code{\link[=fit.model_spec]{fit()}}, parsnip
+will convert factor columns to indicators.
 
 Predictors should have the same scale. One way to achieve this is to
 center and scale each so that each predictor has mean zero and a

--- a/man/details_multinom_reg_keras.Rd
+++ b/man/details_multinom_reg_keras.Rd
@@ -44,8 +44,8 @@ single hidden unit.
 
 Factor/categorical predictors need to be converted to numeric values
 (e.g., dummy or indicator variables) for this engine. When using the
-formula method via \code{\link[=fit.model_spec]{fit.model_spec()}},
-parsnip will convert factor columns to indicators.
+formula method via \code{\link[=fit.model_spec]{fit()}}, parsnip
+will convert factor columns to indicators.
 
 Predictors should have the same scale. One way to achieve this is to
 center and scale each so that each predictor has mean zero and a

--- a/man/details_multinom_reg_nnet.Rd
+++ b/man/details_multinom_reg_nnet.Rd
@@ -40,8 +40,8 @@ For \code{penalty}, the amount of regularization includes only the L2 penalty
 
 Factor/categorical predictors need to be converted to numeric values
 (e.g., dummy or indicator variables) for this engine. When using the
-formula method via \code{\link[=fit.model_spec]{fit.model_spec()}},
-parsnip will convert factor columns to indicators.
+formula method via \code{\link[=fit.model_spec]{fit()}}, parsnip
+will convert factor columns to indicators.
 
 Predictors should have the same scale. One way to achieve this is to
 center and scale each so that each predictor has mean zero and a

--- a/man/details_multinom_reg_spark.Rd
+++ b/man/details_multinom_reg_spark.Rd
@@ -46,8 +46,8 @@ A value of \code{mixture = 1} corresponds to a pure lasso model, while
 
 Factor/categorical predictors need to be converted to numeric values
 (e.g., dummy or indicator variables) for this engine. When using the
-formula method via \code{\link[=fit.model_spec]{fit.model_spec()}},
-parsnip will convert factor columns to indicators.
+formula method via \code{\link[=fit.model_spec]{fit()}}, parsnip
+will convert factor columns to indicators.
 
 Predictors should have the same scale. One way to achieve this is to
 center and scale each so that each predictor has mean zero and a

--- a/man/details_naive_Bayes_klaR.Rd
+++ b/man/details_naive_Bayes_klaR.Rd
@@ -22,8 +22,7 @@ Note that \code{usekernel} is always set to \code{TRUE} for the \code{klaR} engi
 
 \subsection{Translation from parsnip to the original package}{
 
-There is a parsnip extension package required to fit this model to this
-mode: \strong{discrim}.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(discrim)
+The \strong{discrim} extension package is required to fit this model.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(discrim)
 
 naive_Bayes(smoothness = numeric(0), Laplace = numeric(0)) \%>\% 
   set_engine("klaR") \%>\% 

--- a/man/details_naive_Bayes_naivebayes.Rd
+++ b/man/details_naive_Bayes_naivebayes.Rd
@@ -20,8 +20,7 @@ This model has 2 tuning parameter:
 
 \subsection{Translation from parsnip to the original package}{
 
-There is a parsnip extension package required to fit this model to this
-mode: \strong{discrim}.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(discrim)
+The \strong{discrim} extension package is required to fit this model.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(discrim)
 
 naive_Bayes(smoothness = numeric(0), Laplace = numeric(0)) \%>\% 
   set_engine("naivebayes") \%>\% 

--- a/man/details_nearest_neighbor_kknn.Rd
+++ b/man/details_nearest_neighbor_kknn.Rd
@@ -73,8 +73,8 @@ it is not consistent with the actual data dimensions.
 
 Factor/categorical predictors need to be converted to numeric values
 (e.g., dummy or indicator variables) for this engine. When using the
-formula method via \code{\link[=fit.model_spec]{fit.model_spec()}},
-parsnip will convert factor columns to indicators.
+formula method via \code{\link[=fit.model_spec]{fit()}}, parsnip
+will convert factor columns to indicators.
 
 Predictors should have the same scale. One way to achieve this is to
 center and scale each so that each predictor has mean zero and a

--- a/man/details_pls_mixOmics.Rd
+++ b/man/details_pls_mixOmics.Rd
@@ -20,8 +20,7 @@ see below)
 
 \subsection{Translation from parsnip to the underlying model call (regression)}{
 
-There is a parsnip extension package required to fit this model to this
-mode: \strong{plsmod}.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(plsmod)
+The \strong{plsmod} extension package is required to fit this model.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(plsmod)
 
 pls(num_comp = integer(1), predictor_prop = double(1)) \%>\%
   set_engine("mixOmics") \%>\%
@@ -54,8 +53,7 @@ for sparse models.
 
 \subsection{Translation from parsnip to the underlying model call (classification)}{
 
-There is a parsnip extension package required to fit this model to this
-mode: \strong{plsmod}.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(plsmod)
+The \strong{plsmod} extension package is required to fit this model.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(plsmod)
 
 pls(num_comp = integer(1), predictor_prop = double(1)) \%>\%
   set_engine("mixOmics") \%>\%
@@ -74,17 +72,18 @@ pls(num_comp = integer(1), predictor_prop = double(1)) \%>\%
 ##     ncomp = integer(1))
 }
 
-In this case, \code{\link[plsmod:pls_fit]{plsmod::pls_fit()}} has the same role
-as above but eventually targets \code{\link[mixOmics:plsda]{mixOmics::plsda()}}
-or \code{\link[mixOmics:splsda]{mixOmics::splsda()}} .
+In this case, \code{\link[plsmod:pls_fit]{plsmod::pls_fit()}} has the same
+role as above but eventually targets
+\code{\link[mixOmics:plsda]{mixOmics::plsda()}} or
+\code{\link[mixOmics:splsda]{mixOmics::splsda()}} .
 }
 
 \subsection{Preprocessing requirements}{
 
 Factor/categorical predictors need to be converted to numeric values
 (e.g., dummy or indicator variables) for this engine. When using the
-formula method via \code{\link[=fit.model_spec]{fit.model_spec()}},
-parsnip will convert factor columns to indicators.
+formula method via \code{\link[=fit.model_spec]{fit()}}, parsnip
+will convert factor columns to indicators.
 
 Variance calculations are used in these computations so \emph{zero-variance}
 predictors (i.e., with a single unique value) should be eliminated

--- a/man/details_poisson_reg_gee.Rd
+++ b/man/details_poisson_reg_gee.Rd
@@ -20,8 +20,7 @@ values.
 
 \subsection{Translation from parsnip to the original package}{
 
-There is a parsnip extension package required to fit this model to this
-mode: \strong{multilevelmod}.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(multilevelmod)
+The \strong{multilevelmod} extension package is required to fit this model.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(multilevelmod)
 
 poisson_reg(engine = "gee") \%>\% 
   set_engine("gee") \%>\% 
@@ -81,9 +80,9 @@ gee_wflow <-
 fit(gee_wflow, data = longitudinal_counts)
 }\if{html}{\out{</div>}}
 
-\code{gee()} always prints out warnings and output even when \code{silent = TRUE}.
-When using the \code{gee} engine, it will never produce output, even if
-\code{silent = FALSE}.
+The \code{gee::gee()} function always prints out warnings and output even
+when \code{silent = TRUE}. The parsnip \code{"gee"} engine, by contrast, silences
+all console output coming from \code{gee::gee()}, even if \code{silent = FALSE}.
 
 Also, because of issues with the \code{gee()} function, a supplementary call
 to \code{glm()} is needed to get the rank and QR decomposition objects so

--- a/man/details_poisson_reg_glm.Rd
+++ b/man/details_poisson_reg_glm.Rd
@@ -15,8 +15,7 @@ This engine has no tuning parameters.
 
 \subsection{Translation from parsnip to the underlying model call (regression)}{
 
-There is a parsnip extension package required to fit this model to this
-mode: \strong{poissonreg}.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(poissonreg)
+The \strong{poissonreg} extension package is required to fit this model.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(poissonreg)
 
 poisson_reg() \%>\%
   set_engine("glm") \%>\%
@@ -35,8 +34,8 @@ poisson_reg() \%>\%
 
 Factor/categorical predictors need to be converted to numeric values
 (e.g., dummy or indicator variables) for this engine. When using the
-formula method via \code{\link[=fit.model_spec]{fit.model_spec()}},
-parsnip will convert factor columns to indicators.
+formula method via \code{\link[=fit.model_spec]{fit()}}, parsnip
+will convert factor columns to indicators.
 }
 }
 \keyword{internal}

--- a/man/details_poisson_reg_glmer.Rd
+++ b/man/details_poisson_reg_glmer.Rd
@@ -16,8 +16,7 @@ This model has no tuning parameters.
 
 \subsection{Translation from parsnip to the original package}{
 
-There is a parsnip extension package required to fit this model to this
-mode: \strong{multilevelmod}.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(multilevelmod)
+The \strong{multilevelmod} extension package is required to fit this model.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(multilevelmod)
 
 poisson_reg(engine = "glmer") \%>\% 
   set_engine("glmer") \%>\% 
@@ -37,7 +36,7 @@ This model can use subject-specific coefficient estimates to make
 predictions (i.e. partial pooling). For example, this equation shows the
 linear predictor (\emph{η}) for a random intercept:
 
-\emph{η}\if{html}{\out{<sub>}}\emph{i}\if{html}{\out{</sub>}} = (\emph{β}\if{html}{\out{<sub>}}0\if{html}{\out{</sub>}}+\emph{b}\if{html}{\out{<sub>}}0\emph{i}\if{html}{\out{</sub>}}) + \emph{β}\if{html}{\out{<sub>}}1\if{html}{\out{</sub>}}\emph{x}\if{html}{\out{<sub>}}\emph{i}1\if{html}{\out{</sub>}}
+\emph{η}\if{html}{\out{<sub>}}\emph{i}\if{html}{\out{</sub>}} = (\emph{β}\if{html}{\out{<sub>}}0\if{html}{\out{</sub>}} + \emph{b}\if{html}{\out{<sub>}}0\emph{i}\if{html}{\out{</sub>}}) + \emph{β}\if{html}{\out{<sub>}}1\if{html}{\out{</sub>}}\emph{x}\if{html}{\out{<sub>}}\emph{i}1\if{html}{\out{</sub>}}
 
 where \emph{i} denotes the \code{i}th independent experimental unit
 (e.g. subject). When the model has seen subject \code{i}, it can use that

--- a/man/details_poisson_reg_glmnet.Rd
+++ b/man/details_poisson_reg_glmnet.Rd
@@ -28,8 +28,7 @@ see \link{glmnet-details}.
 
 \subsection{Translation from parsnip to the original package}{
 
-There is a parsnip extension package required to fit this model to this
-mode: \strong{poissonreg}.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(poissonreg)
+The \strong{poissonreg} extension package is required to fit this model.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(poissonreg)
 
 poisson_reg(penalty = double(1), mixture = double(1)) \%>\% 
   set_engine("glmnet") \%>\% 
@@ -52,8 +51,8 @@ poisson_reg(penalty = double(1), mixture = double(1)) \%>\%
 
 Factor/categorical predictors need to be converted to numeric values
 (e.g., dummy or indicator variables) for this engine. When using the
-formula method via \code{\link[=fit.model_spec]{fit.model_spec()}},
-parsnip will convert factor columns to indicators.
+formula method via \code{\link[=fit.model_spec]{fit()}}, parsnip
+will convert factor columns to indicators.
 
 Predictors should have the same scale. One way to achieve this is to
 center and scale each so that each predictor has mean zero and a

--- a/man/details_poisson_reg_hurdle.Rd
+++ b/man/details_poisson_reg_hurdle.Rd
@@ -17,8 +17,7 @@ This engine has no tuning parameters.
 
 \subsection{Translation from parsnip to the underlying model call (regression)}{
 
-There is a parsnip extension package required to fit this model to this
-mode: \strong{poissonreg}.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(poissonreg)
+The \strong{poissonreg} extension package is required to fit this model.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(poissonreg)
 
 poisson_reg() \%>\%
   set_engine("hurdle") \%>\%
@@ -36,8 +35,8 @@ poisson_reg() \%>\%
 
 Factor/categorical predictors need to be converted to numeric values
 (e.g., dummy or indicator variables) for this engine. When using the
-formula method via \code{\link[=fit.model_spec]{fit.model_spec()}},
-parsnip will convert factor columns to indicators.
+formula method via \code{\link[=fit.model_spec]{fit()}}, parsnip
+will convert factor columns to indicators.
 
 For this particular model, a special formula is used to specify which
 columns affect the counts and which affect the model for the probability

--- a/man/details_poisson_reg_stan.Rd
+++ b/man/details_poisson_reg_stan.Rd
@@ -39,8 +39,7 @@ and other options.
 
 \subsection{Translation from parsnip to the original package}{
 
-There is a parsnip extension package required to fit this model to this
-mode: \strong{poissonreg}.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(poissonreg)
+The \strong{poissonreg} extension package is required to fit this model.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(poissonreg)
 
 poisson_reg() \%>\% 
   set_engine("stan") \%>\% 
@@ -62,8 +61,8 @@ process. Change this value in \code{set_engine()} to show the MCMC logs.
 
 Factor/categorical predictors need to be converted to numeric values
 (e.g., dummy or indicator variables) for this engine. When using the
-formula method via \code{\link[=fit.model_spec]{fit.model_spec()}},
-parsnip will convert factor columns to indicators.
+formula method via \code{\link[=fit.model_spec]{fit()}}, parsnip
+will convert factor columns to indicators.
 }
 
 \subsection{Other details}{

--- a/man/details_poisson_reg_stan_glmer.Rd
+++ b/man/details_poisson_reg_stan_glmer.Rd
@@ -36,8 +36,7 @@ See \code{?rstanarm::stan_glmer} and \code{?rstan::sampling} for more informatio
 
 \subsection{Translation from parsnip to the original package}{
 
-There is a parsnip extension package required to fit this model to this
-mode: \strong{multilevelmod}.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(multilevelmod)
+The \strong{multilevelmod} extension package is required to fit this model.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(multilevelmod)
 
 poisson_reg(engine = "stan_glmer") \%>\% 
   set_engine("stan_glmer") \%>\% 
@@ -58,7 +57,7 @@ This model can use subject-specific coefficient estimates to make
 predictions (i.e. partial pooling). For example, this equation shows the
 linear predictor (\emph{η}) for a random intercept:
 
-\emph{η}\if{html}{\out{<sub>}}\emph{i}\if{html}{\out{</sub>}} = (\emph{β}\if{html}{\out{<sub>}}0\if{html}{\out{</sub>}}+\emph{b}\if{html}{\out{<sub>}}0\emph{i}\if{html}{\out{</sub>}}) + \emph{β}\if{html}{\out{<sub>}}1\if{html}{\out{</sub>}}\emph{x}\if{html}{\out{<sub>}}\emph{i}1\if{html}{\out{</sub>}}
+\emph{η}\if{html}{\out{<sub>}}\emph{i}\if{html}{\out{</sub>}} = (\emph{β}\if{html}{\out{<sub>}}0\if{html}{\out{</sub>}} + \emph{b}\if{html}{\out{<sub>}}0\emph{i}\if{html}{\out{</sub>}}) + \emph{β}\if{html}{\out{<sub>}}1\if{html}{\out{</sub>}}\emph{x}\if{html}{\out{<sub>}}\emph{i}1\if{html}{\out{</sub>}}
 
 where \emph{i} denotes the \code{i}th independent experimental unit
 (e.g. subject). When the model has seen subject \code{i}, it can use that

--- a/man/details_poisson_reg_zeroinfl.Rd
+++ b/man/details_poisson_reg_zeroinfl.Rd
@@ -17,8 +17,7 @@ This engine has no tuning parameters.
 
 \subsection{Translation from parsnip to the underlying model call (regression)}{
 
-There is a parsnip extension package required to fit this model to this
-mode: \strong{poissonreg}.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(poissonreg)
+The \strong{poissonreg} extension package is required to fit this model.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(poissonreg)
 
 poisson_reg() \%>\%
   set_engine("zeroinfl") \%>\%
@@ -37,8 +36,8 @@ poisson_reg() \%>\%
 
 Factor/categorical predictors need to be converted to numeric values
 (e.g., dummy or indicator variables) for this engine. When using the
-formula method via \code{\link[=fit.model_spec]{fit.model_spec()}},
-parsnip will convert factor columns to indicators.
+formula method via \code{\link[=fit.model_spec]{fit()}}, parsnip
+will convert factor columns to indicators.
 
 For this particular model, a special formula is used to specify which
 columns affect the counts and which affect the model for the probability

--- a/man/details_proportional_hazards_glmnet.Rd
+++ b/man/details_proportional_hazards_glmnet.Rd
@@ -27,8 +27,7 @@ see \link{glmnet-details}.
 
 \subsection{Translation from parsnip to the original package}{
 
-There is a parsnip extension package required to fit this model to this
-mode: \strong{censored}.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(censored)
+The \strong{censored} extension package is required to fit this model.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(censored)
 
 proportional_hazards(penalty = double(1), mixture = double(1)) \%>\% 
   set_engine("glmnet") \%>\% 
@@ -51,8 +50,8 @@ proportional_hazards(penalty = double(1), mixture = double(1)) \%>\%
 
 Factor/categorical predictors need to be converted to numeric values
 (e.g., dummy or indicator variables) for this engine. When using the
-formula method via \code{\link[=fit.model_spec]{fit.model_spec()}},
-parsnip will convert factor columns to indicators.
+formula method via \code{\link[=fit.model_spec]{fit()}}, parsnip
+will convert factor columns to indicators.
 
 Predictors should have the same scale. One way to achieve this is to
 center and scale each so that each predictor has mean zero and a

--- a/man/details_proportional_hazards_survival.Rd
+++ b/man/details_proportional_hazards_survival.Rd
@@ -15,8 +15,7 @@ This model has no tuning parameters.
 
 \subsection{Translation from parsnip to the original package}{
 
-There is a parsnip extension package required to fit this model to this
-mode: \strong{censored}.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(censored)
+The \strong{censored} extension package is required to fit this model.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(censored)
 
 proportional_hazards() \%>\% 
   set_engine("survival") \%>\% 

--- a/man/details_rand_forest_party.Rd
+++ b/man/details_rand_forest_party.Rd
@@ -22,8 +22,7 @@ This model has 3 tuning parameters:
 
 \subsection{Translation from parsnip to the original package (censored regression)}{
 
-There is a parsnip extension package required to fit this model to this
-mode: \strong{censored}.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(censored)
+The \strong{censored} extension package is required to fit this model.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(censored)
 
 rand_forest() \%>\% 
   set_engine("party") \%>\% 

--- a/man/details_rule_fit_xrf.Rd
+++ b/man/details_rule_fit_xrf.Rd
@@ -30,8 +30,7 @@ default: 1.0)
 
 \subsection{Translation from parsnip to the underlying model call (regression)}{
 
-There is a parsnip extension package required to fit this model to this
-mode: \strong{rules}.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(rules)
+The \strong{rules} extension package is required to fit this model.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(rules)
 
 rule_fit(
   mtry = numeric(1),
@@ -70,8 +69,7 @@ rule_fit(
 
 \subsection{Translation from parsnip to the underlying model call (classification)}{
 
-There is a parsnip extension package required to fit this model to this
-mode: \strong{rules}.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(rules)
+The \strong{rules} extension package is required to fit this model.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(rules)
 
 rule_fit(
   mtry = numeric(1),
@@ -133,8 +131,8 @@ whereas \strong{xrf} uses an internal 5-fold cross-validation to determine it
 
 Factor/categorical predictors need to be converted to numeric values
 (e.g., dummy or indicator variables) for this engine. When using the
-formula method via \code{\link[=fit.model_spec]{fit.model_spec()}},
-parsnip will convert factor columns to indicators.
+formula method via \code{\link[=fit.model_spec]{fit()}}, parsnip
+will convert factor columns to indicators.
 }
 
 \subsection{References}{

--- a/man/details_survival_reg_flexsurv.Rd
+++ b/man/details_survival_reg_flexsurv.Rd
@@ -18,8 +18,7 @@ This model has 1 tuning parameters:
 
 \subsection{Translation from parsnip to the original package}{
 
-There is a parsnip extension package required to fit this model to this
-mode: \strong{censored}.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(censored)
+The \strong{censored} extension package is required to fit this model.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(censored)
 
 survival_reg(dist = character(1)) \%>\% 
   set_engine("flexsurv") \%>\% 

--- a/man/details_survival_reg_survival.Rd
+++ b/man/details_survival_reg_survival.Rd
@@ -18,8 +18,7 @@ This model has 1 tuning parameters:
 
 \subsection{Translation from parsnip to the original package}{
 
-There is a parsnip extension package required to fit this model to this
-mode: \strong{censored}.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(censored)
+The \strong{censored} extension package is required to fit this model.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(censored)
 
 survival_reg(dist = character(1)) \%>\% 
   set_engine("survival") \%>\% 

--- a/man/details_svm_linear_LiblineaR.Rd
+++ b/man/details_svm_linear_LiblineaR.Rd
@@ -76,8 +76,8 @@ class predictions (e.g., accuracy).
 
 Factor/categorical predictors need to be converted to numeric values
 (e.g., dummy or indicator variables) for this engine. When using the
-formula method via \code{\link[=fit.model_spec]{fit.model_spec()}},
-parsnip will convert factor columns to indicators.
+formula method via \code{\link[=fit.model_spec]{fit()}}, parsnip
+will convert factor columns to indicators.
 
 Predictors should have the same scale. One way to achieve this is to
 center and scale each so that each predictor has mean zero and a

--- a/man/details_svm_linear_kernlab.Rd
+++ b/man/details_svm_linear_kernlab.Rd
@@ -73,8 +73,8 @@ by R’s random number stream.
 
 Factor/categorical predictors need to be converted to numeric values
 (e.g., dummy or indicator variables) for this engine. When using the
-formula method via \code{\link[=fit.model_spec]{fit.model_spec()}},
-parsnip will convert factor columns to indicators.
+formula method via \code{\link[=fit.model_spec]{fit()}}, parsnip
+will convert factor columns to indicators.
 
 Predictors should have the same scale. One way to achieve this is to
 center and scale each so that each predictor has mean zero and a

--- a/man/details_svm_poly_kernlab.Rd
+++ b/man/details_svm_poly_kernlab.Rd
@@ -85,8 +85,8 @@ by R’s random number stream.
 
 Factor/categorical predictors need to be converted to numeric values
 (e.g., dummy or indicator variables) for this engine. When using the
-formula method via \code{\link[=fit.model_spec]{fit.model_spec()}},
-parsnip will convert factor columns to indicators.
+formula method via \code{\link[=fit.model_spec]{fit()}}, parsnip
+will convert factor columns to indicators.
 
 Predictors should have the same scale. One way to achieve this is to
 center and scale each so that each predictor has mean zero and a

--- a/man/details_svm_rbf_kernlab.Rd
+++ b/man/details_svm_rbf_kernlab.Rd
@@ -85,8 +85,8 @@ by R’s random number stream.
 
 Factor/categorical predictors need to be converted to numeric values
 (e.g., dummy or indicator variables) for this engine. When using the
-formula method via \code{\link[=fit.model_spec]{fit.model_spec()}},
-parsnip will convert factor columns to indicators.
+formula method via \code{\link[=fit.model_spec]{fit()}}, parsnip
+will convert factor columns to indicators.
 
 Predictors should have the same scale. One way to achieve this is to
 center and scale each so that each predictor has mean zero and a

--- a/man/rmd/C5_rules_C5.0.md
+++ b/man/rmd/C5_rules_C5.0.md
@@ -15,7 +15,7 @@ Note that C5.0 has a tool for _early stopping_ during boosting where less iterat
 
 ## Translation from parsnip to the underlying model call  (classification)
 
-There is a parsnip extension package required to fit this model to this mode: **rules**.
+The **rules** extension package is required to fit this model.
 
 
 ```r

--- a/man/rmd/aaa.Rmd
+++ b/man/rmd/aaa.Rmd
@@ -127,13 +127,14 @@ uses_extension <- function(mod, eng, mod_mode) {
     purrr::pluck("pkg")
   
   num_ext <- length(exts)
+  if (num_ext > 1) {
+    rlang::abort(c("There are more than one extension packages for:",
+                   mod, eng, mod_mode))
+  }
   if (num_ext > 0) {
-    res <- paste0("**", exts, "**", collapse = ", ")
-    x <-
-      ifelse(num_ext > 1,
-             "There are parsnip extension packages ",
-             "There is a parsnip extension package ")
-    res <- paste0(x, "required to fit this model to this mode: ", res, ".")
+    res <- paste0("The **", 
+                  exts, 
+                  "** extension package is required to fit this model.")
   } else {
     res <- ""
   }

--- a/man/rmd/bag_mars_earth.md
+++ b/man/rmd/bag_mars_earth.md
@@ -19,7 +19,7 @@ The default value of `num_terms` depends on the number of predictor columns. For
 
 ## Translation from parsnip to the original package (regression)
 
-There is a parsnip extension package required to fit this model to this mode: **baguette**.
+The **baguette** extension package is required to fit this model.
 
 
 ```r
@@ -47,7 +47,7 @@ bag_mars(num_terms = integer(1), prod_degree = integer(1), prune_method = charac
 
 ## Translation from parsnip to the original package (classification)
 
-There is a parsnip extension package required to fit this model to this mode: **baguette**.
+The **baguette** extension package is required to fit this model.
 
 
 ```r
@@ -82,7 +82,7 @@ bag_mars(
 ## Preprocessing requirements
 
 
-Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit.model_spec()}}, parsnip will convert factor columns to indicators.
+Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit()}}, parsnip will convert factor columns to indicators.
 
 ## References
 

--- a/man/rmd/bag_tree_C5.0.md
+++ b/man/rmd/bag_tree_C5.0.md
@@ -13,7 +13,7 @@ This model has 1 tuning parameters:
 
 ## Translation from parsnip to the original package (classification)
 
-There is a parsnip extension package required to fit this model to this mode: **baguette**.
+The **baguette** extension package is required to fit this model.
 
 
 ```r

--- a/man/rmd/bag_tree_rpart.md
+++ b/man/rmd/bag_tree_rpart.md
@@ -22,7 +22,7 @@ For the `class_cost` parameter, the value can be a non-negative scalar for a cla
 
 ## Translation from parsnip to the original package (classification)
 
-There is a parsnip extension package required to fit this model to this mode: **baguette**.
+The **baguette** extension package is required to fit this model.
 
 
 ```r
@@ -53,7 +53,7 @@ bag_tree(tree_depth = integer(1), min_n = integer(1), cost_complexity = double(1
 
 ## Translation from parsnip to the original package (regression)
 
-There is a parsnip extension package required to fit this model to this mode: **baguette**.
+The **baguette** extension package is required to fit this model.
 
 
 ```r
@@ -83,7 +83,7 @@ bag_tree(tree_depth = integer(1), min_n = integer(1), cost_complexity = double(1
 
 ## Translation from parsnip to the original package (censored regression)
 
-There is a parsnip extension package required to fit this model to this mode: **censored**.
+The **censored** extension package is required to fit this model.
 
 
 ```r

--- a/man/rmd/bart_dbarts.md
+++ b/man/rmd/bart_dbarts.md
@@ -103,7 +103,7 @@ bart(
 ## Preprocessing requirements
 
 
-Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit.model_spec()}}, parsnip will convert factor columns to indicators.
+Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit()}}, parsnip will convert factor columns to indicators.
 
 [dbarts::bart()] will also convert the factors to indicators if the user does not create them first. 
 

--- a/man/rmd/boost_tree_mboost.md
+++ b/man/rmd/boost_tree_mboost.md
@@ -23,7 +23,7 @@ The `mtry` parameter is related to the number of predictors. The default is to u
 
 ## Translation from parsnip to the original package (censored regression)
 
-There is a parsnip extension package required to fit this model to this mode: **censored**.
+The **censored** extension package is required to fit this model.
 
 
 ```r

--- a/man/rmd/cubist_rules_Cubist.md
+++ b/man/rmd/cubist_rules_Cubist.md
@@ -18,7 +18,7 @@ This model has 3 tuning parameters:
 
 ## Translation from parsnip to the underlying model call  (regression)
 
-There is a parsnip extension package required to fit this model to this mode: **rules**.
+The **rules** extension package is required to fit this model.
 
 
 ```r
@@ -46,8 +46,7 @@ cubist_rules(
 ## 
 ## Model fit template:
 ## rules::cubist_fit(x = missing_arg(), y = missing_arg(), weights = missing_arg(), 
-##     committees = integer(1), neighbors = integer(1), max_rules = integer(1), 
-##     composite = TRUE)
+##     committees = integer(1), neighbors = integer(1), max_rules = integer(1))
 ```
 
 ## Preprocessing requirements

--- a/man/rmd/decision_tree_party.md
+++ b/man/rmd/decision_tree_party.md
@@ -21,7 +21,7 @@ An engine-specific parameter for this model is:
 
 ## Translation from parsnip to the original package (censored regression)
 
-There is a parsnip extension package required to fit this model to this mode: **censored**.
+The **censored** extension package is required to fit this model.
 
 
 ```r

--- a/man/rmd/decision_tree_rpart.md
+++ b/man/rmd/decision_tree_rpart.md
@@ -71,7 +71,7 @@ decision_tree(tree_depth = integer(1), min_n = integer(1), cost_complexity = dou
 
 ## Translation from parsnip to the original package (censored regression)
 
-There is a parsnip extension package required to fit this model to this mode: **censored**.
+The **censored** extension package is required to fit this model.
 
 
 ```r

--- a/man/rmd/discrim_flexible_earth.md
+++ b/man/rmd/discrim_flexible_earth.md
@@ -19,7 +19,7 @@ The default value of `num_terms` depends on the number of columns (`p`): `min(20
 
 ## Translation from parsnip to the original package
 
-There is a parsnip extension package required to fit this model to this mode: **discrim**.
+The **discrim** extension package is required to fit this model.
 
 
 ```r
@@ -51,7 +51,7 @@ discrim_flexible(
 ## Preprocessing requirements
 
 
-Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit.model_spec()}}, parsnip will convert factor columns to indicators.
+Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit()}}, parsnip will convert factor columns to indicators.
 
 
 ## References

--- a/man/rmd/discrim_linear_MASS.md
+++ b/man/rmd/discrim_linear_MASS.md
@@ -9,7 +9,7 @@ This engine has no tuning parameters.
 
 ## Translation from parsnip to the original package
 
-There is a parsnip extension package required to fit this model to this mode: **discrim**.
+The **discrim** extension package is required to fit this model.
 
 
 ```r
@@ -32,7 +32,7 @@ discrim_linear() %>%
 ## Preprocessing requirements
 
 
-Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit.model_spec()}}, parsnip will convert factor columns to indicators.
+Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit()}}, parsnip will convert factor columns to indicators.
 
 
 Variance calculations are used in these computations so _zero-variance_ predictors (i.e., with a single unique value) should be eliminated before fitting the model. 

--- a/man/rmd/discrim_linear_mda.md
+++ b/man/rmd/discrim_linear_mda.md
@@ -14,7 +14,7 @@ This model has 1 tuning parameter:
 
 ## Translation from parsnip to the original package
 
-There is a parsnip extension package required to fit this model to this mode: **discrim**.
+The **discrim** extension package is required to fit this model.
 
 
 ```r
@@ -41,7 +41,7 @@ discrim_linear(penalty = numeric(0)) %>%
 ## Preprocessing requirements
 
 
-Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit.model_spec()}}, parsnip will convert factor columns to indicators.
+Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit()}}, parsnip will convert factor columns to indicators.
 
 
 Variance calculations are used in these computations so _zero-variance_ predictors (i.e., with a single unique value) should be eliminated before fitting the model. 

--- a/man/rmd/discrim_linear_sda.md
+++ b/man/rmd/discrim_linear_sda.md
@@ -19,7 +19,7 @@ However, there are a few engine-specific parameters that can be set or optimized
 
 ## Translation from parsnip to the original package
 
-There is a parsnip extension package required to fit this model to this mode: **discrim**.
+The **discrim** extension package is required to fit this model.
 
 
 ```r
@@ -42,7 +42,7 @@ discrim_linear() %>%
 ## Preprocessing requirements
 
 
-Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit.model_spec()}}, parsnip will convert factor columns to indicators.
+Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit()}}, parsnip will convert factor columns to indicators.
 
 
 Variance calculations are used in these computations so _zero-variance_ predictors (i.e., with a single unique value) should be eliminated before fitting the model. 

--- a/man/rmd/discrim_linear_sparsediscrim.md
+++ b/man/rmd/discrim_linear_sparsediscrim.md
@@ -20,7 +20,7 @@ The possible values of this parameter, and the functions that they execute, are:
 
 ## Translation from parsnip to the original package
 
-There is a parsnip extension package required to fit this model to this mode: **discrim**.
+The **discrim** extension package is required to fit this model.
 
 
 ```r
@@ -47,7 +47,7 @@ discrim_linear(regularization_method = character(0)) %>%
 ## Preprocessing requirements
 
 
-Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit.model_spec()}}, parsnip will convert factor columns to indicators.
+Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit()}}, parsnip will convert factor columns to indicators.
 
 
 Variance calculations are used in these computations so _zero-variance_ predictors (i.e., with a single unique value) should be eliminated before fitting the model. 

--- a/man/rmd/discrim_quad_MASS.md
+++ b/man/rmd/discrim_quad_MASS.md
@@ -9,7 +9,7 @@ This engine has no tuning parameters.
 
 ## Translation from parsnip to the original package
 
-There is a parsnip extension package required to fit this model to this mode: **discrim**.
+The **discrim** extension package is required to fit this model.
 
 
 ```r
@@ -32,7 +32,7 @@ discrim_quad() %>%
 ## Preprocessing requirements
 
 
-Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit.model_spec()}}, parsnip will convert factor columns to indicators.
+Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit()}}, parsnip will convert factor columns to indicators.
 
 
 Variance calculations are used in these computations within each outcome class. For this reason,  _zero-variance_ predictors (i.e., with a single unique value) within each class should be eliminated before fitting the model. 

--- a/man/rmd/discrim_quad_sparsediscrim.md
+++ b/man/rmd/discrim_quad_sparsediscrim.md
@@ -19,7 +19,7 @@ The possible values of this parameter, and the functions that they execute, are:
 
 ## Translation from parsnip to the original package
 
-There is a parsnip extension package required to fit this model to this mode: **discrim**.
+The **discrim** extension package is required to fit this model.
 
 
 ```r
@@ -46,7 +46,7 @@ discrim_quad(regularization_method = character(0)) %>%
 ## Preprocessing requirements
 
 
-Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit.model_spec()}}, parsnip will convert factor columns to indicators.
+Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit()}}, parsnip will convert factor columns to indicators.
 
 
 Variance calculations are used in these computations within each outcome class. For this reason,  _zero-variance_ predictors (i.e., with a single unique value) within each class should be eliminated before fitting the model. 

--- a/man/rmd/discrim_regularized_klaR.md
+++ b/man/rmd/discrim_regularized_klaR.md
@@ -24,7 +24,7 @@ Some special cases for the RDA model:
 
 ## Translation from parsnip to the original package
 
-There is a parsnip extension package required to fit this model to this mode: **discrim**.
+The **discrim** extension package is required to fit this model.
 
 
 ```r
@@ -52,7 +52,7 @@ discrim_regularized(frac_identity = numeric(0), frac_common_cov = numeric(0)) %>
 ## Preprocessing requirements
 
 
-Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit.model_spec()}}, parsnip will convert factor columns to indicators.
+Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit()}}, parsnip will convert factor columns to indicators.
 
 
 Variance calculations are used in these computations within each outcome class. For this reason,  _zero-variance_ predictors (i.e., with a single unique value) within each class should be eliminated before fitting the model. 

--- a/man/rmd/gen_additive_mod_mgcv.md
+++ b/man/rmd/gen_additive_mod_mgcv.md
@@ -98,7 +98,7 @@ The smoothness of the terms will need to be manually specified (e.g., using `s(x
 ## Preprocessing requirements
 
 
-Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit.model_spec()}}, parsnip will convert factor columns to indicators.
+Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit()}}, parsnip will convert factor columns to indicators.
 
 ## References
 

--- a/man/rmd/linear_reg_brulee.md
+++ b/man/rmd/linear_reg_brulee.md
@@ -51,7 +51,7 @@ linear_reg(penalty = double(1)) %>%
 ## Preprocessing requirements
 
 
-Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit.model_spec()}}, parsnip will convert factor columns to indicators.
+Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit()}}, parsnip will convert factor columns to indicators.
 
 
 Predictors should have the same scale. One way to achieve this is to center and 

--- a/man/rmd/linear_reg_gee.Rmd
+++ b/man/rmd/linear_reg_gee.Rmd
@@ -64,8 +64,8 @@ gee_wflow <-
 
 fit(gee_wflow, data = warpbreaks)
 ```
-
-The `gee::gee()` function always prints out warnings and output even when `silent = TRUE`. The parsnip "gee" engine, by contrast, silences all console output coming from `gee::gee()`, even if `silent = FALSE`.
+```{r child = "template-gee-silent.Rmd"}
+```
 
 Also, because of issues with the `gee()` function, a supplementary call to `glm()` is needed to get the rank and QR decomposition objects so that `predict()` can be used.
 

--- a/man/rmd/linear_reg_gee.md
+++ b/man/rmd/linear_reg_gee.md
@@ -9,7 +9,7 @@ This model has no formal tuning parameters. It may be beneficial to determine th
 
 ## Translation from parsnip to the original package
 
-There is a parsnip extension package required to fit this model to this mode: **multilevelmod**.
+The **multilevelmod** extension package is required to fit this model.
 
 
 ```r

--- a/man/rmd/linear_reg_gee.md
+++ b/man/rmd/linear_reg_gee.md
@@ -76,7 +76,7 @@ gee_wflow <-
 fit(gee_wflow, data = warpbreaks)
 ```
 
-The `gee::gee()` function always prints out warnings and output even when `silent = TRUE`. The parsnip "gee" engine, by contrast, silences all console output coming from `gee::gee()`, even if `silent = FALSE`.
+The `gee::gee()` function always prints out warnings and output even when `silent = TRUE`. The parsnip `"gee"` engine, by contrast, silences all console output coming from `gee::gee()`, even if `silent = FALSE`.
 
 Also, because of issues with the `gee()` function, a supplementary call to `glm()` is needed to get the rank and QR decomposition objects so that `predict()` can be used.
 

--- a/man/rmd/linear_reg_glm.md
+++ b/man/rmd/linear_reg_glm.md
@@ -51,7 +51,7 @@ linear_reg() %>%
 ## Preprocessing requirements
 
 
-Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit.model_spec()}}, parsnip will convert factor columns to indicators.
+Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit()}}, parsnip will convert factor columns to indicators.
 
 ## Examples 
 

--- a/man/rmd/linear_reg_glmnet.md
+++ b/man/rmd/linear_reg_glmnet.md
@@ -43,7 +43,7 @@ linear_reg(penalty = double(1), mixture = double(1)) %>%
 ## Preprocessing requirements
 
 
-Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit.model_spec()}}, parsnip will convert factor columns to indicators.
+Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit()}}, parsnip will convert factor columns to indicators.
 
 
 Predictors should have the same scale. One way to achieve this is to center and 

--- a/man/rmd/linear_reg_gls.md
+++ b/man/rmd/linear_reg_gls.md
@@ -9,7 +9,7 @@ This model has no tuning parameters.
 
 ## Translation from parsnip to the original package
 
-There is a parsnip extension package required to fit this model to this mode: **multilevelmod**.
+The **multilevelmod** extension package is required to fit this model.
 
 
 ```r

--- a/man/rmd/linear_reg_keras.md
+++ b/man/rmd/linear_reg_keras.md
@@ -40,7 +40,7 @@ linear_reg(penalty = double(1)) %>%
 ## Preprocessing requirements
 
 
-Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit.model_spec()}}, parsnip will convert factor columns to indicators.
+Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit()}}, parsnip will convert factor columns to indicators.
 
 
 Predictors should have the same scale. One way to achieve this is to center and 

--- a/man/rmd/linear_reg_lm.md
+++ b/man/rmd/linear_reg_lm.md
@@ -28,7 +28,7 @@ linear_reg() %>%
 ## Preprocessing requirements
 
 
-Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit.model_spec()}}, parsnip will convert factor columns to indicators.
+Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit()}}, parsnip will convert factor columns to indicators.
 
 ## Examples 
 

--- a/man/rmd/linear_reg_lme.md
+++ b/man/rmd/linear_reg_lme.md
@@ -9,7 +9,7 @@ This model has no tuning parameters.
 
 ## Translation from parsnip to the original package
 
-There is a parsnip extension package required to fit this model to this mode: **multilevelmod**.
+The **multilevelmod** extension package is required to fit this model.
 
 
 ```r

--- a/man/rmd/linear_reg_lmer.md
+++ b/man/rmd/linear_reg_lmer.md
@@ -9,7 +9,7 @@ This model has no tuning parameters.
 
 ## Translation from parsnip to the original package
 
-There is a parsnip extension package required to fit this model to this mode: **multilevelmod**.
+The **multilevelmod** extension package is required to fit this model.
 
 
 ```r

--- a/man/rmd/linear_reg_spark.md
+++ b/man/rmd/linear_reg_spark.md
@@ -43,7 +43,7 @@ linear_reg(penalty = double(1), mixture = double(1)) %>%
 ## Preprocessing requirements
 
 
-Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit.model_spec()}}, parsnip will convert factor columns to indicators.
+Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit()}}, parsnip will convert factor columns to indicators.
 
 
 Predictors should have the same scale. One way to achieve this is to center and 

--- a/man/rmd/linear_reg_stan.md
+++ b/man/rmd/linear_reg_stan.md
@@ -44,7 +44,7 @@ Note that the `refresh` default prevents logging of the estimation process. Chan
 ## Preprocessing requirements
 
 
-Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit.model_spec()}}, parsnip will convert factor columns to indicators.
+Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit()}}, parsnip will convert factor columns to indicators.
 
 ## Other details
 

--- a/man/rmd/linear_reg_stan_glmer.md
+++ b/man/rmd/linear_reg_stan_glmer.md
@@ -22,7 +22,7 @@ See `?rstanarm::stan_glmer` and `?rstan::sampling` for more information.
 
 ## Translation from parsnip to the original package
 
-There is a parsnip extension package required to fit this model to this mode: **multilevelmod**.
+The **multilevelmod** extension package is required to fit this model.
 
 
 ```r

--- a/man/rmd/logistic_reg_LiblineaR.md
+++ b/man/rmd/logistic_reg_LiblineaR.md
@@ -43,7 +43,7 @@ logistic_reg(penalty = double(1), mixture = double(1)) %>%
 ## Preprocessing requirements
 
 
-Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit.model_spec()}}, parsnip will convert factor columns to indicators.
+Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit()}}, parsnip will convert factor columns to indicators.
 
 
 Predictors should have the same scale. One way to achieve this is to center and 

--- a/man/rmd/logistic_reg_brulee.md
+++ b/man/rmd/logistic_reg_brulee.md
@@ -50,7 +50,7 @@ logistic_reg(penalty = double(1)) %>%
 
 
 
-Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit.model_spec()}}, parsnip will convert factor columns to indicators.
+Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit()}}, parsnip will convert factor columns to indicators.
 
 
 Predictors should have the same scale. One way to achieve this is to center and 

--- a/man/rmd/logistic_reg_gee.Rmd
+++ b/man/rmd/logistic_reg_gee.Rmd
@@ -64,8 +64,8 @@ gee_wflow <-
 
 fit(gee_wflow, data = toenail)
 ```
-
-The `gee::gee()` function always prints out warnings and output even when `silent = TRUE`. The parsnip "gee" engine, by contrast, silences all console output coming from `gee::gee()`, even if `silent = FALSE`.
+```{r child = "template-gee-silent.Rmd"}
+```
 
 Also, because of issues with the `gee()` function, a supplementary call to `glm()` is needed to get the rank and QR decomposition objects so that `predict()` can be used.
 

--- a/man/rmd/logistic_reg_gee.md
+++ b/man/rmd/logistic_reg_gee.md
@@ -9,7 +9,7 @@ This model has no formal tuning parameters. It may be beneficial to determine th
 
 ## Translation from parsnip to the original package
 
-There is a parsnip extension package required to fit this model to this mode: **multilevelmod**.
+The **multilevelmod** extension package is required to fit this model.
 
 
 ```r

--- a/man/rmd/logistic_reg_gee.md
+++ b/man/rmd/logistic_reg_gee.md
@@ -76,7 +76,7 @@ gee_wflow <-
 fit(gee_wflow, data = toenail)
 ```
 
-The `gee::gee()` function always prints out warnings and output even when `silent = TRUE`. The parsnip "gee" engine, by contrast, silences all console output coming from `gee::gee()`, even if `silent = FALSE`.
+The `gee::gee()` function always prints out warnings and output even when `silent = TRUE`. The parsnip `"gee"` engine, by contrast, silences all console output coming from `gee::gee()`, even if `silent = FALSE`.
 
 Also, because of issues with the `gee()` function, a supplementary call to `glm()` is needed to get the rank and QR decomposition objects so that `predict()` can be used.
 

--- a/man/rmd/logistic_reg_glm.md
+++ b/man/rmd/logistic_reg_glm.md
@@ -51,7 +51,7 @@ linear_reg() %>%
 ## Preprocessing requirements
 
 
-Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit.model_spec()}}, parsnip will convert factor columns to indicators.
+Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit()}}, parsnip will convert factor columns to indicators.
 
 ## Examples 
 

--- a/man/rmd/logistic_reg_glmer.md
+++ b/man/rmd/logistic_reg_glmer.md
@@ -9,7 +9,7 @@ This model has no tuning parameters.
 
 ## Translation from parsnip to the original package
 
-There is a parsnip extension package required to fit this model to this mode: **multilevelmod**.
+The **multilevelmod** extension package is required to fit this model.
 
 
 ```r

--- a/man/rmd/logistic_reg_glmnet.md
+++ b/man/rmd/logistic_reg_glmnet.md
@@ -43,7 +43,7 @@ logistic_reg(penalty = double(1), mixture = double(1)) %>%
 ## Preprocessing requirements
 
 
-Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit.model_spec()}}, parsnip will convert factor columns to indicators.
+Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit()}}, parsnip will convert factor columns to indicators.
 
 
 Predictors should have the same scale. One way to achieve this is to center and 

--- a/man/rmd/logistic_reg_keras.md
+++ b/man/rmd/logistic_reg_keras.md
@@ -40,7 +40,7 @@ logistic_reg(penalty = double(1)) %>%
 ## Preprocessing requirements
 
 
-Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit.model_spec()}}, parsnip will convert factor columns to indicators.
+Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit()}}, parsnip will convert factor columns to indicators.
 
 
 Predictors should have the same scale. One way to achieve this is to center and 

--- a/man/rmd/logistic_reg_spark.md
+++ b/man/rmd/logistic_reg_spark.md
@@ -44,7 +44,7 @@ logistic_reg(penalty = double(1), mixture = double(1)) %>%
 ## Preprocessing requirements
 
 
-Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit.model_spec()}}, parsnip will convert factor columns to indicators.
+Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit()}}, parsnip will convert factor columns to indicators.
 
 
 Predictors should have the same scale. One way to achieve this is to center and 

--- a/man/rmd/logistic_reg_stan.md
+++ b/man/rmd/logistic_reg_stan.md
@@ -44,7 +44,7 @@ Note that the `refresh` default prevents logging of the estimation process. Chan
 ## Preprocessing requirements
 
 
-Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit.model_spec()}}, parsnip will convert factor columns to indicators.
+Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit()}}, parsnip will convert factor columns to indicators.
 
 ## Other details
 

--- a/man/rmd/logistic_reg_stan_glmer.md
+++ b/man/rmd/logistic_reg_stan_glmer.md
@@ -22,7 +22,7 @@ See `?rstanarm::stan_glmer` and `?rstan::sampling` for more information.
 
 ## Translation from parsnip to the original package
 
-There is a parsnip extension package required to fit this model to this mode: **multilevelmod**.
+The **multilevelmod** extension package is required to fit this model.
 
 
 ```r

--- a/man/rmd/mars_earth.md
+++ b/man/rmd/mars_earth.md
@@ -78,7 +78,7 @@ An alternate method for using MARs for categorical outcomes can be found in [dis
 ## Preprocessing requirements
 
 
-Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit.model_spec()}}, parsnip will convert factor columns to indicators.
+Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit()}}, parsnip will convert factor columns to indicators.
 
 ## Examples 
 

--- a/man/rmd/mlp_brulee.md
+++ b/man/rmd/mlp_brulee.md
@@ -113,7 +113,7 @@ mlp(
 ## Preprocessing requirements
 
 
-Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit.model_spec()}}, parsnip will convert factor columns to indicators.
+Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit()}}, parsnip will convert factor columns to indicators.
 
 
 Predictors should have the same scale. One way to achieve this is to center and 

--- a/man/rmd/mlp_keras.md
+++ b/man/rmd/mlp_keras.md
@@ -91,7 +91,7 @@ mlp(
 ## Preprocessing requirements
 
 
-Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit.model_spec()}}, parsnip will convert factor columns to indicators.
+Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit()}}, parsnip will convert factor columns to indicators.
 
 
 Predictors should have the same scale. One way to achieve this is to center and 

--- a/man/rmd/mlp_nnet.md
+++ b/man/rmd/mlp_nnet.md
@@ -84,7 +84,7 @@ mlp(
 ## Preprocessing requirements
 
 
-Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit.model_spec()}}, parsnip will convert factor columns to indicators.
+Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit()}}, parsnip will convert factor columns to indicators.
 
 
 Predictors should have the same scale. One way to achieve this is to center and 

--- a/man/rmd/multinom_reg_brulee.md
+++ b/man/rmd/multinom_reg_brulee.md
@@ -50,7 +50,7 @@ multinom_reg(penalty = double(1)) %>%
 
 
 
-Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit.model_spec()}}, parsnip will convert factor columns to indicators.
+Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit()}}, parsnip will convert factor columns to indicators.
 
 
 Predictors should have the same scale. One way to achieve this is to center and 

--- a/man/rmd/multinom_reg_glmnet.md
+++ b/man/rmd/multinom_reg_glmnet.md
@@ -43,7 +43,7 @@ multinom_reg(penalty = double(1), mixture = double(1)) %>%
 ## Preprocessing requirements
 
 
-Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit.model_spec()}}, parsnip will convert factor columns to indicators.
+Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit()}}, parsnip will convert factor columns to indicators.
 
 
 Predictors should have the same scale. One way to achieve this is to center and 

--- a/man/rmd/multinom_reg_keras.md
+++ b/man/rmd/multinom_reg_keras.md
@@ -40,7 +40,7 @@ multinom_reg(penalty = double(1)) %>%
 ## Preprocessing requirements
 
 
-Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit.model_spec()}}, parsnip will convert factor columns to indicators.
+Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit()}}, parsnip will convert factor columns to indicators.
 
 
 Predictors should have the same scale. One way to achieve this is to center and 

--- a/man/rmd/multinom_reg_nnet.md
+++ b/man/rmd/multinom_reg_nnet.md
@@ -38,7 +38,7 @@ multinom_reg(penalty = double(1)) %>%
 ## Preprocessing requirements
 
 
-Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit.model_spec()}}, parsnip will convert factor columns to indicators.
+Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit()}}, parsnip will convert factor columns to indicators.
 
 
 Predictors should have the same scale. One way to achieve this is to center and 

--- a/man/rmd/multinom_reg_spark.md
+++ b/man/rmd/multinom_reg_spark.md
@@ -44,7 +44,7 @@ multinom_reg(penalty = double(1), mixture = double(1)) %>%
 ## Preprocessing requirements
 
 
-Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit.model_spec()}}, parsnip will convert factor columns to indicators.
+Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit()}}, parsnip will convert factor columns to indicators.
 
 
 Predictors should have the same scale. One way to achieve this is to center and 

--- a/man/rmd/naive_Bayes_klaR.md
+++ b/man/rmd/naive_Bayes_klaR.md
@@ -18,7 +18,7 @@ Note that `usekernel` is always set to `TRUE` for the `klaR` engine.
 
 ## Translation from parsnip to the original package
 
-There is a parsnip extension package required to fit this model to this mode: **discrim**.
+The **discrim** extension package is required to fit this model.
 
 
 ```r

--- a/man/rmd/naive_Bayes_naivebayes.md
+++ b/man/rmd/naive_Bayes_naivebayes.md
@@ -16,7 +16,7 @@ This model has 2 tuning parameter:
 
 ## Translation from parsnip to the original package
 
-There is a parsnip extension package required to fit this model to this mode: **discrim**.
+The **discrim** extension package is required to fit this model.
 
 
 ```r

--- a/man/rmd/nearest_neighbor_kknn.md
+++ b/man/rmd/nearest_neighbor_kknn.md
@@ -78,7 +78,7 @@ nearest_neighbor(
 ## Preprocessing requirements
 
 
-Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit.model_spec()}}, parsnip will convert factor columns to indicators.
+Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit()}}, parsnip will convert factor columns to indicators.
 
 
 Predictors should have the same scale. One way to achieve this is to center and 

--- a/man/rmd/pls_mixOmics.md
+++ b/man/rmd/pls_mixOmics.md
@@ -16,7 +16,7 @@ This model has 2 tuning parameters:
 
 ## Translation from parsnip to the underlying model call  (regression)
 
-There is a parsnip extension package required to fit this model to this mode: **plsmod**.
+The **plsmod** extension package is required to fit this model.
 
 
 ```r
@@ -51,7 +51,7 @@ pls(num_comp = integer(1), predictor_prop = double(1)) %>%
 
 ## Translation from parsnip to the underlying model call  (classification)
 
-There is a parsnip extension package required to fit this model to this mode: **plsmod**.
+The **plsmod** extension package is required to fit this model.
 
 
 ```r
@@ -82,7 +82,7 @@ In this case, [plsmod::pls_fit()] has the same role as above but eventually targ
 ## Preprocessing requirements
 
 
-Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit.model_spec()}}, parsnip will convert factor columns to indicators.
+Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit()}}, parsnip will convert factor columns to indicators.
 
 
 Variance calculations are used in these computations so _zero-variance_ predictors (i.e., with a single unique value) should be eliminated before fitting the model. 

--- a/man/rmd/poisson_reg_gee.Rmd
+++ b/man/rmd/poisson_reg_gee.Rmd
@@ -63,8 +63,8 @@ gee_wflow <-
 
 fit(gee_wflow, data = longitudinal_counts)
 ```
-
-`gee()` always prints out warnings and output even when `silent = TRUE`. When using the `gee` engine, it will never produce output, even if `silent = FALSE`.
+```{r child = "template-gee-silent.Rmd"}
+```
 
 Also, because of issues with the `gee()` function, a supplementary call to `glm()` is needed to get the rank and QR decomposition objects so that `predict()` can be used.
 

--- a/man/rmd/poisson_reg_gee.md
+++ b/man/rmd/poisson_reg_gee.md
@@ -9,7 +9,7 @@ This model has no formal tuning parameters. It may be beneficial to determine th
 
 ## Translation from parsnip to the original package
 
-There is a parsnip extension package required to fit this model to this mode: **multilevelmod**.
+The **multilevelmod** extension package is required to fit this model.
 
 
 ```r

--- a/man/rmd/poisson_reg_gee.md
+++ b/man/rmd/poisson_reg_gee.md
@@ -75,7 +75,7 @@ gee_wflow <-
 fit(gee_wflow, data = longitudinal_counts)
 ```
 
-`gee()` always prints out warnings and output even when `silent = TRUE`. When using the `gee` engine, it will never produce output, even if `silent = FALSE`.
+The `gee::gee()` function always prints out warnings and output even when `silent = TRUE`. The parsnip `"gee"` engine, by contrast, silences all console output coming from `gee::gee()`, even if `silent = FALSE`.
 
 Also, because of issues with the `gee()` function, a supplementary call to `glm()` is needed to get the rank and QR decomposition objects so that `predict()` can be used.
 

--- a/man/rmd/poisson_reg_glm.md
+++ b/man/rmd/poisson_reg_glm.md
@@ -9,7 +9,7 @@ This engine has no tuning parameters.
 
 ## Translation from parsnip to the underlying model call  (regression)
 
-There is a parsnip extension package required to fit this model to this mode: **poissonreg**.
+The **poissonreg** extension package is required to fit this model.
 
 
 ```r
@@ -33,6 +33,6 @@ poisson_reg() %>%
 ## Preprocessing requirements
 
 
-Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit.model_spec()}}, parsnip will convert factor columns to indicators.
+Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit()}}, parsnip will convert factor columns to indicators.
 
 

--- a/man/rmd/poisson_reg_glmer.md
+++ b/man/rmd/poisson_reg_glmer.md
@@ -9,7 +9,7 @@ This model has no tuning parameters.
 
 ## Translation from parsnip to the original package
 
-There is a parsnip extension package required to fit this model to this mode: **multilevelmod**.
+The **multilevelmod** extension package is required to fit this model.
 
 
 ```r

--- a/man/rmd/poisson_reg_glmnet.md
+++ b/man/rmd/poisson_reg_glmnet.md
@@ -19,7 +19,7 @@ The `penalty` parameter has no default and requires a single numeric value. For 
 
 ## Translation from parsnip to the original package
 
-There is a parsnip extension package required to fit this model to this mode: **poissonreg**.
+The **poissonreg** extension package is required to fit this model.
 
 
 ```r
@@ -47,7 +47,7 @@ poisson_reg(penalty = double(1), mixture = double(1)) %>%
 ## Preprocessing requirements
 
 
-Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit.model_spec()}}, parsnip will convert factor columns to indicators.
+Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit()}}, parsnip will convert factor columns to indicators.
 
 
 Predictors should have the same scale. One way to achieve this is to center and 

--- a/man/rmd/poisson_reg_hurdle.md
+++ b/man/rmd/poisson_reg_hurdle.md
@@ -9,7 +9,7 @@ This engine has no tuning parameters.
 
 ## Translation from parsnip to the underlying model call  (regression)
 
-There is a parsnip extension package required to fit this model to this mode: **poissonreg**.
+The **poissonreg** extension package is required to fit this model.
 
 
 ```r
@@ -32,7 +32,7 @@ poisson_reg() %>%
 ## Preprocessing and special formulas for zero-inflated Poisson models
 
 
-Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit.model_spec()}}, parsnip will convert factor columns to indicators.
+Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit()}}, parsnip will convert factor columns to indicators.
 
 For this particular model, a special formula is used to specify which columns affect the counts and which affect the model for the probability of zero counts. These sets of terms are separated by a bar. For example, `y ~ x | z`. This type of formula is not used by the base R infrastructure (e.g. `model.matrix()`)
 

--- a/man/rmd/poisson_reg_stan.md
+++ b/man/rmd/poisson_reg_stan.md
@@ -22,7 +22,7 @@ See [rstan::sampling()] and [rstanarm::priors()] for more information on these a
 
 ## Translation from parsnip to the original package
 
-There is a parsnip extension package required to fit this model to this mode: **poissonreg**.
+The **poissonreg** extension package is required to fit this model.
 
 
 ```r
@@ -48,7 +48,7 @@ Note that the `refresh` default prevents logging of the estimation process. Chan
 ## Preprocessing requirements
 
 
-Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit.model_spec()}}, parsnip will convert factor columns to indicators.
+Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit()}}, parsnip will convert factor columns to indicators.
 
 ## Other details
 

--- a/man/rmd/poisson_reg_stan_glmer.md
+++ b/man/rmd/poisson_reg_stan_glmer.md
@@ -22,7 +22,7 @@ See `?rstanarm::stan_glmer` and `?rstan::sampling` for more information.
 
 ## Translation from parsnip to the original package
 
-There is a parsnip extension package required to fit this model to this mode: **multilevelmod**.
+The **multilevelmod** extension package is required to fit this model.
 
 
 ```r

--- a/man/rmd/poisson_reg_zeroinfl.md
+++ b/man/rmd/poisson_reg_zeroinfl.md
@@ -9,7 +9,7 @@ This engine has no tuning parameters.
 
 ## Translation from parsnip to the underlying model call  (regression)
 
-There is a parsnip extension package required to fit this model to this mode: **poissonreg**.
+The **poissonreg** extension package is required to fit this model.
 
 
 ```r
@@ -33,7 +33,7 @@ poisson_reg() %>%
 ## Preprocessing and special formulas for zero-inflated Poisson models
 
 
-Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit.model_spec()}}, parsnip will convert factor columns to indicators.
+Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit()}}, parsnip will convert factor columns to indicators.
 
 For this particular model, a special formula is used to specify which columns affect the counts and which affect the model for the probability of zero counts. These sets of terms are separated by a bar. For example, `y ~ x | z`. This type of formula is not used by the base R infrastructure (e.g. `model.matrix()`)
 

--- a/man/rmd/proportional_hazards_glmnet.md
+++ b/man/rmd/proportional_hazards_glmnet.md
@@ -19,7 +19,7 @@ The `penalty` parameter has no default and requires a single numeric value. For 
 
 ## Translation from parsnip to the original package
 
-There is a parsnip extension package required to fit this model to this mode: **censored**.
+The **censored** extension package is required to fit this model.
 
 
 ```r
@@ -47,7 +47,7 @@ proportional_hazards(penalty = double(1), mixture = double(1)) %>%
 ## Preprocessing requirements
 
 
-Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit.model_spec()}}, parsnip will convert factor columns to indicators.
+Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit()}}, parsnip will convert factor columns to indicators.
 
 
 Predictors should have the same scale. One way to achieve this is to center and 

--- a/man/rmd/proportional_hazards_survival.md
+++ b/man/rmd/proportional_hazards_survival.md
@@ -9,7 +9,7 @@ This model has no tuning parameters.
 
 ## Translation from parsnip to the original package
 
-There is a parsnip extension package required to fit this model to this mode: **censored**.
+The **censored** extension package is required to fit this model.
 
 
 ```r

--- a/man/rmd/rand_forest_party.md
+++ b/man/rmd/rand_forest_party.md
@@ -17,7 +17,7 @@ This model has 3 tuning parameters:
 
 ## Translation from parsnip to the original package (censored regression)
 
-There is a parsnip extension package required to fit this model to this mode: **censored**.
+The **censored** extension package is required to fit this model.
 
 
 ```r

--- a/man/rmd/rule_fit_xrf.md
+++ b/man/rmd/rule_fit_xrf.md
@@ -28,7 +28,7 @@ This model has 8 tuning parameters:
 
 ## Translation from parsnip to the underlying model call  (regression)
 
-There is a parsnip extension package required to fit this model to this mode: **rules**.
+The **rules** extension package is required to fit this model.
 
 
 ```r
@@ -73,7 +73,7 @@ rule_fit(
 
 ## Translation from parsnip to the underlying model call  (classification)
 
-There is a parsnip extension package required to fit this model to this mode: **rules**.
+The **rules** extension package is required to fit this model.
 
 
 
@@ -135,7 +135,7 @@ These differences will create a disparity in the values of the `penalty` argumen
 ## Preprocessing requirements
 
 
-Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit.model_spec()}}, parsnip will convert factor columns to indicators.
+Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit()}}, parsnip will convert factor columns to indicators.
 
 ## References
 

--- a/man/rmd/survival_reg_flexsurv.md
+++ b/man/rmd/survival_reg_flexsurv.md
@@ -13,7 +13,7 @@ This model has 1 tuning parameters:
 
 ## Translation from parsnip to the original package
 
-There is a parsnip extension package required to fit this model to this mode: **censored**.
+The **censored** extension package is required to fit this model.
 
 
 ```r

--- a/man/rmd/survival_reg_survival.md
+++ b/man/rmd/survival_reg_survival.md
@@ -13,7 +13,7 @@ This model has 1 tuning parameters:
 
 ## Translation from parsnip to the original package
 
-There is a parsnip extension package required to fit this model to this mode: **censored**.
+The **censored** extension package is required to fit this model.
 
 
 ```r

--- a/man/rmd/svm_linear_LiblineaR.md
+++ b/man/rmd/svm_linear_LiblineaR.md
@@ -74,7 +74,7 @@ Note that the `LiblineaR` engine does not produce class probabilities. When opti
 ## Preprocessing requirements
 
 
-Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit.model_spec()}}, parsnip will convert factor columns to indicators.
+Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit()}}, parsnip will convert factor columns to indicators.
 
 
 Predictors should have the same scale. One way to achieve this is to center and 

--- a/man/rmd/svm_linear_kernlab.md
+++ b/man/rmd/svm_linear_kernlab.md
@@ -72,7 +72,7 @@ Note that the `"kernlab"` engine does not naturally estimate class probabilities
 ## Preprocessing requirements
 
 
-Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit.model_spec()}}, parsnip will convert factor columns to indicators.
+Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit()}}, parsnip will convert factor columns to indicators.
 
 
 Predictors should have the same scale. One way to achieve this is to center and 

--- a/man/rmd/svm_poly_kernlab.md
+++ b/man/rmd/svm_poly_kernlab.md
@@ -86,7 +86,7 @@ Note that the `"kernlab"` engine does not naturally estimate class probabilities
 ## Preprocessing requirements
 
 
-Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit.model_spec()}}, parsnip will convert factor columns to indicators.
+Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit()}}, parsnip will convert factor columns to indicators.
 
 
 Predictors should have the same scale. One way to achieve this is to center and 

--- a/man/rmd/svm_rbf_kernlab.md
+++ b/man/rmd/svm_rbf_kernlab.md
@@ -80,7 +80,7 @@ Note that the `"kernlab"` engine does not naturally estimate class probabilities
 ## Preprocessing requirements
 
 
-Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit.model_spec()}}, parsnip will convert factor columns to indicators.
+Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit()}}, parsnip will convert factor columns to indicators.
 
 
 Predictors should have the same scale. One way to achieve this is to center and 

--- a/man/rmd/template-gee-silent.Rmd
+++ b/man/rmd/template-gee-silent.Rmd
@@ -1,0 +1,1 @@
+The `gee::gee()` function always prints out warnings and output even when `silent = TRUE`. The parsnip `"gee"` engine, by contrast, silences all console output coming from `gee::gee()`, even if `silent = FALSE`.

--- a/man/rmd/template-makes-dummies.Rmd
+++ b/man/rmd/template-makes-dummies.Rmd
@@ -1,1 +1,1 @@
-Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit.model_spec()}}, parsnip will convert factor columns to indicators.
+Factor/categorical predictors need to be converted to numeric values (e.g., dummy or indicator variables) for this engine. When using the formula method via \\code{\\link[=fit.model_spec]{fit()}}, parsnip will convert factor columns to indicators.


### PR DESCRIPTION
Closes #648 

This PR clarifies discussion in the `"gee"` engine and changes the wording on "details" pages to be like:

> The **multilevelmod** extension package is required to fit this model.

I don't see how any of those docs could end up with multiple engines at the "**Translation from parsnip to the original package**" section, but I did add an error in case it does, so we can fix things in the future if needed.