### PR TITLE
fix `cforest_train()`

### DIFF
--- a/R/partykit.R
+++ b/R/partykit.R
@@ -171,9 +171,8 @@ cforest_train <-
     eval_env$data <- data
     eval_env$formula <- formula
     eval_env$weights <- weights
-    rlang::eval_tidy(forest_call, env = eval_env)
 
-    rlang::eval_tidy(forest_call)
+    rlang::eval_tidy(forest_call, env = eval_env)
   }
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
it didn't return the results of the evaluation in the environment _with_ the weights which caused the cforests tests in censored to fail. Possibly also the reason for https://github.com/tidymodels/bonsai/issues/9 