### PR TITLE
document elastic net regularization via mixture

### DIFF
--- a/R/linear_reg.R
+++ b/R/linear_reg.R
@@ -17,10 +17,14 @@
 #'  model is `"lm"`.
 #' @param penalty A non-negative number representing the total
 #'  amount of regularization (specific engines only).
-#' @param mixture A number between zero and one (inclusive) that is the
-#'  proportion of L1 regularization (i.e. lasso) in the model. When
-#'  `mixture = 1`, it is a pure lasso model while `mixture = 0` indicates that
-#'  ridge regression is being used (specific engines only).
+#' @param mixture A number between zero and one (inclusive) denoting the
+#'  proportion of L1 regularization (i.e. lasso) in the model.
+#'
+#'  * `mixture = 1` specifies a pure lasso model,
+#'  * `mixture = 0`  specifies a ridge regression model, and
+#'  * `0 < mixture < 1` specifies an elastic net model, interpolating lasso and ridge.
+#'
+#'  Available for specific engines only.
 #'
 #' @template spec-details
 #'

--- a/R/logistic_reg.R
+++ b/R/logistic_reg.R
@@ -20,11 +20,15 @@
 #'  For `keras` models, this corresponds to purely L2 regularization
 #'  (aka weight decay) while the other models can be either or a combination
 #'  of L1 and L2 (depending on the value of `mixture`).
-#' @param mixture A number between zero and one (inclusive) that is the
-#'  proportion of L1 regularization (i.e. lasso) in the model. When
-#'  `mixture = 1`, it is a pure lasso model while `mixture = 0` indicates that
-#'  ridge regression is being used. (specific engines only).
-#'  For `LiblineaR` models, `mixture` must be exactly 0 or 1 only.
+#' @param mixture A number between zero and one (inclusive) giving the
+#'  proportion of L1 regularization (i.e. lasso) in the model.
+#'
+#'  * `mixture = 1` specifies a pure lasso model,
+#'  * `mixture = 0`  specifies a ridge regression model, and
+#'  * `0 < mixture < 1` specifies an elastic net model, interpolating lasso and ridge.
+#'
+#'  Available for specific engines only. For `LiblineaR` models, `mixture` must
+#'  be exactly 1 or 0 only.
 #'
 #' @template spec-details
 #'

--- a/R/multinom_reg.R
+++ b/R/multinom_reg.R
@@ -21,10 +21,14 @@
 #'  For `keras` models, this corresponds to purely L2 regularization
 #'  (aka weight decay) while the other models can be a combination
 #'  of L1 and L2 (depending on the value of `mixture`).
-#' @param mixture A number between zero and one (inclusive) that is the
-#'  proportion of L1 regularization (i.e. lasso) in the model. When
-#'  `mixture = 1`, it is a pure lasso model while `mixture = 0` indicates that
-#'  ridge regression is being used. (specific engines only).
+#' @param mixture A number between zero and one (inclusive) giving the
+#'  proportion of L1 regularization (i.e. lasso) in the model.
+#'
+#'  * `mixture = 1` specifies a pure lasso model,
+#'  * `mixture = 0`  specifies a ridge regression model, and
+#'  * `0 < mixture < 1` specifies an elastic net model, interpolating lasso and ridge.
+#'
+#'  Available for specific engines only.
 #'
 #' @template spec-details
 #'

--- a/R/poisson_reg.R
+++ b/R/poisson_reg.R
@@ -15,10 +15,14 @@
 #'  The only possible value for this model is "regression".
 #' @param penalty A non-negative number representing the total
 #'  amount of regularization (`glmnet` only).
-#' @param mixture A number between zero and one (inclusive) that is the
-#'  proportion of L1 regularization (i.e. lasso) in the model. When
-#'  `mixture = 1`, it is a pure lasso model while `mixture = 0` indicates that
-#'  ridge regression is being used. (`glmnet` and `spark` only).
+#' @param mixture A number between zero and one (inclusive) giving the
+#'  proportion of L1 regularization (i.e. lasso) in the model.
+#'
+#'  * `mixture = 1` specifies a pure lasso model,
+#'  * `mixture = 0`  specifies a ridge regression model, and
+#'  * `0 < mixture < 1` specifies an elastic net model, interpolating lasso and ridge.
+#'
+#'  Available for `glmnet` and `spark` only.
 #'
 #' @template spec-details
 #'

