### PR TITLE
Add release bullet about `knit_engine_docs()`

### DIFF
--- a/R/aaa.R
+++ b/R/aaa.R
@@ -96,4 +96,8 @@ utils::globalVariables(
    )
 )
 
+release_bullets <- function() {
+  c("Run `knit_engine_docs()` and `devtools::document()` to update docs")
+}
+
 # nocov end


### PR DESCRIPTION
Closes #645 

This will add a bullet [when we do `usethis::use_release_issue()`](https://usethis.r-lib.org/reference/use_release_issue.html).