### PR TITLE
Re-registration of model information

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -46,6 +46,10 @@
 
 * xgboost engines now use the new `iterationrange` parameter instead of the deprecated `ntreelimit` (#656).  
 
+## Developer
+
+* Models information can be re-registered as long as the information being registered is the same. This is helpful for packages that add new engines and use `devtools::load_all()` (#653).
+
 
 # parsnip 0.1.7
 

--- a/R/aaa_models.R
+++ b/R/aaa_models.R
@@ -674,12 +674,12 @@ set_dependency <- function(model, eng, pkg = "parsnip", mode = NULL) {
   check_eng_val(eng)
   check_pkg_val(pkg)
 
-  current <- get_model_env()
   model_info <- get_from_env(model)
   pkg_info <- get_from_env(paste0(model, "_pkgs"))
 
   # ----------------------------------------------------------------------------
   # Check engine
+
   has_engine <-
     model_info %>%
     dplyr::distinct(engine) %>%

--- a/R/aaa_models.R
+++ b/R/aaa_models.R
@@ -751,7 +751,7 @@ get_dependency <- function(model) {
 # ------------------------------------------------------------------------------
 
 # This will be used to see if the same information is being registered for the
-# same model/model/engine (and prediction type). If it already exists and the
+# same model/mode/engine (and prediction type). If it already exists and the
 # new information is different, fail with a message. See issue #653
 discordant_info <- function(model, mode, eng, candidate,
                             pred_type = NULL, component = "fit") {
@@ -783,7 +783,7 @@ discordant_info <- function(model, mode, eng, candidate,
   if (!same_info) {
     rlang::abort(
       glue::glue(
-        "The combination of '{eng}' and mode '{mode}' {p_type} already has ",
+        "The combination of engine '{eng}' and mode '{mode}' {p_type} already has ",
         "{component} data for model '{model}' and the new information being ",
         "registered is different."
       )
@@ -828,7 +828,7 @@ check_unregistered <- function(model, mode, eng) {
     nrow()
   if (has_engine != 1) {
     rlang::abort(
-      glue::glue("The combination of '{eng}' and mode '{mode}' has not ",
+      glue::glue("The combination of engine '{eng}' and mode '{mode}' has not ",
                  "been registered for model '{model}'.")
     )
   }

--- a/tests/testthat/test_re_registration.R
+++ b/tests/testthat/test_re_registration.R
@@ -1,0 +1,158 @@
+# For issue #653 we want to be able to re-run the registration code as
+# long as the information being registered is the same.
+
+
+test_that('re-registration of mode', {
+  old_val <- get_from_env("bart_modes")
+  expect_error(set_model_mode("bart", "classification"), regexp = NA)
+  new_val <- get_from_env("bart_modes")
+  expect_equal(old_val, new_val)
+})
+
+test_that('re-registration of engine', {
+  old_val <- get_from_env("bart")
+  expect_error(
+    set_model_engine("bart", mode = "classification", eng = "dbarts"),
+    regexp = NA
+  )
+  new_val <- get_from_env("bart")
+  expect_equal(old_val, new_val)
+})
+
+
+test_that('re-registration of package dependencies', {
+  old_val <- get_from_env("bart_pkgs")
+  expect_error(
+    set_dependency("bart", "dbarts", "dbarts"),
+    regexp = NA
+  )
+  new_val <- get_from_env("bart_pkgs")
+  expect_equal(old_val, new_val)
+})
+
+test_that('re-registration of fit information', {
+  old_val <- get_from_env("bart_fit")
+  expect_error(
+    set_fit(
+      model = "bart",
+      eng = "dbarts",
+      mode = "regression",
+      value = list(
+        interface = "data.frame",
+        data = c(x = "x.train", y = "y.train"),
+        protect = c("x", "y"),
+        func = c(pkg = "dbarts", fun = "bart"),
+        defaults = list(verbose = FALSE, keeptrees = TRUE, keepcall = FALSE)
+      )
+    ),
+    regexp = NA
+  )
+  new_val <- get_from_env("bart_fit")
+  expect_equal(old_val, new_val)
+
+  # Fail if newly registered data is different than existing
+  # `verbose` option is different here
+  expect_error(
+    set_fit(
+      model = "bart",
+      eng = "dbarts",
+      mode = "regression",
+      value = list(
+        interface = "data.frame",
+        data = c(x = "x.train", y = "y.train"),
+        protect = c("x", "y"),
+        func = c(pkg = "dbarts", fun = "bart"),
+        defaults = list(verbose = TRUE, keeptrees = TRUE, keepcall = FALSE)
+      )
+    ),
+    "new information being registered is different"
+  )
+})
+
+test_that('re-registration of encoding information', {
+  old_val <- get_from_env("bart_encoding")
+  expect_error(
+    set_encoding(
+      model = "bart",
+      eng = "dbarts",
+      mode = "regression",
+      options = list(
+        predictor_indicators = "none",
+        compute_intercept = FALSE,
+        remove_intercept = FALSE,
+        allow_sparse_x = FALSE
+      )
+    ),
+    regexp = NA
+  )
+  new_val <- get_from_env("bart_encoding")
+  expect_equal(old_val, new_val)
+
+  # Fail if newly registered data is different than existing
+  # `compute_intercept` option is different here
+  expect_error(
+    set_encoding(
+      model = "bart",
+      eng = "dbarts",
+      mode = "regression",
+      options = list(
+        predictor_indicators = "none",
+        compute_intercept = TRUE,
+        remove_intercept = FALSE,
+        allow_sparse_x = FALSE
+      )
+    ),
+    "new information being registered is different"
+  )
+})
+
+
+test_that('re-registration of prediction information', {
+  old_val <- get_from_env("bart_predict")
+  expect_error(
+    set_pred(
+      model = "bart",
+      eng = "dbarts",
+      mode = "regression",
+      type = "numeric",
+      value = list(
+        pre = NULL,
+        post = NULL,
+        func = c(pkg = "parsnip", fun = "dbart_predict_calc"),
+        args =
+          list(
+            obj = quote(object),
+            new_data =  quote(new_data),
+            type = "numeric"
+          )
+      )
+    ),
+    regexp = NA
+  )
+  new_val <- get_from_env("bart_predict")
+  expect_equal(old_val, new_val)
+
+  # Fail if newly registered data is different than existing
+  # `type` option is different here
+  expect_error(
+    set_pred(
+      model = "bart",
+      eng = "dbarts",
+      mode = "regression",
+      type = "numeric",
+      value = list(
+        pre = NULL,
+        post = NULL,
+        func = c(pkg = "parsnip", fun = "dbart_predict_calc"),
+        args =
+          list(
+            obj = quote(object),
+            new_data =  quote(new_data),
+            type = "tuba"
+          )
+      )
+    ),
+    "new information being registered is different"
+  )
+})
+

--- a/tests/testthat/test_registration.R
+++ b/tests/testthat/test_registration.R
@@ -276,15 +276,6 @@ test_that('adding a new fit', {
     value = fit_vals
   )
 
-  expect_error(
-    set_fit(
-      model = "sponge",
-      eng = "gum",
-      mode = "classification",
-      value = fit_vals
-    )
-  )
-
   fit_env_data <- get_from_env("sponge_fit")
   test_by_col(
     fit_env_data[ 1:2],


### PR DESCRIPTION
Closes #653 

Models components (e.g. fit, pred, etc) can now be re-registered as long as the information is the same. 

One caveat:  package dependencies cannot be check for the same values since those are set one value at a time.  