--- a/man/linear_reg.Rd
+++ b/man/linear_reg.Rd
@@ -17,10 +17,15 @@ model is \code{"lm"}.}
 \item{penalty}{A non-negative number representing the total
 amount of regularization (specific engines only).}
 
-\item{mixture}{A number between zero and one (inclusive) that is the
-proportion of L1 regularization (i.e. lasso) in the model. When
-\code{mixture = 1}, it is a pure lasso model while \code{mixture = 0} indicates that
-ridge regression is being used (specific engines only).}
+\item{mixture}{A number between zero and one (inclusive) denoting the
+proportion of L1 regularization (i.e. lasso) in the model.
+\itemize{
+\item \code{mixture = 1} specifies a pure lasso model,
+\item \code{mixture = 0}  specifies a ridge regression model, and
+\item \verb{0 < mixture < 1} specifies an elastic net model, interpolating lasso and ridge.
+}
+
+Available for specific engines only.}
 }
 \description{
 \code{linear_reg()} defines a model that can predict numeric values from

--- a/man/logistic_reg.Rd
+++ b/man/logistic_reg.Rd
@@ -25,11 +25,16 @@ For \code{keras} models, this corresponds to purely L2 regularization
 (aka weight decay) while the other models can be either or a combination
 of L1 and L2 (depending on the value of \code{mixture}).}
 
-\item{mixture}{A number between zero and one (inclusive) that is the
-proportion of L1 regularization (i.e. lasso) in the model. When
-\code{mixture = 1}, it is a pure lasso model while \code{mixture = 0} indicates that
-ridge regression is being used. (specific engines only).
-For \code{LiblineaR} models, \code{mixture} must be exactly 0 or 1 only.}
+\item{mixture}{A number between zero and one (inclusive) giving the
+proportion of L1 regularization (i.e. lasso) in the model.
+\itemize{
+\item \code{mixture = 1} specifies a pure lasso model,
+\item \code{mixture = 0}  specifies a ridge regression model, and
+\item \verb{0 < mixture < 1} specifies an elastic net model, interpolating lasso and ridge.
+}
+
+Available for specific engines only. For \code{LiblineaR} models, \code{mixture} must
+be exactly 1 or 0 only.}
 }
 \description{
 \code{\link[=logistic_reg]{logistic_reg()}} defines a generalized linear model for binary outcomes. A

--- a/man/multinom_reg.Rd
+++ b/man/multinom_reg.Rd
@@ -25,10 +25,15 @@ For \code{keras} models, this corresponds to purely L2 regularization
 (aka weight decay) while the other models can be a combination
 of L1 and L2 (depending on the value of \code{mixture}).}
 
-\item{mixture}{A number between zero and one (inclusive) that is the
-proportion of L1 regularization (i.e. lasso) in the model. When
-\code{mixture = 1}, it is a pure lasso model while \code{mixture = 0} indicates that
-ridge regression is being used. (specific engines only).}
+\item{mixture}{A number between zero and one (inclusive) giving the
+proportion of L1 regularization (i.e. lasso) in the model.
+\itemize{
+\item \code{mixture = 1} specifies a pure lasso model,
+\item \code{mixture = 0}  specifies a ridge regression model, and
+\item \verb{0 < mixture < 1} specifies an elastic net model, interpolating lasso and ridge.
+}
+
+Available for specific engines only.}
 }
 \description{
 \code{multinom_reg()} defines a model that uses linear predictors to predict

--- a/man/parsnip_update.Rd
+++ b/man/parsnip_update.Rd
@@ -382,9 +382,7 @@ regularization used by some of the engines.}
 estimation. Possible values are: "\code{diagonal}", "\code{min_distance}",
 "\code{shrink_cov}", and "\code{shrink_mean}" (\code{sparsediscrim} engine only).}
 
