### PR TITLE
transition to `vctrs::s3_register`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,7 @@ Imports:
     tibble (>= 2.1.1),
     tidyr (>= 1.0.0),
     utils,
-    vctrs (>= 0.2.0),
+    vctrs (>= 0.4.0),
     withr
 Suggests: 
     C50,

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,19 +1,19 @@
 # nocov start
 
 .onLoad <- function(libname, pkgname) {
-  s3_register("generics::tidy", "model_fit")
-  s3_register("generics::tidy", "nullmodel")
-  s3_register("generics::tidy", "_elnet")
-  s3_register("generics::tidy", "_lognet")
-  s3_register("generics::tidy", "_multnet")
-  s3_register("generics::tidy", "_fishnet")
-  s3_register("generics::glance", "model_fit")
-  s3_register("generics::augment", "model_fit")
-  s3_register("generics::required_pkgs", "model_fit")
-  s3_register("generics::required_pkgs", "model_spec")
+  vctrs::s3_register("generics::tidy", "model_fit")
+  vctrs::s3_register("generics::tidy", "nullmodel")
+  vctrs::s3_register("generics::tidy", "_elnet")
+  vctrs::s3_register("generics::tidy", "_lognet")
+  vctrs::s3_register("generics::tidy", "_multnet")
+  vctrs::s3_register("generics::tidy", "_fishnet")
+  vctrs::s3_register("generics::glance", "model_fit")
+  vctrs::s3_register("generics::augment", "model_fit")
+  vctrs::s3_register("generics::required_pkgs", "model_fit")
+  vctrs::s3_register("generics::required_pkgs", "model_spec")
 
-  s3_register("ggplot2::autoplot", "model_fit")
-  s3_register("ggplot2::autoplot", "glmnet")
+  vctrs::s3_register("ggplot2::autoplot", "model_fit")
+  vctrs::s3_register("ggplot2::autoplot", "glmnet")
 
   # - If tune isn't installed, register the method (`packageVersion()` will error here)
   # - If tune >= 0.1.6.9001 is installed, register the method
@@ -50,65 +50,4 @@
 
 }
 
-
-# vctrs:::s3_register()
-s3_register <- function(generic, class, method = NULL) {
-  stopifnot(is.character(generic), length(generic) == 1)
-  stopifnot(is.character(class), length(class) == 1)
-
-  pieces <- strsplit(generic, "::")[[1]]
-  stopifnot(length(pieces) == 2)
-  package <- pieces[[1]]
-  generic <- pieces[[2]]
-
-  caller <- parent.frame()
-
-  get_method_env <- function() {
-    top <- topenv(caller)
-    if (isNamespace(top)) {
-      asNamespace(environmentName(top))
-    } else {
-      caller
-    }
-  }
-  get_method <- function(method, env) {
-    if (is.null(method)) {
-      get(paste0(generic, ".", class), envir = get_method_env())
-    } else {
-      method
-    }
-  }
-
-  method_fn <- get_method(method)
-  stopifnot(is.function(method_fn))
-
-  # Always register hook in case package is later unloaded & reloaded
-  setHook(
-    packageEvent(package, "onLoad"),
-    function(...) {
-      ns <- asNamespace(package)
-
-      # Refresh the method, it might have been updated by `devtools::load_all()`
-      method_fn <- get_method(method)
-
-      registerS3method(generic, class, method_fn, envir = ns)
-    }
-  )
-
-  # Avoid registration failures during loading (pkgload or regular)
-  if (!isNamespaceLoaded(package)) {
-    return(invisible())
-  }
-
-  envir <- asNamespace(package)
-
-  # Only register if generic can be accessed
-  if (exists(generic, envir)) {
-    registerS3method(generic, class, method_fn, envir = envir)
-  }
-
-  invisible()
-}
-
 # nocov end
-


### PR DESCRIPTION
Following up on the release of vctrs this month, closes #652. Not sure if there are additional ad-hoc ways this is tested, but from what I could tell, the `tidy` methods interface in the same way as before this change!