### PR TITLE
add missing comment about usekernel in naive_Bayes naivebayes

### DIFF
--- a/man/details_naive_Bayes_naivebayes.Rd
+++ b/man/details_naive_Bayes_naivebayes.Rd
@@ -16,6 +16,9 @@ This model has 2 tuning parameter:
 \item \code{smoothness}: Kernel Smoothness (type: double, default: 1.0)
 \item \code{Laplace}: Laplace Correction (type: double, default: 0.0)
 }
+
+Note that \code{usekernel} is always set to \code{TRUE} for the \code{naivebayes}
+engine.
 }
 
 \subsection{Translation from parsnip to the original package}{

--- a/man/rmd/naive_Bayes_klaR.Rmd
+++ b/man/rmd/naive_Bayes_klaR.Rmd
@@ -23,7 +23,7 @@ This model has `r nrow(param)` tuning parameter:
 param$item
 ```
 
-Note that `usekernel` is always set to `TRUE` for the `klaR` engine.
+Note that the engine argument `usekernel` is set to `TRUE` by default when using the `klaR` engine. 
 
 ## Translation from parsnip to the original package
 

--- a/man/rmd/naive_Bayes_klaR.md
+++ b/man/rmd/naive_Bayes_klaR.md
@@ -14,7 +14,7 @@ This model has 2 tuning parameter:
 
 - `Laplace`: Laplace Correction (type: double, default: 0.0)
 
-Note that `usekernel` is always set to `TRUE` for the `klaR` engine.
+Note that the engine argument `usekernel` is set to `TRUE` by default when using the `klaR` engine. 
 
 ## Translation from parsnip to the original package
 

--- a/man/rmd/naive_Bayes_naivebayes.Rmd
+++ b/man/rmd/naive_Bayes_naivebayes.Rmd
@@ -23,7 +23,7 @@ This model has `r nrow(param)` tuning parameter:
 param$item
 ```
 
-Note that `usekernel` is always set to `TRUE` for the `naivebayes` engine.
+Note that the engine argument `usekernel` is set to `TRUE` by default when using the `naivebayes` engine. 
 
 ## Translation from parsnip to the original package
 

--- a/man/rmd/naive_Bayes_naivebayes.Rmd
+++ b/man/rmd/naive_Bayes_naivebayes.Rmd
@@ -23,6 +23,8 @@ This model has `r nrow(param)` tuning parameter:
 param$item
 ```
 
+Note that `usekernel` is always set to `TRUE` for the `naivebayes` engine.
+
 ## Translation from parsnip to the original package
 
 `r uses_extension("naive_Bayes", "naivebayes", "classification")`

--- a/man/rmd/naive_Bayes_naivebayes.md
+++ b/man/rmd/naive_Bayes_naivebayes.md
@@ -14,7 +14,7 @@ This model has 2 tuning parameter:
 
 - `Laplace`: Laplace Correction (type: double, default: 0.0)
 
-Note that `usekernel` is always set to `TRUE` for the `naivebayes` engine.
+Note that the engine argument `usekernel` is set to `TRUE` by default when using the `naivebayes` engine. 
 
 ## Translation from parsnip to the original package
 

--- a/man/rmd/naive_Bayes_naivebayes.md
+++ b/man/rmd/naive_Bayes_naivebayes.md
@@ -14,6 +14,8 @@ This model has 2 tuning parameter:
 
 - `Laplace`: Laplace Correction (type: double, default: 0.0)
 
+Note that `usekernel` is always set to `TRUE` for the `naivebayes` engine.
+
 ## Translation from parsnip to the original package
 
 The **discrim** extension package is required to fit this model.


### PR DESCRIPTION
Missing documentation has been added to close https://github.com/tidymodels/parsnip/issues/712.