### PR TITLE
set `call = NULL` in internal model registration error

### DIFF
--- a/R/aaa_models.R
+++ b/R/aaa_models.R
@@ -780,7 +780,8 @@ is_discordant_info <- function(model, mode, eng, candidate,
         "The combination of engine '{eng}' and mode '{mode}' {p_type} already has ",
         "{component} data for model '{model}' and the new information being ",
         "registered is different."
-      )
+      ),
+      call = NULL
     )
   }
 


### PR DESCRIPTION
I came across this error while working on bonsai earlier today. I don't think the user needs to know which internal function (`is_discordant_info()`) this error comes from—revises the error from:

```r
devtools::load_all(".")
#> ℹ Loading bonsai
#> Error in `is_discordant_info()`:
#> ! The combination of engine 'lightgbm' and mode 'regression'  already has fit data for model 'boost_tree' and the new information being registered is different.
#> Run `rlang::last_error()` to see where the error occurred.
```

to:

```r
devtools::load_all(".")
#> ℹ Loading bonsai
#> Error: 
#> ! The combination of engine 'lightgbm' and mode 'regression'  already has fit data for model 'boost_tree' and the new information being registered is different.
#> Run `rlang::last_error()` to see where the error occurred.
```

Reproduce with

``` r
fn <- function() {
  rlang::abort("msg")
}

fn_ <- function() {
  rlang::abort("msg", call = NULL)
}

fn()
#> Error in `fn()`:
#> ! msg

fn_()
#> Error:
#> ! msg
```

<sup>Created on 2022-05-20 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>