-\item{frac_common_cov}{Numeric values between zero and one.}
-
-\item{frac_identity}{Numeric values between zero and one.}
+\item{frac_common_cov, frac_identity}{Numeric values between zero and one.}
 
 \item{select_features}{\code{TRUE} or \code{FALSE.} If \code{TRUE}, the model has the
 ability to eliminate a predictor (via penalization). Increasing
@@ -393,10 +391,15 @@ ability to eliminate a predictor (via penalization). Increasing
 \item{adjust_deg_free}{If \code{select_features = TRUE}, then acts as a multiplier
 for smoothness. Increase this beyond 1 to produce smoother models.}
 
-\item{mixture}{A number between zero and one (inclusive) that is the
-proportion of L1 regularization (i.e. lasso) in the model. When
-\code{mixture = 1}, it is a pure lasso model while \code{mixture = 0} indicates that
-ridge regression is being used (specific engines only).}
+\item{mixture}{A number between zero and one (inclusive) denoting the
+proportion of L1 regularization (i.e. lasso) in the model.
+\itemize{
+\item \code{mixture = 1} specifies a pure lasso model,
+\item \code{mixture = 0}  specifies a ridge regression model, and
+\item \verb{0 < mixture < 1} specifies an elastic net model, interpolating lasso and ridge.
+}
+
+Available for specific engines only.}
 
 \item{hidden_units}{An integer for the number of units in the hidden model.}
 

--- a/man/poisson_reg.Rd
+++ b/man/poisson_reg.Rd
@@ -18,10 +18,15 @@ The only possible value for this model is "regression".}
 \item{penalty}{A non-negative number representing the total
 amount of regularization (\code{glmnet} only).}
 
-\item{mixture}{A number between zero and one (inclusive) that is the
-proportion of L1 regularization (i.e. lasso) in the model. When
-\code{mixture = 1}, it is a pure lasso model while \code{mixture = 0} indicates that
-ridge regression is being used. (\code{glmnet} and \code{spark} only).}
+\item{mixture}{A number between zero and one (inclusive) giving the
+proportion of L1 regularization (i.e. lasso) in the model.
+\itemize{
+\item \code{mixture = 1} specifies a pure lasso model,
+\item \code{mixture = 0}  specifies a ridge regression model, and
+\item \verb{0 < mixture < 1} specifies an elastic net model, interpolating lasso and ridge.
+}
+
+Available for \code{glmnet} and \code{spark} only.}
 
 \item{engine}{A single character string specifying what computational engine
 to use for fitting.}

--- a/man/proportional_hazards.Rd
+++ b/man/proportional_hazards.Rd
@@ -21,10 +21,15 @@ to use for fitting.}
 \item{penalty}{A non-negative number representing the total
 amount of regularization (specific engines only).}
 
