### PR TITLE
refine documentation of set_engine to make passing arguments to the engine fit function clearer

### DIFF
--- a/R/engines.R
+++ b/R/engines.R
@@ -78,7 +78,8 @@ load_libs <- function(x, quiet, attach = FALSE) {
 #' these in your model type function, like `rand_forest(trees = 2000)`.
 #' - _Engine arguments_ are either specific to a particular engine or used
 #' more rarely; there is no change for these argument names from the underlying
-#' engine. Set these in `set_engine()`, like
+#' engine. The `...` argument of `set_engine()` allows any engine-specific
+#' argument to be passed directly to the engine fitting function, like
 #' `set_engine("ranger", importance = "permutation")`.
 #'
 #'

--- a/man/set_engine.Rd
+++ b/man/set_engine.Rd
@@ -48,7 +48,8 @@ and  \pkg{randomForest} packages (\code{num.trees} and \code{ntree}, respectivel
 these in your model type function, like \code{rand_forest(trees = 2000)}.
 \item \emph{Engine arguments} are either specific to a particular engine or used
 more rarely; there is no change for these argument names from the underlying
-engine. Set these in \code{set_engine()}, like
+engine. The \code{...} argument of \code{set_engine()} allows any engine-specific
+argument to be passed directly to the engine fitting function, like
 \code{set_engine("ranger", importance = "permutation")}.
 }
 }


### PR DESCRIPTION
I was confused with how to pass arguments directly to the fit function (see https://github.com/tidymodels/discrim/pull/48) so this refines the language of the `set_engine` documentation so that hopefully others might avoid the same confusion.