### PR TITLE
update `format_time()`

### DIFF
--- a/R/predict.R
+++ b/R/predict.R
@@ -243,8 +243,8 @@ format_classprobs <- function(x) {
 format_time <- function(x) {
   if (isTRUE(ncol(x) > 1) | is.data.frame(x)) {
     x <- as_tibble(x, .name_repair = "minimal")
-    if (!any(grepl("^\\.time", names(x)))) {
-      names(x) <- paste0(".time_", names(x))
+    if (!any(grepl("^\\.pred_time", names(x)))) {
+      names(x) <- paste0(".pred_time_", names(x))
     }
   } else {
     x <- tibble(.pred_time = unname(x))


### PR DESCRIPTION
The format of flexsurv's `predict()` output changed to our naming convention, i.e. it now has a column named `.pred_time` so it shouldn't get reformated here.