-\item{mixture}{A number between zero and one (inclusive) that is the
-proportion of L1 regularization (i.e. lasso) in the model. When
-\code{mixture = 1}, it is a pure lasso model while \code{mixture = 0} indicates that
-ridge regression is being used (specific engines only).}
+\item{mixture}{A number between zero and one (inclusive) denoting the
+proportion of L1 regularization (i.e. lasso) in the model.
+\itemize{
+\item \code{mixture = 1} specifies a pure lasso model,
+\item \code{mixture = 0}  specifies a ridge regression model, and
+\item \verb{0 < mixture < 1} specifies an elastic net model, interpolating lasso and ridge.
+}
+
+Available for specific engines only.}
 }
 \description{
 \code{proportional_hazards()} defines a model for the hazard function

--- a/man/rmd/linear_reg_spark.Rmd
+++ b/man/rmd/linear_reg_spark.Rmd
@@ -22,9 +22,11 @@ This model has `r nrow(param)` tuning parameters:
 param$item
 ```
 
-For `penalty`, the amount of regularization includes both the L1 penalty (i.e., lasso) and the L2 penalty (i.e., ridge or weight decay). 
+For `penalty`, the amount of regularization includes both the L1 penalty (i.e., lasso) and the L2 penalty (i.e., ridge or weight decay). As for `mixture`:
 
-A value of `mixture = 1` corresponds to a pure lasso model, while `mixture = 0` indicates ridge regression.
+* `mixture = 1` specifies a pure lasso model,
+* `mixture = 0`  specifies a ridge regression model, and
+* `0 < mixture < 1` specifies an elastic net model, interpolating lasso and ridge.
 
 ## Translation from parsnip to the original package
 

--- a/man/rmd/linear_reg_spark.md
+++ b/man/rmd/linear_reg_spark.md
@@ -13,9 +13,11 @@ This model has 2 tuning parameters:
 
 - `mixture`: Proportion of Lasso Penalty (type: double, default: 0.0)
 
-For `penalty`, the amount of regularization includes both the L1 penalty (i.e., lasso) and the L2 penalty (i.e., ridge or weight decay). 
+For `penalty`, the amount of regularization includes both the L1 penalty (i.e., lasso) and the L2 penalty (i.e., ridge or weight decay). As for `mixture`:
 
-A value of `mixture = 1` corresponds to a pure lasso model, while `mixture = 0` indicates ridge regression.
+* `mixture = 1` specifies a pure lasso model,
+* `mixture = 0`  specifies a ridge regression model, and
+* `0 < mixture < 1` specifies an elastic net model, interpolating lasso and ridge.
 
 ## Translation from parsnip to the original package
 

--- a/man/rmd/logistic_reg_glmnet.Rmd
+++ b/man/rmd/logistic_reg_glmnet.Rmd
@@ -22,9 +22,11 @@ This model has `r nrow(param)` tuning parameters:
 param$item
 ```
 
-A value of `mixture = 1` corresponds to a pure lasso model, while `mixture = 0` indicates ridge regression.
+The `penalty` parameter has no default and requires a single numeric value. For more details about this, and the `glmnet` model in general, see [glmnet-details]. As for `mixture`:
 
-The `penalty` parameter has no default and requires a single numeric value. For more details about this, and the `glmnet` model in general, see [glmnet-details].
+* `mixture = 1` specifies a pure lasso model,
+* `mixture = 0`  specifies a ridge regression model, and
+* `0 < mixture < 1` specifies an elastic net model, interpolating lasso and ridge.
 
 ## Translation from parsnip to the original package
 

--- a/man/rmd/logistic_reg_glmnet.md
+++ b/man/rmd/logistic_reg_glmnet.md
@@ -13,9 +13,11 @@ This model has 2 tuning parameters:
 
 - `mixture`: Proportion of Lasso Penalty (type: double, default: 1.0)
 
-A value of `mixture = 1` corresponds to a pure lasso model, while `mixture = 0` indicates ridge regression.
+The `penalty` parameter has no default and requires a single numeric value. For more details about this, and the `glmnet` model in general, see [glmnet-details]. As for `mixture`:
 
-The `penalty` parameter has no default and requires a single numeric value. For more details about this, and the `glmnet` model in general, see [glmnet-details].
+* `mixture = 1` specifies a pure lasso model,
+* `mixture = 0`  specifies a ridge regression model, and
+* `0 < mixture < 1` specifies an elastic net model, interpolating lasso and ridge.
 
 ## Translation from parsnip to the original package
 

--- a/man/rmd/logistic_reg_spark.Rmd
+++ b/man/rmd/logistic_reg_spark.Rmd
@@ -22,9 +22,11 @@ This model has `r nrow(param)` tuning parameters:
 param$item
 ```
 
-For `penalty`, the amount of regularization includes both the L1 penalty (i.e., lasso) and the L2 penalty (i.e., ridge or weight decay). 
+For `penalty`, the amount of regularization includes both the L1 penalty (i.e., lasso) and the L2 penalty (i.e., ridge or weight decay). As for `mixture`:
 
-A value of `mixture = 1` corresponds to a pure lasso model, while `mixture = 0` indicates ridge regression.
+* `mixture = 1` specifies a pure lasso model,
+* `mixture = 0`  specifies a ridge regression model, and
+* `0 < mixture < 1` specifies an elastic net model, interpolating lasso and ridge.
 
 ## Translation from parsnip to the original package
 

--- a/man/rmd/logistic_reg_spark.md
+++ b/man/rmd/logistic_reg_spark.md
@@ -13,9 +13,11 @@ This model has 2 tuning parameters:
 
 - `mixture`: Proportion of Lasso Penalty (type: double, default: 0.0)
 
-For `penalty`, the amount of regularization includes both the L1 penalty (i.e., lasso) and the L2 penalty (i.e., ridge or weight decay). 
+For `penalty`, the amount of regularization includes both the L1 penalty (i.e., lasso) and the L2 penalty (i.e., ridge or weight decay). As for `mixture`:
 
-A value of `mixture = 1` corresponds to a pure lasso model, while `mixture = 0` indicates ridge regression.
+* `mixture = 1` specifies a pure lasso model,
+* `mixture = 0`  specifies a ridge regression model, and
+* `0 < mixture < 1` specifies an elastic net model, interpolating lasso and ridge.
 
 ## Translation from parsnip to the original package
 

--- a/man/rmd/multinom_reg_glmnet.Rmd
+++ b/man/rmd/multinom_reg_glmnet.Rmd
@@ -22,9 +22,11 @@ This model has `r nrow(param)` tuning parameters:
 param$item
 ```
 
-A value of `mixture = 1` corresponds to a pure lasso model, while `mixture = 0` indicates ridge regression.
+The `penalty` parameter has no default and requires a single numeric value. For more details about this, and the `glmnet` model in general, see [glmnet-details]. As for `mixture`:
 
-The `penalty` parameter has no default and requires a single numeric value. For more details about this, and the `glmnet` model in general, see [glmnet-details].
+* `mixture = 1` specifies a pure lasso model,
+* `mixture = 0`  specifies a ridge regression model, and
+* `0 < mixture < 1` specifies an elastic net model, interpolating lasso and ridge.
 
 ## Translation from parsnip to the original package
 

--- a/man/rmd/multinom_reg_glmnet.md
+++ b/man/rmd/multinom_reg_glmnet.md
@@ -13,9 +13,11 @@ This model has 2 tuning parameters:
 
 - `mixture`: Proportion of Lasso Penalty (type: double, default: 1.0)
 
-A value of `mixture = 1` corresponds to a pure lasso model, while `mixture = 0` indicates ridge regression.
+The `penalty` parameter has no default and requires a single numeric value. For more details about this, and the `glmnet` model in general, see [glmnet-details]. As for `mixture`:
 
-The `penalty` parameter has no default and requires a single numeric value. For more details about this, and the `glmnet` model in general, see [glmnet-details].
+* `mixture = 1` specifies a pure lasso model,
+* `mixture = 0`  specifies a ridge regression model, and
+* `0 < mixture < 1` specifies an elastic net model, interpolating lasso and ridge.
 
 ## Translation from parsnip to the original package
 

--- a/man/rmd/multinom_reg_spark.Rmd
+++ b/man/rmd/multinom_reg_spark.Rmd
@@ -22,9 +22,11 @@ This model has `r nrow(param)` tuning parameters:
 param$item
 ```
 
-For `penalty`, the amount of regularization includes both the L1 penalty (i.e., lasso) and the L2 penalty (i.e., ridge or weight decay). 
+For `penalty`, the amount of regularization includes both the L1 penalty (i.e., lasso) and the L2 penalty (i.e., ridge or weight decay). As for `mixture`:
 
-A value of `mixture = 1` corresponds to a pure lasso model, while `mixture = 0` indicates ridge regression.
+* `mixture = 1` specifies a pure lasso model,
+* `mixture = 0`  specifies a ridge regression model, and
+* `0 < mixture < 1` specifies an elastic net model, interpolating lasso and ridge.
 
 ## Translation from parsnip to the original package
 

--- a/man/rmd/multinom_reg_spark.md
+++ b/man/rmd/multinom_reg_spark.md
@@ -13,9 +13,11 @@ This model has 2 tuning parameters:
 
 - `mixture`: Proportion of Lasso Penalty (type: double, default: 0.0)
 
-For `penalty`, the amount of regularization includes both the L1 penalty (i.e., lasso) and the L2 penalty (i.e., ridge or weight decay). 
+For `penalty`, the amount of regularization includes both the L1 penalty (i.e., lasso) and the L2 penalty (i.e., ridge or weight decay). As for `mixture`:
 
-A value of `mixture = 1` corresponds to a pure lasso model, while `mixture = 0` indicates ridge regression.
+* `mixture = 1` specifies a pure lasso model,
+* `mixture = 0`  specifies a ridge regression model, and
+* `0 < mixture < 1` specifies an elastic net model, interpolating lasso and ridge.
 
 ## Translation from parsnip to the original package
 

--- a/man/rmd/poisson_reg_glmnet.Rmd
+++ b/man/rmd/poisson_reg_glmnet.Rmd
@@ -22,9 +22,11 @@ This model has `r nrow(param)` tuning parameters:
 param$item
 ```
 
-A value of `mixture = 1` corresponds to a pure lasso model, while `mixture = 0` indicates ridge regression.
+The `penalty` parameter has no default and requires a single numeric value. For more details about this, and the `glmnet` model in general, see [glmnet-details]. As for `mixture`:
 
-The `penalty` parameter has no default and requires a single numeric value. For more details about this, and the `glmnet` model in general, see [glmnet-details].
+* `mixture = 1` specifies a pure lasso model,
+* `mixture = 0`  specifies a ridge regression model, and
+* `0 < mixture < 1` specifies an elastic net model, interpolating lasso and ridge.
 
 ## Translation from parsnip to the original package
 

--- a/man/rmd/poisson_reg_glmnet.md
+++ b/man/rmd/poisson_reg_glmnet.md
@@ -13,9 +13,11 @@ This model has 2 tuning parameters:
 
 - `mixture`: Proportion of Lasso Penalty (type: double, default: 1.0)
 
-A value of `mixture = 1` corresponds to a pure lasso model, while `mixture = 0` indicates ridge regression.
+The `penalty` parameter has no default and requires a single numeric value. For more details about this, and the `glmnet` model in general, see [glmnet-details]. As for `mixture`:
 
-The `penalty` parameter has no default and requires a single numeric value. For more details about this, and the `glmnet` model in general, see [glmnet-details].
+* `mixture = 1` specifies a pure lasso model,
+* `mixture = 0`  specifies a ridge regression model, and
+* `0 < mixture < 1` specifies an elastic net model, interpolating lasso and ridge.
 
 ## Translation from parsnip to the original package
 

--- a/man/rmd/proportional_hazards_glmnet.Rmd
+++ b/man/rmd/proportional_hazards_glmnet.Rmd
@@ -22,9 +22,11 @@ This model has `r nrow(param)` tuning parameters:
 param$item
 ```
 
-A value of `mixture = 1` corresponds to a pure lasso model, while `mixture = 0` indicates ridge regression.
+The `penalty` parameter has no default and requires a single numeric value. For more details about this, and the `glmnet` model in general, see [parsnip::glmnet-details]. As for `mixture`:
 
-The `penalty` parameter has no default and requires a single numeric value. For more details about this, and the `glmnet` model in general, see [parsnip::glmnet-details].
+* `mixture = 1` specifies a pure lasso model,
+* `mixture = 0`  specifies a ridge regression model, and
+* `0 < mixture < 1` specifies an elastic net model, interpolating lasso and ridge.
 
 ## Translation from parsnip to the original package
 

--- a/man/rmd/proportional_hazards_glmnet.md
+++ b/man/rmd/proportional_hazards_glmnet.md
@@ -13,9 +13,11 @@ This model has 2 tuning parameters:
 
 - `mixture`: Proportion of Lasso Penalty (type: double, default: 1.0)
 
-A value of `mixture = 1` corresponds to a pure lasso model, while `mixture = 0` indicates ridge regression.
+The `penalty` parameter has no default and requires a single numeric value. For more details about this, and the `glmnet` model in general, see [parsnip::glmnet-details]. As for `mixture`:
 
-The `penalty` parameter has no default and requires a single numeric value. For more details about this, and the `glmnet` model in general, see [parsnip::glmnet-details].
+* `mixture = 1` specifies a pure lasso model,
+* `mixture = 0`  specifies a ridge regression model, and
+* `0 < mixture < 1` specifies an elastic net model, interpolating lasso and ridge.
 
 ## Translation from parsnip to the original package
 


### PR DESCRIPTION
Closes #570. In my experience, "interpolate" is the verbiage here. :)

Will need someone else to generate documentation for me—spent a while trying to debug, and eventually came across a set of errors in `knit_engine_docs`:

```
Failed with error:  'package 'parsnip' required by 'censored' could not be found'
Failed with error:  'package 'parsnip' required by 'discrim' could not be found'
# etc etc
```

that's not worth me troubleshooting if others are able to follow [inst/README-DOCS.md](https://github.com/tidymodels/parsnip/blob/main/inst/README-DOCS.md) just fine.🛫