### PR TITLE
Refactor `make_engine_list()` to refine docs

### DIFF
--- a/R/engine_docs.R
+++ b/R/engine_docs.R
@@ -234,7 +234,8 @@ make_engine_list <- function(mod) {
         dplyr::filter(has_ext != "") %>%
         dplyr::pull(mode) %>%
         unique() %>%
-        knitr::combine_words(and = " and ")
+        sort() %>%
+        knitr::combine_words()
       notes <- paste0(
         notes, " ",
         cli::symbol$sup_2, " Requires a parsnip extension package for ",

--- a/man-roxygen/spec-details.R
+++ b/man-roxygen/spec-details.R
@@ -2,5 +2,5 @@
 #' This function only defines what _type_ of model is being fit. Once an engine
 #'  is specified, the _method_ to fit the model is also defined.
 #'
-#' The model is not trained or fit until the [fit.model_spec()] function is used
+#' The model is not trained or fit until the [`fit()`][fit.model_spec()] function is used
 #' with the data.

--- a/man/C5_rules.Rd
+++ b/man/C5_rules.Rd
@@ -41,7 +41,7 @@ iteration of boosting.
 This function only defines what \emph{type} of model is being fit. Once an engine
 is specified, the \emph{method} to fit the model is also defined.
 
-The model is not trained or fit until the \code{\link[=fit.model_spec]{fit.model_spec()}} function is used
+The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.
 }
 \examples{

--- a/man/bag_mars.Rd
+++ b/man/bag_mars.Rd
@@ -42,7 +42,7 @@ More information on how \pkg{parsnip} is used for modeling is at
 This function only defines what \emph{type} of model is being fit. Once an engine
 is specified, the \emph{method} to fit the model is also defined.
 
-The model is not trained or fit until the \code{\link[=fit.model_spec]{fit.model_spec()}} function is used
+The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.
 }
 \references{

--- a/man/bag_tree.Rd
+++ b/man/bag_tree.Rd
@@ -47,7 +47,7 @@ More information on how \pkg{parsnip} is used for modeling is at
 This function only defines what \emph{type} of model is being fit. Once an engine
 is specified, the \emph{method} to fit the model is also defined.
 
-The model is not trained or fit until the \code{\link[=fit.model_spec]{fit.model_spec()}} function is used
+The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.
 }
 \references{

--- a/man/bart.Rd
+++ b/man/bart.Rd
@@ -61,7 +61,7 @@ terminal node for different values of these parameters.
 This function only defines what \emph{type} of model is being fit. Once an engine
 is specified, the \emph{method} to fit the model is also defined.
 
-The model is not trained or fit until the \code{\link[=fit.model_spec]{fit.model_spec()}} function is used
+The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.
 }
 \examples{

--- a/man/boost_tree.Rd
+++ b/man/boost_tree.Rd
@@ -66,7 +66,7 @@ More information on how \pkg{parsnip} is used for modeling is at
 This function only defines what \emph{type} of model is being fit. Once an engine
 is specified, the \emph{method} to fit the model is also defined.
 
-The model is not trained or fit until the \code{\link[=fit.model_spec]{fit.model_spec()}} function is used
+The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.
 }
 \examples{

--- a/man/cubist_rules.Rd
+++ b/man/cubist_rules.Rd
@@ -72,7 +72,7 @@ to the distance to the neighbor.
 This function only defines what \emph{type} of model is being fit. Once an engine
 is specified, the \emph{method} to fit the model is also defined.
 
-The model is not trained or fit until the \code{\link[=fit.model_spec]{fit.model_spec()}} function is used
+The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.
 }
 \references{

--- a/man/decision_tree.Rd
+++ b/man/decision_tree.Rd
@@ -42,7 +42,7 @@ More information on how \pkg{parsnip} is used for modeling is at
 This function only defines what \emph{type} of model is being fit. Once an engine
 is specified, the \emph{method} to fit the model is also defined.
 
-The model is not trained or fit until the \code{\link[=fit.model_spec]{fit.model_spec()}} function is used
+The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.
 }
 \examples{

--- a/man/discrim_flexible.Rd
+++ b/man/discrim_flexible.Rd
@@ -41,7 +41,7 @@ More information on how \pkg{parsnip} is used for modeling is at
 This function only defines what \emph{type} of model is being fit. Once an engine
 is specified, the \emph{method} to fit the model is also defined.
 
-The model is not trained or fit until the \code{\link[=fit.model_spec]{fit.model_spec()}} function is used
+The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.
 }
 \references{

--- a/man/discrim_linear.Rd
+++ b/man/discrim_linear.Rd
@@ -41,7 +41,7 @@ More information on how \pkg{parsnip} is used for modeling is at
 This function only defines what \emph{type} of model is being fit. Once an engine
 is specified, the \emph{method} to fit the model is also defined.
 
-The model is not trained or fit until the \code{\link[=fit.model_spec]{fit.model_spec()}} function is used
+The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.
 }
 \references{

--- a/man/discrim_quad.Rd
+++ b/man/discrim_quad.Rd
@@ -37,7 +37,7 @@ More information on how \pkg{parsnip} is used for modeling is at
 This function only defines what \emph{type} of model is being fit. Once an engine
 is specified, the \emph{method} to fit the model is also defined.
 
-The model is not trained or fit until the \code{\link[=fit.model_spec]{fit.model_spec()}} function is used
+The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.
 }
 \references{

--- a/man/discrim_regularized.Rd
+++ b/man/discrim_regularized.Rd
@@ -52,7 +52,7 @@ used. Other regularization methods can be used with \code{\link[=discrim_linear]
 This function only defines what \emph{type} of model is being fit. Once an engine
 is specified, the \emph{method} to fit the model is also defined.
 
-The model is not trained or fit until the \code{\link[=fit.model_spec]{fit.model_spec()}} function is used
+The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.
 }
 \references{

--- a/man/gen_additive_mod.Rd
+++ b/man/gen_additive_mod.Rd
@@ -40,7 +40,7 @@ More information on how \pkg{parsnip} is used for modeling is at
 This function only defines what \emph{type} of model is being fit. Once an engine
 is specified, the \emph{method} to fit the model is also defined.
 
-The model is not trained or fit until the \code{\link[=fit.model_spec]{fit.model_spec()}} function is used
+The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.
 }
 \examples{

--- a/man/linear_reg.Rd
+++ b/man/linear_reg.Rd
@@ -35,7 +35,7 @@ More information on how \pkg{parsnip} is used for modeling is at
 This function only defines what \emph{type} of model is being fit. Once an engine
 is specified, the \emph{method} to fit the model is also defined.
 
-The model is not trained or fit until the \code{\link[=fit.model_spec]{fit.model_spec()}} function is used
+The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.
 }
 \examples{

--- a/man/logistic_reg.Rd
+++ b/man/logistic_reg.Rd
@@ -45,7 +45,7 @@ More information on how \pkg{parsnip} is used for modeling is at
 This function only defines what \emph{type} of model is being fit. Once an engine
 is specified, the \emph{method} to fit the model is also defined.
 
-The model is not trained or fit until the \code{\link[=fit.model_spec]{fit.model_spec()}} function is used
+The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.
 
 This model fits a classification model for binary outcomes; for

--- a/man/mars.Rd
+++ b/man/mars.Rd
@@ -42,7 +42,7 @@ More information on how \pkg{parsnip} is used for modeling is at
 This function only defines what \emph{type} of model is being fit. Once an engine
 is specified, the \emph{method} to fit the model is also defined.
 
-The model is not trained or fit until the \code{\link[=fit.model_spec]{fit.model_spec()}} function is used
+The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.
 }
 \examples{

--- a/man/mlp.Rd
+++ b/man/mlp.Rd
@@ -56,7 +56,7 @@ More information on how \pkg{parsnip} is used for modeling is at
 This function only defines what \emph{type} of model is being fit. Once an engine
 is specified, the \emph{method} to fit the model is also defined.
 
-The model is not trained or fit until the \code{\link[=fit.model_spec]{fit.model_spec()}} function is used
+The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.
 }
 \examples{

--- a/man/multinom_reg.Rd
+++ b/man/multinom_reg.Rd
@@ -44,7 +44,7 @@ More information on how \pkg{parsnip} is used for modeling is at
 This function only defines what \emph{type} of model is being fit. Once an engine
 is specified, the \emph{method} to fit the model is also defined.
 
-The model is not trained or fit until the \code{\link[=fit.model_spec]{fit.model_spec()}} function is used
+The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.
 
 This model fits a classification model for multiclass outcomes; for

--- a/man/naive_Bayes.Rd
+++ b/man/naive_Bayes.Rd
@@ -41,7 +41,7 @@ More information on how \pkg{parsnip} is used for modeling is at
 This function only defines what \emph{type} of model is being fit. Once an engine
 is specified, the \emph{method} to fit the model is also defined.
 
-The model is not trained or fit until the \code{\link[=fit.model_spec]{fit.model_spec()}} function is used
+The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.
 }
 \references{

--- a/man/nearest_neighbor.Rd
+++ b/man/nearest_neighbor.Rd
@@ -46,7 +46,7 @@ More information on how \pkg{parsnip} is used for modeling is at
 This function only defines what \emph{type} of model is being fit. Once an engine
 is specified, the \emph{method} to fit the model is also defined.
 
-The model is not trained or fit until the \code{\link[=fit.model_spec]{fit.model_spec()}} function is used
+The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.
 }
 \examples{

--- a/man/pls.Rd
+++ b/man/pls.Rd
@@ -39,7 +39,7 @@ More information on how \pkg{parsnip} is used for modeling is at
 This function only defines what \emph{type} of model is being fit. Once an engine
 is specified, the \emph{method} to fit the model is also defined.
 
-The model is not trained or fit until the \code{\link[=fit.model_spec]{fit.model_spec()}} function is used
+The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.
 }
 \references{

--- a/man/poisson_reg.Rd
+++ b/man/poisson_reg.Rd
@@ -39,7 +39,7 @@ More information on how \pkg{parsnip} is used for modeling is at
 This function only defines what \emph{type} of model is being fit. Once an engine
 is specified, the \emph{method} to fit the model is also defined.
 
-The model is not trained or fit until the \code{\link[=fit.model_spec]{fit.model_spec()}} function is used
+The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.
 }
 \references{

--- a/man/proportional_hazards.Rd
+++ b/man/proportional_hazards.Rd
@@ -40,7 +40,7 @@ More information on how \pkg{parsnip} is used for modeling is at
 This function only defines what \emph{type} of model is being fit. Once an engine
 is specified, the \emph{method} to fit the model is also defined.
 
-The model is not trained or fit until the \code{\link[=fit.model_spec]{fit.model_spec()}} function is used
+The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.
 
 Since survival models typically involve censoring (and require the use of

--- a/man/rand_forest.Rd
+++ b/man/rand_forest.Rd
@@ -44,7 +44,7 @@ More information on how \pkg{parsnip} is used for modeling is at
 This function only defines what \emph{type} of model is being fit. Once an engine
 is specified, the \emph{method} to fit the model is also defined.
 
-The model is not trained or fit until the \code{\link[=fit.model_spec]{fit.model_spec()}} function is used
+The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.
 }
 \examples{

--- a/man/rule_fit.Rd
+++ b/man/rule_fit.Rd
@@ -70,7 +70,7 @@ conduct feature selection during model training.
 This function only defines what \emph{type} of model is being fit. Once an engine
 is specified, the \emph{method} to fit the model is also defined.
 
-The model is not trained or fit until the \code{\link[=fit.model_spec]{fit.model_spec()}} function is used
+The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.
 }
 \examples{

--- a/man/surv_reg.Rd
+++ b/man/surv_reg.Rd
@@ -33,7 +33,7 @@ More information on how \pkg{parsnip} is used for modeling is at
 This function only defines what \emph{type} of model is being fit. Once an engine
 is specified, the \emph{method} to fit the model is also defined.
 
-The model is not trained or fit until the \code{\link[=fit.model_spec]{fit.model_spec()}} function is used
+The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.
 
 Since survival models typically involve censoring (and require the use of

--- a/man/survival_reg.Rd
+++ b/man/survival_reg.Rd
@@ -29,7 +29,7 @@ More information on how \pkg{parsnip} is used for modeling is at
 This function only defines what \emph{type} of model is being fit. Once an engine
 is specified, the \emph{method} to fit the model is also defined.
 
-The model is not trained or fit until the \code{\link[=fit.model_spec]{fit.model_spec()}} function is used
+The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.
 
 Since survival models typically involve censoring (and require the use of

--- a/man/svm_linear.Rd
+++ b/man/svm_linear.Rd
@@ -36,7 +36,7 @@ More information on how \pkg{parsnip} is used for modeling is at
 This function only defines what \emph{type} of model is being fit. Once an engine
 is specified, the \emph{method} to fit the model is also defined.
 
-The model is not trained or fit until the \code{\link[=fit.model_spec]{fit.model_spec()}} function is used
+The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.
 }
 \examples{

--- a/man/svm_poly.Rd
+++ b/man/svm_poly.Rd
@@ -48,7 +48,7 @@ More information on how \pkg{parsnip} is used for modeling is at
 This function only defines what \emph{type} of model is being fit. Once an engine
 is specified, the \emph{method} to fit the model is also defined.
 
-The model is not trained or fit until the \code{\link[=fit.model_spec]{fit.model_spec()}} function is used
+The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.
 }
 \examples{

--- a/man/svm_rbf.Rd
+++ b/man/svm_rbf.Rd
@@ -46,7 +46,7 @@ More information on how \pkg{parsnip} is used for modeling is at
 This function only defines what \emph{type} of model is being fit. Once an engine
 is specified, the \emph{method} to fit the model is also defined.
 
-The model is not trained or fit until the \code{\link[=fit.model_spec]{fit.model_spec()}} function is used
+The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.
 }
 \examples{


### PR DESCRIPTION
Closes #649 

After reworking this function a bit, there is more clarity in the note on the engine list.

For `linear_reg()`:

> Requires a parsnip extension package.

For `decision_tree()`:

> Requires a parsnip extension package for censored regression.

For `bag_tree()`:

> Requires a parsnip extension package for censored regression, classification, and regression.