### PR TITLE
Better `set_engine()` docs

### DIFF
--- a/R/engine_docs.R
+++ b/R/engine_docs.R
@@ -285,33 +285,6 @@ find_details_topics <- function(mod, pkg = "parsnip") {
   unique(res)
 }
 
-# For use in `set_engine()` docs
-generate_set_engine_bullets <- function() {
-  env <- get_model_env()
-  models <- env$models
-  info <- rlang::env_get_list(env, models)
-
-  model_engines <- purrr::map(info, get_sorted_unique_engines)
-
-  model_prefixes <- glue::glue(
-    "\\code{\\link[=.{models}.]{.{models}.()}}:",
-    .open = ".{",
-    .close = "}."
-  )
-
-  bullets <- purrr::map2(
-    .x = model_prefixes,
-    .y = model_engines,
-    .f = combine_prefix_with_engines
-  )
-
-  bullets <- glue::glue("\\item {bullets}")
-  bullets <- glue::glue_collapse(bullets, sep = "\n")
-  bullets <- paste("\\itemize{", bullets, "}", sep = "\n")
-
-  bullets
-}
-
 sort_c <- function(x) {
   withr::with_collate("C", sort(x))
 }

--- a/R/engines.R
+++ b/R/engines.R
@@ -65,6 +65,9 @@ load_libs <- function(x, quiet, attach = FALSE) {
 #' a specific R package implementation or even methods outside of R like Keras
 #' or Stan.
 #'
+#' Use [show_engines()] to get a list of possible engines for the model of
+#' interest.
+#'
 #' Modeling functions in parsnip separate model arguments into two categories:
 #'
 #' - _Main arguments_ are more commonly used and tend to be available across
@@ -136,11 +139,12 @@ set_engine <- function(object, engine, ...) {
 #' Display currently available engines for a model
 #'
 #' The possible engines for a model can depend on what packages are loaded.
-#' Some `parsnip`-adjacent packages add engines to existing models. For example,
-#' the `multilevelmod` package adds additional engines for the [linear_reg()]
-#' model and these are not available unless `multilevelmod` is loaded.
+#' Some \pkg{parsnip} extension add engines to existing models. For example,
+#' the \pkg{poissonreg} package adds additional engines for the [poisson_reg()]
+#' model and these are not available unless \pkg{poissonreg} is loaded.
 #' @param x The name of a `parsnip` model (e.g., "linear_reg", "mars", etc.)
 #' @return A tibble.
+#'
 #' @examples
 #' show_engines("linear_reg")
 #' @export

--- a/R/engines.R
+++ b/R/engines.R
@@ -74,6 +74,15 @@ load_libs <- function(x, quiet, attach = FALSE) {
 #' more rarely. Set these in `set_engine()`, like
 #' `set_engine("ranger", importance = "permutation")`.
 #'
+#' Also, main argument names are _standardized_ to work across all packages.
+#'  For example, for the number of trees in a random forest model, the
+#'  \pkg{parsnip} main argument is `trees`. For the \pkg{ranger} and
+#'  \pkg{randomForest} packages, the argument names are different (`num.trees`
+#'  and `ntree`, respectively).
+#'
+#' Conversely, engine arguments are the same as their package (since they
+#'  are engine-specific).
+#'
 #' @param object A model specification.
 #' @param engine A character string for the software that should
 #'  be used to fit the model. This is highly dependent on the type

--- a/R/engines.R
+++ b/R/engines.R
@@ -54,26 +54,46 @@ load_libs <- function(x, quiet, attach = FALSE) {
 #' `set_engine()` is used to specify which package or system will be used
 #'  to fit the model, along with any arguments specific to that software.
 #'
-#' @section Engines:
-#' Based on the currently loaded packages, the following lists the set of
-#' engines available to each model specification.
+#' @details
+#' In parsnip,
 #'
-#' \Sexpr[stage=render,results=rd]{parsnip:::generate_set_engine_bullets()}
+#' - the model **type** differentiates basic modeling approaches, such as random
+#' forests, logistic regression, linear support vector machines, etc.,
+#' - the **mode** denotes in what kind of modeling context it will be used
+#' (most commonly, classification or regression), and
+#' - the computational **engine** indicates how the model is fit, such as with
+#' a specific R package implementation or even methods outside of R like Keras
+#' or Stan.
+#'
+#' Modeling functions in parsnip separate model arguments into two categories:
+#'
+#' - _Main arguments_ are more commonly used and tend to be available across
+#' engines. Set these in your model type function, like
+#' `rand_forest(trees = 2000)`.
+#' - _Engine arguments_ are either specific to a particular engine or used
+#' more rarely. Set these in `set_engine()`, like
+#' `set_engine("ranger", importance = "permutation")`.
 #'
 #' @param object A model specification.
 #' @param engine A character string for the software that should
 #'  be used to fit the model. This is highly dependent on the type
 #'  of model (e.g. linear regression, random forest, etc.).
 #' @param ... Any optional arguments associated with the chosen computational
-#'  engine. These are captured as quosures and can be `tune()`.
+#'  engine. These are captured as quosures and can be tuned with `tune()`.
 #' @return An updated model specification.
 #' @examples
-#' # First, set general arguments using the standardized names
-#' mod <-
-#'   logistic_reg(penalty = 0.01, mixture = 1/3) %>%
-#'   # now say how you want to fit the model and another other options
-#'   set_engine("glmnet", nlambda = 10)
-#' translate(mod, engine = "glmnet")
+#' # First, set main arguments using the standardized names
+#' logistic_reg(penalty = 0.01, mixture = 1/3) %>%
+#'   # Now specify how you want to fit the model with another argument
+#'   set_engine("glmnet", nlambda = 10) %>%
+#'   translate()
+#'
+#' # Many models have possible engine-specific arguments
+#' decision_tree(tree_depth = 5) %>%
+#'   set_engine("rpart", parms = list(prior = c(.65,.35))) %>%
+#'   set_mode("classification") %>%
+#'   translate()
+#'
 #' @export
 set_engine <- function(object, engine, ...) {
   mod_type <- class(object)[1]

--- a/R/engines.R
+++ b/R/engines.R
@@ -71,20 +71,16 @@ load_libs <- function(x, quiet, attach = FALSE) {
 #' Modeling functions in parsnip separate model arguments into two categories:
 #'
 #' - _Main arguments_ are more commonly used and tend to be available across
-#' engines. Set these in your model type function, like
-#' `rand_forest(trees = 2000)`.
+#' engines. These names are standardized to work with different engines in a
+#' consistent way, so you can use the \pkg{parsnip} main argument `trees`,
+#' instead of the heterogeneous arguments for this parameter from \pkg{ranger}
+#' and  \pkg{randomForest} packages (`num.trees` and `ntree`, respectively). Set
+#' these in your model type function, like `rand_forest(trees = 2000)`.
 #' - _Engine arguments_ are either specific to a particular engine or used
-#' more rarely. Set these in `set_engine()`, like
+#' more rarely; there is no change for these argument names from the underlying
+#' engine. Set these in `set_engine()`, like
 #' `set_engine("ranger", importance = "permutation")`.
 #'
-#' Also, main argument names are _standardized_ to work across all packages.
-#'  For example, for the number of trees in a random forest model, the
-#'  \pkg{parsnip} main argument is `trees`. For the \pkg{ranger} and
-#'  \pkg{randomForest} packages, the argument names are different (`num.trees`
-#'  and `ntree`, respectively).
-#'
-#' Conversely, engine arguments are the same as their package (since they
-#'  are engine-specific).
 #'
 #' @param object A model specification.
 #' @param engine A character string for the software that should

--- a/man-roxygen/spec-details.R
+++ b/man-roxygen/spec-details.R
@@ -1,6 +1,8 @@
 #' @details
 #' This function only defines what _type_ of model is being fit. Once an engine
-#'  is specified, the _method_ to fit the model is also defined.
+#'  is specified, the _method_ to fit the model is also defined. See
+#'  [set_engine()] for more on setting the engine, including how to set engine
+#'  arguments.
 #'
 #' The model is not trained or fit until the [`fit()`][fit.model_spec()] function is used
 #' with the data.

--- a/man/C5_rules.Rd
+++ b/man/C5_rules.Rd
@@ -39,7 +39,9 @@ are pruned, simplified, and ordered. Rule sets are created within each
 iteration of boosting.
 
 This function only defines what \emph{type} of model is being fit. Once an engine
-is specified, the \emph{method} to fit the model is also defined.
+is specified, the \emph{method} to fit the model is also defined. See
+\code{\link[=set_engine]{set_engine()}} for more on setting the engine, including how to set engine
+arguments.
 
 The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.

--- a/man/bag_mars.Rd
+++ b/man/bag_mars.Rd
@@ -40,7 +40,9 @@ More information on how \pkg{parsnip} is used for modeling is at
 }
 \details{
 This function only defines what \emph{type} of model is being fit. Once an engine
-is specified, the \emph{method} to fit the model is also defined.
+is specified, the \emph{method} to fit the model is also defined. See
+\code{\link[=set_engine]{set_engine()}} for more on setting the engine, including how to set engine
+arguments.
 
 The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.

--- a/man/bag_tree.Rd
+++ b/man/bag_tree.Rd
@@ -45,7 +45,9 @@ More information on how \pkg{parsnip} is used for modeling is at
 }
 \details{
 This function only defines what \emph{type} of model is being fit. Once an engine
-is specified, the \emph{method} to fit the model is also defined.
+is specified, the \emph{method} to fit the model is also defined. See
+\code{\link[=set_engine]{set_engine()}} for more on setting the engine, including how to set engine
+arguments.
 
 The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.

--- a/man/bart.Rd
+++ b/man/bart.Rd
@@ -59,7 +59,9 @@ Examples section below for an example graph of the prior probability of a
 terminal node for different values of these parameters.
 
 This function only defines what \emph{type} of model is being fit. Once an engine
-is specified, the \emph{method} to fit the model is also defined.
+is specified, the \emph{method} to fit the model is also defined. See
+\code{\link[=set_engine]{set_engine()}} for more on setting the engine, including how to set engine
+arguments.
 
 The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.

--- a/man/boost_tree.Rd
+++ b/man/boost_tree.Rd
@@ -64,7 +64,9 @@ More information on how \pkg{parsnip} is used for modeling is at
 }
 \details{
 This function only defines what \emph{type} of model is being fit. Once an engine
-is specified, the \emph{method} to fit the model is also defined.
+is specified, the \emph{method} to fit the model is also defined. See
+\code{\link[=set_engine]{set_engine()}} for more on setting the engine, including how to set engine
+arguments.
 
 The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.

--- a/man/cubist_rules.Rd
+++ b/man/cubist_rules.Rd
@@ -70,7 +70,9 @@ where \code{t} is the training set prediction and \code{w} is a weight that is i
 to the distance to the neighbor.
 
 This function only defines what \emph{type} of model is being fit. Once an engine
-is specified, the \emph{method} to fit the model is also defined.
+is specified, the \emph{method} to fit the model is also defined. See
+\code{\link[=set_engine]{set_engine()}} for more on setting the engine, including how to set engine
+arguments.
 
 The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.

--- a/man/decision_tree.Rd
+++ b/man/decision_tree.Rd
@@ -40,7 +40,9 @@ More information on how \pkg{parsnip} is used for modeling is at
 }
 \details{
 This function only defines what \emph{type} of model is being fit. Once an engine
-is specified, the \emph{method} to fit the model is also defined.
+is specified, the \emph{method} to fit the model is also defined. See
+\code{\link[=set_engine]{set_engine()}} for more on setting the engine, including how to set engine
+arguments.
 
 The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.

--- a/man/details_C5_rules_C5.0.Rd
+++ b/man/details_C5_rules_C5.0.Rd
@@ -61,7 +61,7 @@ are not required for this model.
 \item Quinlan R (1992). “Learning with Continuous Classes.” Proceedings of
 the 5th Australian Joint Conference On Artificial Intelligence,
 pp. 343-348.
-\item Quinlan R (1993).”Combining Instance-Based and Model-Based
+\item Quinlan R (1993).“Combining Instance-Based and Model-Based
 Learning.” Proceedings of the Tenth International Conference on
 Machine Learning, pp. 236-243.
 \item Kuhn M and Johnson K (2013). \emph{Applied Predictive Modeling}.

--- a/man/details_C5_rules_C5.0.Rd
+++ b/man/details_C5_rules_C5.0.Rd
@@ -61,7 +61,7 @@ are not required for this model.
 \item Quinlan R (1992). “Learning with Continuous Classes.” Proceedings of
 the 5th Australian Joint Conference On Artificial Intelligence,
 pp. 343-348.
-\item Quinlan R (1993).“Combining Instance-Based and Model-Based
+\item Quinlan R (1993).”Combining Instance-Based and Model-Based
 Learning.” Proceedings of the Tenth International Conference on
 Machine Learning, pp. 236-243.
 \item Kuhn M and Johnson K (2013). \emph{Applied Predictive Modeling}.

--- a/man/details_cubist_rules_Cubist.Rd
+++ b/man/details_cubist_rules_Cubist.Rd
@@ -60,7 +60,7 @@ are not required for this model.
 \item Quinlan R (1992). “Learning with Continuous Classes.” Proceedings of
 the 5th Australian Joint Conference On Artificial Intelligence,
 pp. 343-348.
-\item Quinlan R (1993).”Combining Instance-Based and Model-Based
+\item Quinlan R (1993).“Combining Instance-Based and Model-Based
 Learning.” Proceedings of the Tenth International Conference on
 Machine Learning, pp. 236-243.
 \item Kuhn M and Johnson K (2013). \emph{Applied Predictive Modeling}.

--- a/man/details_cubist_rules_Cubist.Rd
+++ b/man/details_cubist_rules_Cubist.Rd
@@ -60,7 +60,7 @@ are not required for this model.
 \item Quinlan R (1992). “Learning with Continuous Classes.” Proceedings of
 the 5th Australian Joint Conference On Artificial Intelligence,
 pp. 343-348.
-\item Quinlan R (1993).“Combining Instance-Based and Model-Based
+\item Quinlan R (1993).”Combining Instance-Based and Model-Based
 Learning.” Proceedings of the Tenth International Conference on
 Machine Learning, pp. 236-243.
 \item Kuhn M and Johnson K (2013). \emph{Applied Predictive Modeling}.

--- a/man/discrim_flexible.Rd
+++ b/man/discrim_flexible.Rd
@@ -39,7 +39,9 @@ More information on how \pkg{parsnip} is used for modeling is at
 }
 \details{
 This function only defines what \emph{type} of model is being fit. Once an engine
-is specified, the \emph{method} to fit the model is also defined.
+is specified, the \emph{method} to fit the model is also defined. See
+\code{\link[=set_engine]{set_engine()}} for more on setting the engine, including how to set engine
+arguments.
 
 The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.

--- a/man/discrim_linear.Rd
+++ b/man/discrim_linear.Rd
@@ -39,7 +39,9 @@ More information on how \pkg{parsnip} is used for modeling is at
 }
 \details{
 This function only defines what \emph{type} of model is being fit. Once an engine
-is specified, the \emph{method} to fit the model is also defined.
+is specified, the \emph{method} to fit the model is also defined. See
+\code{\link[=set_engine]{set_engine()}} for more on setting the engine, including how to set engine
+arguments.
 
 The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.

--- a/man/discrim_quad.Rd
+++ b/man/discrim_quad.Rd
@@ -35,7 +35,9 @@ More information on how \pkg{parsnip} is used for modeling is at
 }
 \details{
 This function only defines what \emph{type} of model is being fit. Once an engine
-is specified, the \emph{method} to fit the model is also defined.
+is specified, the \emph{method} to fit the model is also defined. See
+\code{\link[=set_engine]{set_engine()}} for more on setting the engine, including how to set engine
+arguments.
 
 The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.

--- a/man/discrim_regularized.Rd
+++ b/man/discrim_regularized.Rd
@@ -50,7 +50,9 @@ used. Other regularization methods can be used with \code{\link[=discrim_linear]
 \code{\link[=discrim_quad]{discrim_quad()}} can used via the \code{sparsediscrim} engine for those functions.
 
 This function only defines what \emph{type} of model is being fit. Once an engine
-is specified, the \emph{method} to fit the model is also defined.
+is specified, the \emph{method} to fit the model is also defined. See
+\code{\link[=set_engine]{set_engine()}} for more on setting the engine, including how to set engine
+arguments.
 
 The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.

--- a/man/gen_additive_mod.Rd
+++ b/man/gen_additive_mod.Rd
@@ -38,7 +38,9 @@ More information on how \pkg{parsnip} is used for modeling is at
 }
 \details{
 This function only defines what \emph{type} of model is being fit. Once an engine
-is specified, the \emph{method} to fit the model is also defined.
+is specified, the \emph{method} to fit the model is also defined. See
+\code{\link[=set_engine]{set_engine()}} for more on setting the engine, including how to set engine
+arguments.
 
 The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.

--- a/man/linear_reg.Rd
+++ b/man/linear_reg.Rd
@@ -33,7 +33,9 @@ More information on how \pkg{parsnip} is used for modeling is at
 }
 \details{
 This function only defines what \emph{type} of model is being fit. Once an engine
-is specified, the \emph{method} to fit the model is also defined.
+is specified, the \emph{method} to fit the model is also defined. See
+\code{\link[=set_engine]{set_engine()}} for more on setting the engine, including how to set engine
+arguments.
 
 The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.

--- a/man/logistic_reg.Rd
+++ b/man/logistic_reg.Rd
@@ -43,7 +43,9 @@ More information on how \pkg{parsnip} is used for modeling is at
 }
 \details{
 This function only defines what \emph{type} of model is being fit. Once an engine
-is specified, the \emph{method} to fit the model is also defined.
+is specified, the \emph{method} to fit the model is also defined. See
+\code{\link[=set_engine]{set_engine()}} for more on setting the engine, including how to set engine
+arguments.
 
 The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.

--- a/man/mars.Rd
+++ b/man/mars.Rd
@@ -40,7 +40,9 @@ More information on how \pkg{parsnip} is used for modeling is at
 }
 \details{
 This function only defines what \emph{type} of model is being fit. Once an engine
-is specified, the \emph{method} to fit the model is also defined.
+is specified, the \emph{method} to fit the model is also defined. See
+\code{\link[=set_engine]{set_engine()}} for more on setting the engine, including how to set engine
+arguments.
 
 The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.

--- a/man/mlp.Rd
+++ b/man/mlp.Rd
@@ -54,7 +54,9 @@ More information on how \pkg{parsnip} is used for modeling is at
 }
 \details{
 This function only defines what \emph{type} of model is being fit. Once an engine
-is specified, the \emph{method} to fit the model is also defined.
+is specified, the \emph{method} to fit the model is also defined. See
+\code{\link[=set_engine]{set_engine()}} for more on setting the engine, including how to set engine
+arguments.
 
 The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.

--- a/man/multinom_reg.Rd
+++ b/man/multinom_reg.Rd
@@ -42,7 +42,9 @@ More information on how \pkg{parsnip} is used for modeling is at
 }
 \details{
 This function only defines what \emph{type} of model is being fit. Once an engine
-is specified, the \emph{method} to fit the model is also defined.
+is specified, the \emph{method} to fit the model is also defined. See
+\code{\link[=set_engine]{set_engine()}} for more on setting the engine, including how to set engine
+arguments.
 
 The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.

--- a/man/naive_Bayes.Rd
+++ b/man/naive_Bayes.Rd
@@ -39,7 +39,9 @@ More information on how \pkg{parsnip} is used for modeling is at
 }
 \details{
 This function only defines what \emph{type} of model is being fit. Once an engine
-is specified, the \emph{method} to fit the model is also defined.
+is specified, the \emph{method} to fit the model is also defined. See
+\code{\link[=set_engine]{set_engine()}} for more on setting the engine, including how to set engine
+arguments.
 
 The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.

--- a/man/nearest_neighbor.Rd
+++ b/man/nearest_neighbor.Rd
@@ -44,7 +44,9 @@ More information on how \pkg{parsnip} is used for modeling is at
 }
 \details{
 This function only defines what \emph{type} of model is being fit. Once an engine
-is specified, the \emph{method} to fit the model is also defined.
+is specified, the \emph{method} to fit the model is also defined. See
+\code{\link[=set_engine]{set_engine()}} for more on setting the engine, including how to set engine
+arguments.
 
 The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.

--- a/man/pls.Rd
+++ b/man/pls.Rd
@@ -37,7 +37,9 @@ More information on how \pkg{parsnip} is used for modeling is at
 }
 \details{
 This function only defines what \emph{type} of model is being fit. Once an engine
-is specified, the \emph{method} to fit the model is also defined.
+is specified, the \emph{method} to fit the model is also defined. See
+\code{\link[=set_engine]{set_engine()}} for more on setting the engine, including how to set engine
+arguments.
 
 The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.

--- a/man/poisson_reg.Rd
+++ b/man/poisson_reg.Rd
@@ -37,7 +37,9 @@ More information on how \pkg{parsnip} is used for modeling is at
 }
 \details{
 This function only defines what \emph{type} of model is being fit. Once an engine
-is specified, the \emph{method} to fit the model is also defined.
+is specified, the \emph{method} to fit the model is also defined. See
+\code{\link[=set_engine]{set_engine()}} for more on setting the engine, including how to set engine
+arguments.
 
 The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.

--- a/man/proportional_hazards.Rd
+++ b/man/proportional_hazards.Rd
@@ -38,7 +38,9 @@ More information on how \pkg{parsnip} is used for modeling is at
 }
 \details{
 This function only defines what \emph{type} of model is being fit. Once an engine
-is specified, the \emph{method} to fit the model is also defined.
+is specified, the \emph{method} to fit the model is also defined. See
+\code{\link[=set_engine]{set_engine()}} for more on setting the engine, including how to set engine
+arguments.
 
 The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.

--- a/man/rand_forest.Rd
+++ b/man/rand_forest.Rd
@@ -42,7 +42,9 @@ More information on how \pkg{parsnip} is used for modeling is at
 }
 \details{
 This function only defines what \emph{type} of model is being fit. Once an engine
-is specified, the \emph{method} to fit the model is also defined.
+is specified, the \emph{method} to fit the model is also defined. See
+\code{\link[=set_engine]{set_engine()}} for more on setting the engine, including how to set engine
+arguments.
 
 The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.

--- a/man/rule_fit.Rd
+++ b/man/rule_fit.Rd
@@ -68,7 +68,9 @@ as predictors to a regularized generalized linear model that can also
 conduct feature selection during model training.
 
 This function only defines what \emph{type} of model is being fit. Once an engine
-is specified, the \emph{method} to fit the model is also defined.
+is specified, the \emph{method} to fit the model is also defined. See
+\code{\link[=set_engine]{set_engine()}} for more on setting the engine, including how to set engine
+arguments.
 
 The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.

--- a/man/set_engine.Rd
+++ b/man/set_engine.Rd
@@ -35,6 +35,9 @@ a specific R package implementation or even methods outside of R like Keras
 or Stan.
 }
 
+Use \code{\link[=show_engines]{show_engines()}} to get a list of possible engines for the model of
+interest.
+
 Modeling functions in parsnip separate model arguments into two categories:
 \itemize{
 \item \emph{Main arguments} are more commonly used and tend to be available across

--- a/man/set_engine.Rd
+++ b/man/set_engine.Rd
@@ -44,6 +44,15 @@ engines. Set these in your model type function, like
 more rarely. Set these in \code{set_engine()}, like
 \code{set_engine("ranger", importance = "permutation")}.
 }
+
+Also, main argument names are \emph{standardized} to work across all packages.
+For example, for the number of trees in a random forest model, the
+\pkg{parsnip} main argument is \code{trees}. For the \pkg{ranger} and
+\pkg{randomForest} packages, the argument names are different (\code{num.trees}
+and \code{ntree}, respectively).
+
+Conversely, engine arguments are the same as their package (since they
+are engine-specific).
 }
 \examples{
 # First, set main arguments using the standardized names

--- a/man/set_engine.Rd
+++ b/man/set_engine.Rd
@@ -41,21 +41,16 @@ interest.
 Modeling functions in parsnip separate model arguments into two categories:
 \itemize{
 \item \emph{Main arguments} are more commonly used and tend to be available across
-engines. Set these in your model type function, like
-\code{rand_forest(trees = 2000)}.
+engines. These names are standardized to work with different engines in a
+consistent way, so you can use the \pkg{parsnip} main argument \code{trees},
+instead of the heterogeneous arguments for this parameter from \pkg{ranger}
+and  \pkg{randomForest} packages (\code{num.trees} and \code{ntree}, respectively). Set
+these in your model type function, like \code{rand_forest(trees = 2000)}.
 \item \emph{Engine arguments} are either specific to a particular engine or used
-more rarely. Set these in \code{set_engine()}, like
+more rarely; there is no change for these argument names from the underlying
+engine. Set these in \code{set_engine()}, like
 \code{set_engine("ranger", importance = "permutation")}.
 }
-
-Also, main argument names are \emph{standardized} to work across all packages.
-For example, for the number of trees in a random forest model, the
-\pkg{parsnip} main argument is \code{trees}. For the \pkg{ranger} and
-\pkg{randomForest} packages, the argument names are different (\code{num.trees}
-and \code{ntree}, respectively).
-
-Conversely, engine arguments are the same as their package (since they
-are engine-specific).
 }
 \examples{
 # First, set main arguments using the standardized names

--- a/man/set_engine.Rd
+++ b/man/set_engine.Rd
@@ -14,7 +14,7 @@ be used to fit the model. This is highly dependent on the type
 of model (e.g. linear regression, random forest, etc.).}
 
 \item{...}{Any optional arguments associated with the chosen computational
-engine. These are captured as quosures and can be \code{tune()}.}
+engine. These are captured as quosures and can be tuned with \code{tune()}.}
 }
 \value{
 An updated model specification.
@@ -23,19 +23,39 @@ An updated model specification.
 \code{set_engine()} is used to specify which package or system will be used
 to fit the model, along with any arguments specific to that software.
 }
-\section{Engines}{
-
-Based on the currently loaded packages, the following lists the set of
-engines available to each model specification.
-
-\Sexpr[stage=render,results=rd]{parsnip:::generate_set_engine_bullets()}
+\details{
+In parsnip,
+\itemize{
+\item the model \strong{type} differentiates basic modeling approaches, such as random
+forests, logistic regression, linear support vector machines, etc.,
+\item the \strong{mode} denotes in what kind of modeling context it will be used
+(most commonly, classification or regression), and
+\item the computational \strong{engine} indicates how the model is fit, such as with
+a specific R package implementation or even methods outside of R like Keras
+or Stan.
 }
 
+Modeling functions in parsnip separate model arguments into two categories:
+\itemize{
+\item \emph{Main arguments} are more commonly used and tend to be available across
+engines. Set these in your model type function, like
+\code{rand_forest(trees = 2000)}.
+\item \emph{Engine arguments} are either specific to a particular engine or used
+more rarely. Set these in \code{set_engine()}, like
+\code{set_engine("ranger", importance = "permutation")}.
+}
+}
 \examples{
-# First, set general arguments using the standardized names
-mod <-
-  logistic_reg(penalty = 0.01, mixture = 1/3) \%>\%
-  # now say how you want to fit the model and another other options
-  set_engine("glmnet", nlambda = 10)
-translate(mod, engine = "glmnet")
+# First, set main arguments using the standardized names
+logistic_reg(penalty = 0.01, mixture = 1/3) \%>\%
+  # Now specify how you want to fit the model with another argument
+  set_engine("glmnet", nlambda = 10) \%>\%
+  translate()
+
+# Many models have possible engine-specific arguments
+decision_tree(tree_depth = 5) \%>\%
+  set_engine("rpart", parms = list(prior = c(.65,.35))) \%>\%
+  set_mode("classification") \%>\%
+  translate()
+
 }

--- a/man/show_engines.Rd
+++ b/man/show_engines.Rd
@@ -14,9 +14,9 @@ A tibble.
 }
 \description{
 The possible engines for a model can depend on what packages are loaded.
-Some \code{parsnip}-adjacent packages add engines to existing models. For example,
-the \code{multilevelmod} package adds additional engines for the \code{\link[=linear_reg]{linear_reg()}}
-model and these are not available unless \code{multilevelmod} is loaded.
+Some \pkg{parsnip} extension add engines to existing models. For example,
+the \pkg{poissonreg} package adds additional engines for the \code{\link[=poisson_reg]{poisson_reg()}}
+model and these are not available unless \pkg{poissonreg} is loaded.
 }
 \examples{
 show_engines("linear_reg")

--- a/man/surv_reg.Rd
+++ b/man/surv_reg.Rd
@@ -31,7 +31,9 @@ More information on how \pkg{parsnip} is used for modeling is at
 }
 \details{
 This function only defines what \emph{type} of model is being fit. Once an engine
-is specified, the \emph{method} to fit the model is also defined.
+is specified, the \emph{method} to fit the model is also defined. See
+\code{\link[=set_engine]{set_engine()}} for more on setting the engine, including how to set engine
+arguments.
 
 The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.

--- a/man/survival_reg.Rd
+++ b/man/survival_reg.Rd
@@ -27,7 +27,9 @@ More information on how \pkg{parsnip} is used for modeling is at
 }
 \details{
 This function only defines what \emph{type} of model is being fit. Once an engine
-is specified, the \emph{method} to fit the model is also defined.
+is specified, the \emph{method} to fit the model is also defined. See
+\code{\link[=set_engine]{set_engine()}} for more on setting the engine, including how to set engine
+arguments.
 
 The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.

--- a/man/svm_linear.Rd
+++ b/man/svm_linear.Rd
@@ -34,7 +34,9 @@ More information on how \pkg{parsnip} is used for modeling is at
 }
 \details{
 This function only defines what \emph{type} of model is being fit. Once an engine
-is specified, the \emph{method} to fit the model is also defined.
+is specified, the \emph{method} to fit the model is also defined. See
+\code{\link[=set_engine]{set_engine()}} for more on setting the engine, including how to set engine
+arguments.
 
 The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.

--- a/man/svm_poly.Rd
+++ b/man/svm_poly.Rd
@@ -46,7 +46,9 @@ More information on how \pkg{parsnip} is used for modeling is at
 }
 \details{
 This function only defines what \emph{type} of model is being fit. Once an engine
-is specified, the \emph{method} to fit the model is also defined.
+is specified, the \emph{method} to fit the model is also defined. See
+\code{\link[=set_engine]{set_engine()}} for more on setting the engine, including how to set engine
+arguments.
 
 The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.

--- a/man/svm_rbf.Rd
+++ b/man/svm_rbf.Rd
@@ -44,7 +44,9 @@ More information on how \pkg{parsnip} is used for modeling is at
 }
 \details{
 This function only defines what \emph{type} of model is being fit. Once an engine
-is specified, the \emph{method} to fit the model is also defined.
+is specified, the \emph{method} to fit the model is also defined. See
+\code{\link[=set_engine]{set_engine()}} for more on setting the engine, including how to set engine
+arguments.
 
 The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.


### PR DESCRIPTION
Closes #641

In this PR I _removed_ the Sexpr that dynamically told folks what engines they have available right then, since it took up a lot of space and seems not so relevant after our update to the parsnip documentation system. I replaced it with a fuller explanation of how to use engine arguments.