### PR TITLE
don't use check_outcome() when using sparklyr

### DIFF
--- a/R/fit_helpers.R
+++ b/R/fit_helpers.R
@@ -6,7 +6,7 @@
 form_form <-
   function(object, control, env, ...) {
 
-    if (!inherits(env$data, "tbl_spark")) {
+    if (inherits(env$data, "data.frame")) {
       check_outcome(eval_tidy(env$formula[[2]], env$data), object)
     }
 

--- a/R/fit_helpers.R
+++ b/R/fit_helpers.R
@@ -6,7 +6,9 @@
 form_form <-
   function(object, control, env, ...) {
 
-    check_outcome(eval_tidy(env$formula[[2]], env$data), object)
+    if (!inherits(env$data, "tbl_spark")) {
+      check_outcome(eval_tidy(env$formula[[2]], env$data), object)
+    }
 
     # prob rewrite this as simple subset/levels
     y_levels <- levels_from_formula(env$formula, env$data)


### PR DESCRIPTION
To close https://github.com/tidymodels/parsnip/issues/671

``` r
library(sparklyr)
#> 
#> Attaching package: 'sparklyr'
#> The following object is masked from 'package:stats':
#> 
#>     filter
library(parsnip)

sc <- spark_connect("local")
iris_tbl <- sdf_copy_to(sc, iris)

decision_tree(engine = "spark") %>%
  set_mode("classification") %>%
  fit(Species ~ Sepal_Length + Petal_Length, iris_tbl)
#> parsnip model object
#> 
#> Formula: Species ~ Sepal_Length + Petal_Length
#> 
#> DecisionTreeClassificationModel (uid=decision_tree_classifier__6a7e32a5_0707_461f_bfe5_d825c6b6f9f1) of depth 5 with 17 nodes

spark_disconnect(sc)
```

<sup>Created on 2022-03-11 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

Should I add a corresponding test in https://github.com/tidymodels/extratests?