### PR TITLE
prompt on unavailable extension packages

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,7 +12,7 @@
 
 * `predict(type = "prob")` will now provide an error if the outcome variable has a level called `"class"` (#720).
 
-* Print methods will now prompt informatively if a needed parsnip extension package is not loaded (#731).
+* Model type functions will now message informatively if a needed parsnip extension package is not loaded (#731).
 
 # parsnip 0.2.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,8 @@
 
 * `predict(type = "prob")` will now provide an error if the outcome variable has a level called `"class"` (#720).
 
+* Print methods will now prompt informatively if a needed parsnip extension package is not loaded (#731).
+
 # parsnip 0.2.1
 
 * Fixed a major bug in spark models induced in the previous version (#671).

--- a/R/arguments.R
+++ b/R/arguments.R
@@ -68,7 +68,7 @@ set_args <- function(object, ...) {
     mode = object$mode,
     method = NULL,
     engine = object$engine,
-    new = FALSE
+    check_missing_spec = FALSE
   )
 }
 

--- a/R/arguments.R
+++ b/R/arguments.R
@@ -67,7 +67,8 @@ set_args <- function(object, ...) {
     eng_args = object$eng_args,
     mode = object$mode,
     method = NULL,
-    engine = object$engine
+    engine = object$engine,
+    new = FALSE
   )
 }
 

--- a/R/bag_mars.R
+++ b/R/bag_mars.R
@@ -47,7 +47,7 @@ print.bag_mars <- function(x, ...) {
   cat("Bagged MARS Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(class(x)[1], x$engine, x$mode)) {
+  if (is_printable_spec(x)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/bag_mars.R
+++ b/R/bag_mars.R
@@ -47,7 +47,7 @@ print.bag_mars <- function(x, ...) {
   cat("Bagged MARS Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
+  if (!is.null(x$method$fit$args) && has_loaded_implementation(class(x)[1], x$engine, x$mode)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/bag_mars.R
+++ b/R/bag_mars.R
@@ -47,7 +47,7 @@ print.bag_mars <- function(x, ...) {
   cat("Bagged MARS Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args)) {
+  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/bag_mars.R
+++ b/R/bag_mars.R
@@ -47,7 +47,7 @@ print.bag_mars <- function(x, ...) {
   cat("Bagged MARS Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
+  if (!is.null(x$method$fit$args)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/bag_tree.R
+++ b/R/bag_tree.R
@@ -51,7 +51,7 @@ print.bag_tree <- function(x, ...) {
   cat("Bagged Decision Tree Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
+  if (!is.null(x$method$fit$args)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/bag_tree.R
+++ b/R/bag_tree.R
@@ -51,7 +51,7 @@ print.bag_tree <- function(x, ...) {
   cat("Bagged Decision Tree Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
+  if (!is.null(x$method$fit$args) && has_loaded_implementation(class(x)[1], x$engine, x$mode)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/bag_tree.R
+++ b/R/bag_tree.R
@@ -51,7 +51,7 @@ print.bag_tree <- function(x, ...) {
   cat("Bagged Decision Tree Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(class(x)[1], x$engine, x$mode)) {
+  if (is_printable_spec(x)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/bag_tree.R
+++ b/R/bag_tree.R
@@ -51,7 +51,7 @@ print.bag_tree <- function(x, ...) {
   cat("Bagged Decision Tree Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args)) {
+  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/bart.R
+++ b/R/bart.R
@@ -95,7 +95,7 @@ print.bart <- function(x, ...) {
   cat("BART Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
+  if(!is.null(x$method$fit$args)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/bart.R
+++ b/R/bart.R
@@ -95,7 +95,7 @@ print.bart <- function(x, ...) {
   cat("BART Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
+  if (!is.null(x$method$fit$args) && has_loaded_implementation(class(x)[1], x$engine, x$mode)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/bart.R
+++ b/R/bart.R
@@ -95,7 +95,7 @@ print.bart <- function(x, ...) {
   cat("BART Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if(!is.null(x$method$fit$args)) {
+  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/bart.R
+++ b/R/bart.R
@@ -95,7 +95,7 @@ print.bart <- function(x, ...) {
   cat("BART Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(class(x)[1], x$engine, x$mode)) {
+  if (is_printable_spec(x)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/boost_tree.R
+++ b/R/boost_tree.R
@@ -84,7 +84,7 @@ print.boost_tree <- function(x, ...) {
   cat("Boosted Tree Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
+  if (!is.null(x$method$fit$args)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/boost_tree.R
+++ b/R/boost_tree.R
@@ -84,7 +84,7 @@ print.boost_tree <- function(x, ...) {
   cat("Boosted Tree Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(class(x)[1], x$engine, x$mode)) {
+  if (is_printable_spec(x)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/boost_tree.R
+++ b/R/boost_tree.R
@@ -84,7 +84,7 @@ print.boost_tree <- function(x, ...) {
   cat("Boosted Tree Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
+  if (!is.null(x$method$fit$args) && has_loaded_implementation(class(x)[1], x$engine, x$mode)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/boost_tree.R
+++ b/R/boost_tree.R
@@ -84,7 +84,7 @@ print.boost_tree <- function(x, ...) {
   cat("Boosted Tree Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args)) {
+  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/c5_rules.R
+++ b/R/c5_rules.R
@@ -68,7 +68,7 @@ print.C5_rules <- function(x, ...) {
   cat("C5.0 Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
+  if (!is.null(x$method$fit$args) && has_loaded_implementation(class(x)[1], x$engine, x$mode)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/c5_rules.R
+++ b/R/c5_rules.R
@@ -68,7 +68,7 @@ print.C5_rules <- function(x, ...) {
   cat("C5.0 Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args)) {
+  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/c5_rules.R
+++ b/R/c5_rules.R
@@ -68,7 +68,7 @@ print.C5_rules <- function(x, ...) {
   cat("C5.0 Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(class(x)[1], x$engine, x$mode)) {
+  if (is_printable_spec(x)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/c5_rules.R
+++ b/R/c5_rules.R
@@ -68,7 +68,7 @@ print.C5_rules <- function(x, ...) {
   cat("C5.0 Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
+  if (!is.null(x$method$fit$args)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/cubist_rules.R
+++ b/R/cubist_rules.R
@@ -94,7 +94,7 @@ print.cubist_rules <- function(x, ...) {
   cat("Cubist Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
+  if (!is.null(x$method$fit$args) && has_loaded_implementation(class(x)[1], x$engine, x$mode)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/cubist_rules.R
+++ b/R/cubist_rules.R
@@ -94,7 +94,7 @@ print.cubist_rules <- function(x, ...) {
   cat("Cubist Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(class(x)[1], x$engine, x$mode)) {
+  if (is_printable_spec(x)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/cubist_rules.R
+++ b/R/cubist_rules.R
@@ -94,7 +94,7 @@ print.cubist_rules <- function(x, ...) {
   cat("Cubist Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args)) {
+  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/cubist_rules.R
+++ b/R/cubist_rules.R
@@ -94,7 +94,7 @@ print.cubist_rules <- function(x, ...) {
   cat("Cubist Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
+  if (!is.null(x$method$fit$args)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/decision_tree.R
+++ b/R/decision_tree.R
@@ -56,7 +56,7 @@ print.decision_tree <- function(x, ...) {
   cat("Decision Tree Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args)) {
+  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/decision_tree.R
+++ b/R/decision_tree.R
@@ -56,7 +56,7 @@ print.decision_tree <- function(x, ...) {
   cat("Decision Tree Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(class(x)[1], x$engine, x$mode)) {
+  if (is_printable_spec(x)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/decision_tree.R
+++ b/R/decision_tree.R
@@ -56,7 +56,7 @@ print.decision_tree <- function(x, ...) {
   cat("Decision Tree Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
+  if (!is.null(x$method$fit$args) && has_loaded_implementation(class(x)[1], x$engine, x$mode)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/decision_tree.R
+++ b/R/decision_tree.R
@@ -56,7 +56,7 @@ print.decision_tree <- function(x, ...) {
   cat("Decision Tree Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
+  if (!is.null(x$method$fit$args)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/discrim_flexible.R
+++ b/R/discrim_flexible.R
@@ -50,7 +50,7 @@ print.discrim_flexible <- function(x, ...) {
   cat("Flexible Discriminant Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
+  if (!is.null(x$method$fit$args)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/discrim_flexible.R
+++ b/R/discrim_flexible.R
@@ -50,7 +50,7 @@ print.discrim_flexible <- function(x, ...) {
   cat("Flexible Discriminant Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
+  if (!is.null(x$method$fit$args) && has_loaded_implementation(class(x)[1], x$engine, x$mode)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/discrim_flexible.R
+++ b/R/discrim_flexible.R
@@ -50,7 +50,7 @@ print.discrim_flexible <- function(x, ...) {
   cat("Flexible Discriminant Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(class(x)[1], x$engine, x$mode)) {
+  if (is_printable_spec(x)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/discrim_flexible.R
+++ b/R/discrim_flexible.R
@@ -50,7 +50,7 @@ print.discrim_flexible <- function(x, ...) {
   cat("Flexible Discriminant Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args)) {
+  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/discrim_linear.R
+++ b/R/discrim_linear.R
@@ -52,7 +52,7 @@ print.discrim_linear <- function(x, ...) {
   cat("Linear Discriminant Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
+  if (!is.null(x$method$fit$args)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/discrim_linear.R
+++ b/R/discrim_linear.R
@@ -52,7 +52,7 @@ print.discrim_linear <- function(x, ...) {
   cat("Linear Discriminant Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
+  if (!is.null(x$method$fit$args) && has_loaded_implementation(class(x)[1], x$engine, x$mode)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/discrim_linear.R
+++ b/R/discrim_linear.R
@@ -52,7 +52,7 @@ print.discrim_linear <- function(x, ...) {
   cat("Linear Discriminant Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(class(x)[1], x$engine, x$mode)) {
+  if (is_printable_spec(x)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/discrim_linear.R
+++ b/R/discrim_linear.R
@@ -52,7 +52,7 @@ print.discrim_linear <- function(x, ...) {
   cat("Linear Discriminant Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args)) {
+  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/discrim_quad.R
+++ b/R/discrim_quad.R
@@ -46,7 +46,7 @@ print.discrim_quad <- function(x, ...) {
   cat("Quadratic Discriminant Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(class(x)[1], x$engine, x$mode)) {
+  if (is_printable_spec(x)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/discrim_quad.R
+++ b/R/discrim_quad.R
@@ -46,7 +46,7 @@ print.discrim_quad <- function(x, ...) {
   cat("Quadratic Discriminant Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args)) {
+  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/discrim_quad.R
+++ b/R/discrim_quad.R
@@ -46,7 +46,7 @@ print.discrim_quad <- function(x, ...) {
   cat("Quadratic Discriminant Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
+  if (!is.null(x$method$fit$args) && has_loaded_implementation(class(x)[1], x$engine, x$mode)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/discrim_quad.R
+++ b/R/discrim_quad.R
@@ -46,7 +46,7 @@ print.discrim_quad <- function(x, ...) {
   cat("Quadratic Discriminant Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
+  if (!is.null(x$method$fit$args)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/discrim_regularized.R
+++ b/R/discrim_regularized.R
@@ -67,7 +67,7 @@ print.discrim_regularized <- function(x, ...) {
   cat("Regularized Discriminant Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args)) {
+  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/discrim_regularized.R
+++ b/R/discrim_regularized.R
@@ -67,7 +67,7 @@ print.discrim_regularized <- function(x, ...) {
   cat("Regularized Discriminant Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
+  if (!is.null(x$method$fit$args)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/discrim_regularized.R
+++ b/R/discrim_regularized.R
@@ -67,7 +67,7 @@ print.discrim_regularized <- function(x, ...) {
   cat("Regularized Discriminant Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(class(x)[1], x$engine, x$mode)) {
+  if (is_printable_spec(x)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/discrim_regularized.R
+++ b/R/discrim_regularized.R
@@ -67,7 +67,7 @@ print.discrim_regularized <- function(x, ...) {
   cat("Regularized Discriminant Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
+  if (!is.null(x$method$fit$args) && has_loaded_implementation(class(x)[1], x$engine, x$mode)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/engine_docs.R
+++ b/R/engine_docs.R
@@ -243,7 +243,10 @@ make_engine_list <- function(mod) {
 
 get_default_engine <- function(mod, pkg = "parsnip") {
   cl <- rlang::call2(mod, .ns = pkg)
-  rlang::eval_tidy(cl)$engine
+  suppressMessages(
+    res <- rlang::eval_tidy(cl)$engine
+  )
+  res
 }
 
 #' @export

--- a/R/engines.R
+++ b/R/engines.R
@@ -129,7 +129,8 @@ set_engine <- function(object, engine, ...) {
     eng_args = enquos(...),
     mode = object$mode,
     method = NULL,
-    engine = object$engine
+    engine = object$engine,
+    new = FALSE
   )
 }
 

--- a/R/engines.R
+++ b/R/engines.R
@@ -130,7 +130,7 @@ set_engine <- function(object, engine, ...) {
     mode = object$mode,
     method = NULL,
     engine = object$engine,
-    new = FALSE
+    check_missing_spec = FALSE
   )
 }
 

--- a/R/gen_additive_mod.R
+++ b/R/gen_additive_mod.R
@@ -55,7 +55,7 @@ print.gen_additive_mod <- function(x, ...) {
   cat("GAM Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
+  if(!is.null(x$method$fit$args)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/gen_additive_mod.R
+++ b/R/gen_additive_mod.R
@@ -55,7 +55,7 @@ print.gen_additive_mod <- function(x, ...) {
   cat("GAM Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
+  if (!is.null(x$method$fit$args) && has_loaded_implementation(class(x)[1], x$engine, x$mode)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/gen_additive_mod.R
+++ b/R/gen_additive_mod.R
@@ -55,7 +55,7 @@ print.gen_additive_mod <- function(x, ...) {
   cat("GAM Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(class(x)[1], x$engine, x$mode)) {
+  if (is_printable_spec(x)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/gen_additive_mod.R
+++ b/R/gen_additive_mod.R
@@ -55,7 +55,7 @@ print.gen_additive_mod <- function(x, ...) {
   cat("GAM Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if(!is.null(x$method$fit$args)) {
+  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/linear_reg.R
+++ b/R/linear_reg.R
@@ -63,7 +63,7 @@ print.linear_reg <- function(x, ...) {
   cat("Linear Regression Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(class(x)[1], x$engine, x$mode)) {
+  if (is_printable_spec(x)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/linear_reg.R
+++ b/R/linear_reg.R
@@ -63,7 +63,7 @@ print.linear_reg <- function(x, ...) {
   cat("Linear Regression Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
+  if (!is.null(x$method$fit$args)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/linear_reg.R
+++ b/R/linear_reg.R
@@ -63,7 +63,7 @@ print.linear_reg <- function(x, ...) {
   cat("Linear Regression Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args)) {
+  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/linear_reg.R
+++ b/R/linear_reg.R
@@ -63,7 +63,7 @@ print.linear_reg <- function(x, ...) {
   cat("Linear Regression Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
+  if (!is.null(x$method$fit$args) && has_loaded_implementation(class(x)[1], x$engine, x$mode)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/logistic_reg.R
+++ b/R/logistic_reg.R
@@ -70,7 +70,7 @@ print.logistic_reg <- function(x, ...) {
   cat("Logistic Regression Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if(!is.null(x$method$fit$args)) {
+  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/logistic_reg.R
+++ b/R/logistic_reg.R
@@ -70,7 +70,7 @@ print.logistic_reg <- function(x, ...) {
   cat("Logistic Regression Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
+  if(!is.null(x$method$fit$args)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/logistic_reg.R
+++ b/R/logistic_reg.R
@@ -70,7 +70,7 @@ print.logistic_reg <- function(x, ...) {
   cat("Logistic Regression Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(class(x)[1], x$engine, x$mode)) {
+  if (is_printable_spec(x)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/logistic_reg.R
+++ b/R/logistic_reg.R
@@ -70,7 +70,7 @@ print.logistic_reg <- function(x, ...) {
   cat("Logistic Regression Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
+  if (!is.null(x$method$fit$args) && has_loaded_implementation(class(x)[1], x$engine, x$mode)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/mars.R
+++ b/R/mars.R
@@ -54,7 +54,7 @@ print.mars <- function(x, ...) {
   cat("MARS Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
+  if(!is.null(x$method$fit$args)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/mars.R
+++ b/R/mars.R
@@ -54,7 +54,7 @@ print.mars <- function(x, ...) {
   cat("MARS Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
+  if (!is.null(x$method$fit$args) && has_loaded_implementation(class(x)[1], x$engine, x$mode)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/mars.R
+++ b/R/mars.R
@@ -54,7 +54,7 @@ print.mars <- function(x, ...) {
   cat("MARS Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if(!is.null(x$method$fit$args)) {
+  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/mars.R
+++ b/R/mars.R
@@ -54,7 +54,7 @@ print.mars <- function(x, ...) {
   cat("MARS Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(class(x)[1], x$engine, x$mode)) {
+  if (is_printable_spec(x)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/misc.R
+++ b/R/misc.R
@@ -241,11 +241,12 @@ update_dot_check <- function(...) {
 #' @export
 #' @keywords internal
 #' @rdname add_on_exports
-new_model_spec <- function(cls, args, eng_args, mode, method, engine, new = TRUE) {
+new_model_spec <- function(cls, args, eng_args, mode, method, engine,
+                           check_missing_spec = TRUE) {
 
   check_spec_mode_engine_val(cls, engine, mode)
 
-  if ((!has_loaded_implementation(cls, engine, mode)) && new) {
+  if ((!has_loaded_implementation(cls, engine, mode)) && check_missing_spec) {
     rlang::inform(prompt_missing_implementation(cls, engine, mode))
   }
 

--- a/R/misc.R
+++ b/R/misc.R
@@ -119,10 +119,14 @@ prompt_missing_implementation <- function(spec_, engine_, mode_) {
     dplyr::filter(model == spec_, mode == mode_, engine == engine_, !is.na(pkg)) %>%
     dplyr::select(-model)
 
+  if (identical(mode_, "unknown")) {
+    mode_ <- ""
+  }
+
   msg <-
     glue::glue(
-      "A parsnip implementation for `{spec_}` {mode_} model ",
-      "specifications using the `{engine_}` engine is not loaded."
+      "parsnip could not locate an implementation for `{spec_}` {mode_} model ",
+      "specifications using the `{engine_}` engine."
     )
 
   if (nrow(avail) == 0 && nrow(all) > 0) {
@@ -132,7 +136,7 @@ prompt_missing_implementation <- function(spec_, engine_, mode_) {
         glue::glue_collapse(c(
           "\nThe parsnip extension package {",
           cli::col_yellow(all$pkg[[1]]),
-          "} implements support for this specification/mode/engine combination. \n",
+          "} implements support for this specification. \n",
           "Please install (if needed) and load to continue.\n"
         ))
       ))

--- a/R/misc.R
+++ b/R/misc.R
@@ -140,7 +140,8 @@ prompt_missing_implementation <- function(spec_, engine_, mode_) {
         msg,
         i = paste0("The parsnip extension package ", all$pkg[[1]],
                    " implements support for this specification."),
-        i = "Please install (if needed) and load to continue."
+        i = "Please install (if needed) and load to continue.",
+        ""
       )
   }
 

--- a/R/misc.R
+++ b/R/misc.R
@@ -79,6 +79,9 @@ model_printer <- function(x, ...) {
 is_missing_arg <- function(x)
   identical(x, quote(missing_arg()))
 
+model_info_table <-
+  utils::read.delim(system.file("models.tsv", package = "parsnip"))
+
 # given a model object, return TRUE if:
 # * the model is supported without extensions
 # * the model needs an extension and it is loaded
@@ -95,7 +98,7 @@ has_loaded_implementation <- function(spec_, engine_, mode_) {
     get_from_env(spec_) %>%
     dplyr::filter(mode %in% mode_, !!eng_cond)
   pars <-
-    utils::read.delim(system.file("models.tsv", package = "parsnip")) %>%
+    model_info_table %>%
     dplyr::filter(model == spec_, !!eng_cond, mode %in% mode_, is.na(pkg))
 
   if (nrow(pars) > 0 || nrow(avail) > 0) {
@@ -120,7 +123,7 @@ inform_missing_implementation <- function(spec_, engine_, mode_) {
     show_engines(spec_) %>%
     dplyr::filter(mode == mode_, engine == engine_)
   all <-
-    utils::read.delim(system.file("models.tsv", package = "parsnip")) %>%
+    model_info_table %>%
     dplyr::filter(model == spec_, mode == mode_, engine == engine_, !is.na(pkg)) %>%
     dplyr::select(-model)
 

--- a/R/misc.R
+++ b/R/misc.R
@@ -125,21 +125,18 @@ prompt_missing_implementation <- function(spec_, engine_, mode_) {
 
   msg <-
     glue::glue(
-      "parsnip could not locate an implementation for `{spec_}` {mode_} model ",
-      "specifications using the `{engine_}` engine."
+      "parsnip could not locate an implementation for `{spec_}` {mode_} model \\
+       specifications using the `{engine_}` engine."
     )
 
   if (nrow(avail) == 0 && nrow(all) > 0) {
     msg <-
-      glue::glue_collapse(c(
+      c(
         msg,
-        glue::glue_collapse(c(
-          "\nThe parsnip extension package {",
-          cli::col_yellow(all$pkg[[1]]),
-          "} implements support for this specification. \n",
-          "Please install (if needed) and load to continue.\n"
-        ))
-      ))
+        i = paste0("The parsnip extension package ", all$pkg[[1]],
+                   " implements support for this specification."),
+        i = "Please install (if needed) and load to continue."
+      )
   }
 
   msg

--- a/R/misc.R
+++ b/R/misc.R
@@ -122,7 +122,7 @@ prompt_missing_implementation <- function(spec_, engine_, mode_) {
   msg <-
     glue::glue(
       "A parsnip implementation for `{spec_}` {mode_} model ",
-      "specifications using the `{engine_}` engine is not loaded. "
+      "specifications using the `{engine_}` engine is not loaded."
     )
 
   if (nrow(avail) == 0 && nrow(all) > 0) {
@@ -130,9 +130,9 @@ prompt_missing_implementation <- function(spec_, engine_, mode_) {
       glue::glue_collapse(c(
         msg,
         glue::glue_collapse(c(
-          "The parsnip extension package {",
+          "\nThe parsnip extension package {",
           cli::col_yellow(all$pkg[[1]]),
-          "} implements support for this specification/mode/engine combination. ",
+          "} implements support for this specification/mode/engine combination. \n",
           "Please install (if needed) and load to continue.\n"
         ))
       ))

--- a/R/misc.R
+++ b/R/misc.R
@@ -92,7 +92,7 @@ has_loaded_implementation <- function(x) {
   spec_ <- class(x)[1]
   mode_ <- x$mode
 
-  if (mode_ == "unknown") {
+  if (isFALSE(mode_ %in% c("regression", "censored regression", "classification"))) {
     mode_ <- c("regression", "censored regression", "classification")
   }
 

--- a/R/misc.R
+++ b/R/misc.R
@@ -115,7 +115,7 @@ is_printable_spec <- function(x) {
 #
 # if there's a "pre-registered" extension supporting that setup,
 # nudge the user to install/load it.
-prompt_missing_implementation <- function(spec_, engine_, mode_) {
+inform_missing_implementation <- function(spec_, engine_, mode_) {
   avail <-
     show_engines(spec_) %>%
     dplyr::filter(mode == mode_, engine == engine_)
@@ -247,7 +247,7 @@ new_model_spec <- function(cls, args, eng_args, mode, method, engine,
   check_spec_mode_engine_val(cls, engine, mode)
 
   if ((!has_loaded_implementation(cls, engine, mode)) && check_missing_spec) {
-    rlang::inform(prompt_missing_implementation(cls, engine, mode))
+    rlang::inform(inform_missing_implementation(cls, engine, mode))
   }
 
   out <- list(args = args, eng_args = eng_args,

--- a/R/misc.R
+++ b/R/misc.R
@@ -105,6 +105,11 @@ has_loaded_implementation <- function(spec_, engine_, mode_) {
   FALSE
 }
 
+is_printable_spec <- function(x) {
+  !is.null(x$method$fit$args) &&
+  has_loaded_implementation(class(x)[1], x$engine, x$mode)
+}
+
 # construct a message informing the user that there are no
 # implementations for the current model spec / mode / engine.
 #

--- a/R/mlp.R
+++ b/R/mlp.R
@@ -64,7 +64,7 @@ print.mlp <- function(x, ...) {
   cat("Single Layer Neural Network Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(class(x)[1], x$engine, x$mode)) {
+  if (is_printable_spec(x)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/mlp.R
+++ b/R/mlp.R
@@ -64,7 +64,7 @@ print.mlp <- function(x, ...) {
   cat("Single Layer Neural Network Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if(!is.null(x$method$fit$args)) {
+  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/mlp.R
+++ b/R/mlp.R
@@ -64,7 +64,7 @@ print.mlp <- function(x, ...) {
   cat("Single Layer Neural Network Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
+  if (!is.null(x$method$fit$args) && has_loaded_implementation(class(x)[1], x$engine, x$mode)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/mlp.R
+++ b/R/mlp.R
@@ -64,7 +64,7 @@ print.mlp <- function(x, ...) {
   cat("Single Layer Neural Network Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
+  if(!is.null(x$method$fit$args)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/multinom_reg.R
+++ b/R/multinom_reg.R
@@ -70,7 +70,7 @@ print.multinom_reg <- function(x, ...) {
   cat("Multinomial Regression Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(class(x)[1], x$engine, x$mode)) {
+  if (is_printable_spec(x)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/multinom_reg.R
+++ b/R/multinom_reg.R
@@ -70,7 +70,7 @@ print.multinom_reg <- function(x, ...) {
   cat("Multinomial Regression Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
+  if (!is.null(x$method$fit$args) && has_loaded_implementation(class(x)[1], x$engine, x$mode)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/multinom_reg.R
+++ b/R/multinom_reg.R
@@ -70,7 +70,7 @@ print.multinom_reg <- function(x, ...) {
   cat("Multinomial Regression Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
+  if (!is.null(x$method$fit$args)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/multinom_reg.R
+++ b/R/multinom_reg.R
@@ -70,7 +70,7 @@ print.multinom_reg <- function(x, ...) {
   cat("Multinomial Regression Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args)) {
+  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/naive_Bayes.R
+++ b/R/naive_Bayes.R
@@ -49,7 +49,7 @@ print.naive_Bayes <- function(x, ...) {
   cat("Naive Bayes Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args)) {
+  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/naive_Bayes.R
+++ b/R/naive_Bayes.R
@@ -49,7 +49,7 @@ print.naive_Bayes <- function(x, ...) {
   cat("Naive Bayes Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
+  if (!is.null(x$method$fit$args) && has_loaded_implementation(class(x)[1], x$engine, x$mode)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/naive_Bayes.R
+++ b/R/naive_Bayes.R
@@ -49,7 +49,7 @@ print.naive_Bayes <- function(x, ...) {
   cat("Naive Bayes Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
+  if (!is.null(x$method$fit$args)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/naive_Bayes.R
+++ b/R/naive_Bayes.R
@@ -49,7 +49,7 @@ print.naive_Bayes <- function(x, ...) {
   cat("Naive Bayes Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(class(x)[1], x$engine, x$mode)) {
+  if (is_printable_spec(x)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/nearest_neighbor.R
+++ b/R/nearest_neighbor.R
@@ -60,7 +60,7 @@ print.nearest_neighbor <- function(x, ...) {
   cat("K-Nearest Neighbor Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
+  if (!is.null(x$method$fit$args) && has_loaded_implementation(class(x)[1], x$engine, x$mode)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/nearest_neighbor.R
+++ b/R/nearest_neighbor.R
@@ -60,7 +60,7 @@ print.nearest_neighbor <- function(x, ...) {
   cat("K-Nearest Neighbor Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(class(x)[1], x$engine, x$mode)) {
+  if (is_printable_spec(x)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/nearest_neighbor.R
+++ b/R/nearest_neighbor.R
@@ -60,7 +60,7 @@ print.nearest_neighbor <- function(x, ...) {
   cat("K-Nearest Neighbor Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if(!is.null(x$method$fit$args)) {
+  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/nearest_neighbor.R
+++ b/R/nearest_neighbor.R
@@ -60,7 +60,7 @@ print.nearest_neighbor <- function(x, ...) {
   cat("K-Nearest Neighbor Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
+  if(!is.null(x$method$fit$args)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/pls.R
+++ b/R/pls.R
@@ -45,7 +45,7 @@ print.pls <- function(x, ...) {
   cat("PLS Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
+  if (!is.null(x$method$fit$args) && has_loaded_implementation(class(x)[1], x$engine, x$mode)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/pls.R
+++ b/R/pls.R
@@ -45,7 +45,7 @@ print.pls <- function(x, ...) {
   cat("PLS Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args)) {
+  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/pls.R
+++ b/R/pls.R
@@ -45,7 +45,7 @@ print.pls <- function(x, ...) {
   cat("PLS Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
+  if (!is.null(x$method$fit$args)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/pls.R
+++ b/R/pls.R
@@ -45,7 +45,7 @@ print.pls <- function(x, ...) {
   cat("PLS Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(class(x)[1], x$engine, x$mode)) {
+  if (is_printable_spec(x)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/poisson_reg.R
+++ b/R/poisson_reg.R
@@ -56,7 +56,7 @@ print.poisson_reg <- function(x, ...) {
   cat("Poisson Regression Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
+  if (!is.null(x$method$fit$args) && has_loaded_implementation(class(x)[1], x$engine, x$mode)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/poisson_reg.R
+++ b/R/poisson_reg.R
@@ -56,7 +56,7 @@ print.poisson_reg <- function(x, ...) {
   cat("Poisson Regression Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
+  if (!is.null(x$method$fit$args)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/poisson_reg.R
+++ b/R/poisson_reg.R
@@ -56,7 +56,7 @@ print.poisson_reg <- function(x, ...) {
   cat("Poisson Regression Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args)) {
+  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/poisson_reg.R
+++ b/R/poisson_reg.R
@@ -56,7 +56,7 @@ print.poisson_reg <- function(x, ...) {
   cat("Poisson Regression Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(class(x)[1], x$engine, x$mode)) {
+  if (is_printable_spec(x)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/proportional_hazards.R
+++ b/R/proportional_hazards.R
@@ -58,7 +58,7 @@ print.proportional_hazards <- function(x, ...) {
   cat("Proportional Hazards Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
+  if (!is.null(x$method$fit$args) && has_loaded_implementation(class(x)[1], x$engine, x$mode)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/proportional_hazards.R
+++ b/R/proportional_hazards.R
@@ -58,7 +58,7 @@ print.proportional_hazards <- function(x, ...) {
   cat("Proportional Hazards Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args)) {
+  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/proportional_hazards.R
+++ b/R/proportional_hazards.R
@@ -58,7 +58,7 @@ print.proportional_hazards <- function(x, ...) {
   cat("Proportional Hazards Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(class(x)[1], x$engine, x$mode)) {
+  if (is_printable_spec(x)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/proportional_hazards.R
+++ b/R/proportional_hazards.R
@@ -58,7 +58,7 @@ print.proportional_hazards <- function(x, ...) {
   cat("Proportional Hazards Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
+  if (!is.null(x$method$fit$args)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/rand_forest.R
+++ b/R/rand_forest.R
@@ -56,7 +56,7 @@ print.rand_forest <- function(x, ...) {
   cat("Random Forest Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
+  if(!is.null(x$method$fit$args)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/rand_forest.R
+++ b/R/rand_forest.R
@@ -56,7 +56,7 @@ print.rand_forest <- function(x, ...) {
   cat("Random Forest Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if(!is.null(x$method$fit$args)) {
+  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/rand_forest.R
+++ b/R/rand_forest.R
@@ -56,7 +56,7 @@ print.rand_forest <- function(x, ...) {
   cat("Random Forest Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
+  if (!is.null(x$method$fit$args) && has_loaded_implementation(class(x)[1], x$engine, x$mode)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/rand_forest.R
+++ b/R/rand_forest.R
@@ -56,7 +56,7 @@ print.rand_forest <- function(x, ...) {
   cat("Random Forest Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(class(x)[1], x$engine, x$mode)) {
+  if (is_printable_spec(x)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/rule_fit.R
+++ b/R/rule_fit.R
@@ -70,7 +70,7 @@ print.rule_fit <- function(x, ...) {
   cat("RuleFit Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(class(x)[1], x$engine, x$mode)) {
+  if (is_printable_spec(x)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/rule_fit.R
+++ b/R/rule_fit.R
@@ -70,7 +70,7 @@ print.rule_fit <- function(x, ...) {
   cat("RuleFit Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
+  if (!is.null(x$method$fit$args)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/rule_fit.R
+++ b/R/rule_fit.R
@@ -70,7 +70,7 @@ print.rule_fit <- function(x, ...) {
   cat("RuleFit Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args)) {
+  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/rule_fit.R
+++ b/R/rule_fit.R
@@ -70,7 +70,7 @@ print.rule_fit <- function(x, ...) {
   cat("RuleFit Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
+  if (!is.null(x$method$fit$args) && has_loaded_implementation(class(x)[1], x$engine, x$mode)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/surv_reg.R
+++ b/R/surv_reg.R
@@ -57,7 +57,7 @@ print.surv_reg <- function(x, ...) {
   cat("Parametric Survival Regression Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
+  if (!is.null(x$method$fit$args) && has_loaded_implementation(class(x)[1], x$engine, x$mode)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/surv_reg.R
+++ b/R/surv_reg.R
@@ -57,7 +57,7 @@ print.surv_reg <- function(x, ...) {
   cat("Parametric Survival Regression Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(class(x)[1], x$engine, x$mode)) {
+  if (is_printable_spec(x)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/surv_reg.R
+++ b/R/surv_reg.R
@@ -57,7 +57,7 @@ print.surv_reg <- function(x, ...) {
   cat("Parametric Survival Regression Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if(!is.null(x$method$fit$args)) {
+  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/surv_reg.R
+++ b/R/surv_reg.R
@@ -57,7 +57,7 @@ print.surv_reg <- function(x, ...) {
   cat("Parametric Survival Regression Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
+  if(!is.null(x$method$fit$args)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/survival_reg.R
+++ b/R/survival_reg.R
@@ -51,7 +51,7 @@ print.survival_reg <- function(x, ...) {
   cat("Parametric Survival Regression Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
+  if (!is.null(x$method$fit$args)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/survival_reg.R
+++ b/R/survival_reg.R
@@ -51,7 +51,7 @@ print.survival_reg <- function(x, ...) {
   cat("Parametric Survival Regression Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args)) {
+  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/survival_reg.R
+++ b/R/survival_reg.R
@@ -51,7 +51,7 @@ print.survival_reg <- function(x, ...) {
   cat("Parametric Survival Regression Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(class(x)[1], x$engine, x$mode)) {
+  if (is_printable_spec(x)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/survival_reg.R
+++ b/R/survival_reg.R
@@ -51,7 +51,7 @@ print.survival_reg <- function(x, ...) {
   cat("Parametric Survival Regression Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
+  if (!is.null(x$method$fit$args) && has_loaded_implementation(class(x)[1], x$engine, x$mode)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/svm_linear.R
+++ b/R/svm_linear.R
@@ -55,7 +55,7 @@ print.svm_linear <- function(x, ...) {
   cat("Linear Support Vector Machine Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if(!is.null(x$method$fit$args)) {
+  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/svm_linear.R
+++ b/R/svm_linear.R
@@ -55,7 +55,7 @@ print.svm_linear <- function(x, ...) {
   cat("Linear Support Vector Machine Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(class(x)[1], x$engine, x$mode)) {
+  if (is_printable_spec(x)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/svm_linear.R
+++ b/R/svm_linear.R
@@ -55,7 +55,7 @@ print.svm_linear <- function(x, ...) {
   cat("Linear Support Vector Machine Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
+  if (!is.null(x$method$fit$args) && has_loaded_implementation(class(x)[1], x$engine, x$mode)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/svm_linear.R
+++ b/R/svm_linear.R
@@ -55,7 +55,7 @@ print.svm_linear <- function(x, ...) {
   cat("Linear Support Vector Machine Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
+  if(!is.null(x$method$fit$args)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/svm_poly.R
+++ b/R/svm_poly.R
@@ -60,7 +60,7 @@ print.svm_poly <- function(x, ...) {
   cat("Polynomial Support Vector Machine Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if(!is.null(x$method$fit$args)) {
+  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/svm_poly.R
+++ b/R/svm_poly.R
@@ -60,7 +60,7 @@ print.svm_poly <- function(x, ...) {
   cat("Polynomial Support Vector Machine Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
+  if(!is.null(x$method$fit$args)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/svm_poly.R
+++ b/R/svm_poly.R
@@ -60,7 +60,7 @@ print.svm_poly <- function(x, ...) {
   cat("Polynomial Support Vector Machine Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(class(x)[1], x$engine, x$mode)) {
+  if (is_printable_spec(x)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/svm_poly.R
+++ b/R/svm_poly.R
@@ -60,7 +60,7 @@ print.svm_poly <- function(x, ...) {
   cat("Polynomial Support Vector Machine Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
+  if (!is.null(x$method$fit$args) && has_loaded_implementation(class(x)[1], x$engine, x$mode)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/svm_rbf.R
+++ b/R/svm_rbf.R
@@ -61,7 +61,7 @@ print.svm_rbf <- function(x, ...) {
   cat("Radial Basis Function Support Vector Machine Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
+  if (!is.null(x$method$fit$args) && has_loaded_implementation(class(x)[1], x$engine, x$mode)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/svm_rbf.R
+++ b/R/svm_rbf.R
@@ -61,7 +61,7 @@ print.svm_rbf <- function(x, ...) {
   cat("Radial Basis Function Support Vector Machine Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(class(x)[1], x$engine, x$mode)) {
+  if (is_printable_spec(x)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/svm_rbf.R
+++ b/R/svm_rbf.R
@@ -61,7 +61,7 @@ print.svm_rbf <- function(x, ...) {
   cat("Radial Basis Function Support Vector Machine Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
+  if(!is.null(x$method$fit$args)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/svm_rbf.R
+++ b/R/svm_rbf.R
@@ -61,7 +61,7 @@ print.svm_rbf <- function(x, ...) {
   cat("Radial Basis Function Support Vector Machine Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
-  if(!is.null(x$method$fit$args)) {
+  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/translate.R
+++ b/R/translate.R
@@ -101,7 +101,7 @@ translate.default <- function(x, engine = x$engine, ...) {
 print.model_spec <- function(x, ...) {
   cat("Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
-  if (!is.null(x$method$fit$args)) {
+  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/translate.R
+++ b/R/translate.R
@@ -101,7 +101,7 @@ translate.default <- function(x, engine = x$engine, ...) {
 print.model_spec <- function(x, ...) {
   cat("Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
+  if (!is.null(x$method$fit$args) && has_loaded_implementation(class(x)[1], x$engine, x$mode)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/translate.R
+++ b/R/translate.R
@@ -101,7 +101,7 @@ translate.default <- function(x, engine = x$engine, ...) {
 print.model_spec <- function(x, ...) {
   cat("Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(x)) {
+  if (!is.null(x$method$fit$args)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/translate.R
+++ b/R/translate.R
@@ -101,7 +101,7 @@ translate.default <- function(x, engine = x$engine, ...) {
 print.model_spec <- function(x, ...) {
   cat("Model Specification (", x$mode, ")\n\n", sep = "")
   model_printer(x, ...)
-  if (!is.null(x$method$fit$args) && has_loaded_implementation(class(x)[1], x$engine, x$mode)) {
+  if (is_printable_spec(x)) {
     cat("Model fit template:\n")
     print(show_call(x))
   }

--- a/R/update.R
+++ b/R/update.R
@@ -88,6 +88,6 @@ update_spec <- function(object, parameters, args_enquo_list, fresh, cls, ...) {
     mode = object$mode,
     method = NULL,
     engine = object$engine,
-    new = FALSE
+    check_missing_spec = FALSE
   )
 }

--- a/R/update.R
+++ b/R/update.R
@@ -87,6 +87,7 @@ update_spec <- function(object, parameters, args_enquo_list, fresh, cls, ...) {
     eng_args = object$eng_args,
     mode = object$mode,
     method = NULL,
-    engine = object$engine
+    engine = object$engine,
+    new = FALSE
   )
 }

--- a/man/add_on_exports.Rd
+++ b/man/add_on_exports.Rd
@@ -18,7 +18,7 @@ show_fit(model, eng)
 
 update_dot_check(...)
 
-new_model_spec(cls, args, eng_args, mode, method, engine)
+new_model_spec(cls, args, eng_args, mode, method, engine, new = TRUE)
 
 check_final_param(x)
 

--- a/man/add_on_exports.Rd
+++ b/man/add_on_exports.Rd
@@ -18,7 +18,15 @@ show_fit(model, eng)
 
 update_dot_check(...)
 
-new_model_spec(cls, args, eng_args, mode, method, engine, new = TRUE)
+new_model_spec(
+  cls,
+  args,
+  eng_args,
+  mode,
+  method,
+  engine,
+  check_missing_spec = TRUE
+)
 
 check_final_param(x)
 

--- a/tests/testthat/_snaps/misc.md
+++ b/tests/testthat/_snaps/misc.md
@@ -1,0 +1,16 @@
+# model type functions message informatively with unknown implementation
+
+    Code
+      bag_tree() %>% set_engine("rpart")
+    Message
+      parsnip could not locate an implementation for `bag_tree`  model specifications using the `rpart` engine.
+    Output
+      Bagged Decision Tree Model Specification (unknown)
+      
+      Main Arguments:
+        cost_complexity = 0
+        min_n = 2
+      
+      Computational engine: rpart 
+      
+

--- a/tests/testthat/_snaps/proportional_hazards.md
+++ b/tests/testthat/_snaps/proportional_hazards.md
@@ -3,8 +3,8 @@
     Code
       proportional_hazards()
     Message
-      A parsnip implementation for `proportional_hazards` censored regression model specifications using the `survival` engine is not loaded.
-      The parsnip extension package {censored} implements support for this specification/mode/engine combination. 
+      parsnip could not locate an implementation for `proportional_hazards` censored regression model specifications using the `survival` engine.
+      The parsnip extension package {censored} implements support for this specification. 
       Please install (if needed) and load to continue.
     Output
       Proportional Hazards Model Specification (censored regression)
@@ -17,8 +17,8 @@
     Code
       proportional_hazards() %>% update(penalty = tune())
     Message
-      A parsnip implementation for `proportional_hazards` censored regression model specifications using the `survival` engine is not loaded.
-      The parsnip extension package {censored} implements support for this specification/mode/engine combination. 
+      parsnip could not locate an implementation for `proportional_hazards` censored regression model specifications using the `survival` engine.
+      The parsnip extension package {censored} implements support for this specification. 
       Please install (if needed) and load to continue.
     Output
       Proportional Hazards Model Specification (censored regression)

--- a/tests/testthat/_snaps/proportional_hazards.md
+++ b/tests/testthat/_snaps/proportional_hazards.md
@@ -1,7 +1,21 @@
+# printing
+
+    Code
+      proportional_hazards()
+    Message
+      A parsnip implementation for `proportional_hazards` censored regression model specifications using the `survival` engine is not loaded. The parsnip extension package {censored} implements support for this specification/mode/engine combination. Please install (if needed) and load to continue.
+    Output
+      Proportional Hazards Model Specification (censored regression)
+      
+      Computational engine: survival 
+      
+
 # updating
 
     Code
       proportional_hazards() %>% update(penalty = tune())
+    Message
+      A parsnip implementation for `proportional_hazards` censored regression model specifications using the `survival` engine is not loaded. The parsnip extension package {censored} implements support for this specification/mode/engine combination. Please install (if needed) and load to continue.
     Output
       Proportional Hazards Model Specification (censored regression)
       
@@ -10,7 +24,4 @@
       
       Computational engine: survival 
       
-      A parsnip implementation for `proportional_hazards` censored regression model specifications using the `survival` engine is not loaded.
-      The parsnip extension package {censored} implements support for this specification/mode/engine combination. 
-      Please install (if needed) and load to continue.
 

--- a/tests/testthat/_snaps/proportional_hazards.md
+++ b/tests/testthat/_snaps/proportional_hazards.md
@@ -10,4 +10,7 @@
       
       Computational engine: survival 
       
+      A parsnip implementation for `proportional_hazards` censored regression model specifications using the `survival` engine is not loaded.
+      The parsnip extension package {censored} implements support for this specification/mode/engine combination. 
+      Please install (if needed) and load to continue.
 

--- a/tests/testthat/_snaps/proportional_hazards.md
+++ b/tests/testthat/_snaps/proportional_hazards.md
@@ -3,7 +3,9 @@
     Code
       proportional_hazards()
     Message
-      A parsnip implementation for `proportional_hazards` censored regression model specifications using the `survival` engine is not loaded. The parsnip extension package {censored} implements support for this specification/mode/engine combination. Please install (if needed) and load to continue.
+      A parsnip implementation for `proportional_hazards` censored regression model specifications using the `survival` engine is not loaded.
+      The parsnip extension package {censored} implements support for this specification/mode/engine combination. 
+      Please install (if needed) and load to continue.
     Output
       Proportional Hazards Model Specification (censored regression)
       
@@ -15,7 +17,9 @@
     Code
       proportional_hazards() %>% update(penalty = tune())
     Message
-      A parsnip implementation for `proportional_hazards` censored regression model specifications using the `survival` engine is not loaded. The parsnip extension package {censored} implements support for this specification/mode/engine combination. Please install (if needed) and load to continue.
+      A parsnip implementation for `proportional_hazards` censored regression model specifications using the `survival` engine is not loaded.
+      The parsnip extension package {censored} implements support for this specification/mode/engine combination. 
+      Please install (if needed) and load to continue.
     Output
       Proportional Hazards Model Specification (censored regression)
       

--- a/tests/testthat/_snaps/proportional_hazards.md
+++ b/tests/testthat/_snaps/proportional_hazards.md
@@ -4,8 +4,8 @@
       proportional_hazards()
     Message
       parsnip could not locate an implementation for `proportional_hazards` censored regression model specifications using the `survival` engine.
-      The parsnip extension package {censored} implements support for this specification. 
-      Please install (if needed) and load to continue.
+      i The parsnip extension package censored implements support for this specification.
+      i Please install (if needed) and load to continue.
     Output
       Proportional Hazards Model Specification (censored regression)
       
@@ -18,8 +18,8 @@
       proportional_hazards() %>% update(penalty = tune())
     Message
       parsnip could not locate an implementation for `proportional_hazards` censored regression model specifications using the `survival` engine.
-      The parsnip extension package {censored} implements support for this specification. 
-      Please install (if needed) and load to continue.
+      i The parsnip extension package censored implements support for this specification.
+      i Please install (if needed) and load to continue.
     Output
       Proportional Hazards Model Specification (censored regression)
       

--- a/tests/testthat/_snaps/survival_reg.md
+++ b/tests/testthat/_snaps/survival_reg.md
@@ -4,8 +4,8 @@
       survival_reg() %>% update(dist = "lnorm")
     Message
       parsnip could not locate an implementation for `survival_reg` censored regression model specifications using the `survival` engine.
-      The parsnip extension package {censored} implements support for this specification. 
-      Please install (if needed) and load to continue.
+      i The parsnip extension package censored implements support for this specification.
+      i Please install (if needed) and load to continue.
     Output
       Parametric Survival Regression Model Specification (censored regression)
       

--- a/tests/testthat/_snaps/survival_reg.md
+++ b/tests/testthat/_snaps/survival_reg.md
@@ -3,7 +3,9 @@
     Code
       survival_reg() %>% update(dist = "lnorm")
     Message
-      A parsnip implementation for `survival_reg` censored regression model specifications using the `survival` engine is not loaded. The parsnip extension package {censored} implements support for this specification/mode/engine combination. Please install (if needed) and load to continue.
+      A parsnip implementation for `survival_reg` censored regression model specifications using the `survival` engine is not loaded.
+      The parsnip extension package {censored} implements support for this specification/mode/engine combination. 
+      Please install (if needed) and load to continue.
     Output
       Parametric Survival Regression Model Specification (censored regression)
       

--- a/tests/testthat/_snaps/survival_reg.md
+++ b/tests/testthat/_snaps/survival_reg.md
@@ -10,4 +10,7 @@
       
       Computational engine: survival 
       
+      A parsnip implementation for `survival_reg` censored regression model specifications using the `survival` engine is not loaded.
+      The parsnip extension package {censored} implements support for this specification/mode/engine combination. 
+      Please install (if needed) and load to continue.
 

--- a/tests/testthat/_snaps/survival_reg.md
+++ b/tests/testthat/_snaps/survival_reg.md
@@ -2,6 +2,8 @@
 
     Code
       survival_reg() %>% update(dist = "lnorm")
+    Message
+      A parsnip implementation for `survival_reg` censored regression model specifications using the `survival` engine is not loaded. The parsnip extension package {censored} implements support for this specification/mode/engine combination. Please install (if needed) and load to continue.
     Output
       Parametric Survival Regression Model Specification (censored regression)
       
@@ -10,7 +12,4 @@
       
       Computational engine: survival 
       
-      A parsnip implementation for `survival_reg` censored regression model specifications using the `survival` engine is not loaded.
-      The parsnip extension package {censored} implements support for this specification/mode/engine combination. 
-      Please install (if needed) and load to continue.
 

--- a/tests/testthat/_snaps/survival_reg.md
+++ b/tests/testthat/_snaps/survival_reg.md
@@ -3,8 +3,8 @@
     Code
       survival_reg() %>% update(dist = "lnorm")
     Message
-      A parsnip implementation for `survival_reg` censored regression model specifications using the `survival` engine is not loaded.
-      The parsnip extension package {censored} implements support for this specification/mode/engine combination. 
+      parsnip could not locate an implementation for `survival_reg` censored regression model specifications using the `survival` engine.
+      The parsnip extension package {censored} implements support for this specification. 
       Please install (if needed) and load to continue.
     Output
       Parametric Survival Regression Model Specification (censored regression)

--- a/tests/testthat/_snaps/translate.md
+++ b/tests/testthat/_snaps/translate.md
@@ -2100,7 +2100,9 @@
     Code
       C5_rules(engine = "C5.0")
     Message
-      A parsnip implementation for `C5_rules` classification model specifications using the `C5.0` engine is not loaded. The parsnip extension package {rules} implements support for this specification/mode/engine combination. Please install (if needed) and load to continue.
+      A parsnip implementation for `C5_rules` classification model specifications using the `C5.0` engine is not loaded.
+      The parsnip extension package {rules} implements support for this specification/mode/engine combination. 
+      Please install (if needed) and load to continue.
     Output
       C5.0 Model Specification (classification)
       
@@ -2112,7 +2114,9 @@
     Code
       C5_rules(engine = "C5.0") %>% translate()
     Message
-      A parsnip implementation for `C5_rules` classification model specifications using the `C5.0` engine is not loaded. The parsnip extension package {rules} implements support for this specification/mode/engine combination. Please install (if needed) and load to continue.
+      A parsnip implementation for `C5_rules` classification model specifications using the `C5.0` engine is not loaded.
+      The parsnip extension package {rules} implements support for this specification/mode/engine combination. 
+      Please install (if needed) and load to continue.
     Output
       C5.0 Model Specification (classification)
       

--- a/tests/testthat/_snaps/translate.md
+++ b/tests/testthat/_snaps/translate.md
@@ -2099,6 +2099,8 @@
 
     Code
       C5_rules(engine = "C5.0")
+    Message
+      A parsnip implementation for `C5_rules` classification model specifications using the `C5.0` engine is not loaded. The parsnip extension package {rules} implements support for this specification/mode/engine combination. Please install (if needed) and load to continue.
     Output
       C5.0 Model Specification (classification)
       
@@ -2109,11 +2111,11 @@
 
     Code
       C5_rules(engine = "C5.0") %>% translate()
+    Message
+      A parsnip implementation for `C5_rules` classification model specifications using the `C5.0` engine is not loaded. The parsnip extension package {rules} implements support for this specification/mode/engine combination. Please install (if needed) and load to continue.
     Output
       C5.0 Model Specification (classification)
       
       Computational engine: C5.0 
       
-      Model fit template:
-      rules::c5_fit(x = missing_arg(), y = missing_arg(), weights = missing_arg())
 

--- a/tests/testthat/_snaps/translate.md
+++ b/tests/testthat/_snaps/translate.md
@@ -2095,3 +2095,25 @@
       list(sigma = ~0.2)
       
 
+# print methods warn with unloaded extensions
+
+    Code
+      C5_rules(engine = "C5.0")
+    Output
+      C5.0 Model Specification (classification)
+      
+      Computational engine: C5.0 
+      
+
+---
+
+    Code
+      C5_rules(engine = "C5.0") %>% translate()
+    Output
+      C5.0 Model Specification (classification)
+      
+      Computational engine: C5.0 
+      
+      Model fit template:
+      rules::c5_fit(x = missing_arg(), y = missing_arg(), weights = missing_arg())
+

--- a/tests/testthat/_snaps/translate.md
+++ b/tests/testthat/_snaps/translate.md
@@ -2095,31 +2095,3 @@
       list(sigma = ~0.2)
       
 
-# print methods warn with unloaded extensions
-
-    Code
-      C5_rules(engine = "C5.0")
-    Message
-      A parsnip implementation for `C5_rules` classification model specifications using the `C5.0` engine is not loaded.
-      The parsnip extension package {rules} implements support for this specification/mode/engine combination. 
-      Please install (if needed) and load to continue.
-    Output
-      C5.0 Model Specification (classification)
-      
-      Computational engine: C5.0 
-      
-
----
-
-    Code
-      C5_rules(engine = "C5.0") %>% translate()
-    Message
-      A parsnip implementation for `C5_rules` classification model specifications using the `C5.0` engine is not loaded.
-      The parsnip extension package {rules} implements support for this specification/mode/engine combination. 
-      Please install (if needed) and load to continue.
-    Output
-      C5.0 Model Specification (classification)
-      
-      Computational engine: C5.0 
-      
-

--- a/tests/testthat/test_args_and_modes.R
+++ b/tests/testthat/test_args_and_modes.R
@@ -77,7 +77,9 @@ test_that("unavailable modes for an engine and vice-versa", {
   )
 
   expect_error(
-    proportional_hazards() %>% set_mode("regression"),
+    expect_message(
+      proportional_hazards() %>% set_mode("regression")
+    ),
     "'regression' is not a known mode"
   )
 
@@ -92,7 +94,9 @@ test_that("unavailable modes for an engine and vice-versa", {
   )
 
   expect_error(
-    proportional_hazards() %>% set_engine(),
+    expect_message(
+      proportional_hazards() %>% set_engine()
+    ),
     "No known engines for"
   )
 })

--- a/tests/testthat/test_default_engines.R
+++ b/tests/testthat/test_default_engines.R
@@ -7,9 +7,15 @@ test_that('check default engines', {
   expect_equal(mlp()$engine, "nnet")
   expect_equal(multinom_reg()$engine, "nnet")
   expect_equal(nearest_neighbor()$engine, "kknn")
-  expect_equal(proportional_hazards()$engine, "survival")
+
+  expect_message(prop_haz <- proportional_hazards()$engine)
+  expect_equal(prop_haz, "survival")
+
   expect_equal(rand_forest()$engine, "ranger")
-  expect_equal(survival_reg()$engine, "survival")
+
+  expect_message(surv_regr <- survival_reg()$engine)
+  expect_equal(surv_regr, "survival")
+
   expect_equal(svm_linear()$engine, "LiblineaR")
   expect_equal(svm_poly()$engine, "kernlab")
   expect_equal(svm_rbf()$engine, "kernlab")

--- a/tests/testthat/test_fit_interfaces.R
+++ b/tests/testthat/test_fit_interfaces.R
@@ -108,11 +108,15 @@ test_that('No loaded engines', {
     regexp = NA
   )
   expect_error(
-    cubist_rules() %>% fit(mpg ~., data = mtcars),
+    expect_message(
+      cubist_rules() %>% fit(mpg ~., data = mtcars)
+    ),
     regexp = "Please load a parsnip extension package that provides one"
   )
   expect_error(
-    poisson_reg() %>% fit(mpg ~., data = mtcars),
+    expect_message(
+      poisson_reg() %>% fit(mpg ~., data = mtcars)
+    ),
     regexp = "Please load a parsnip extension package that provides one"
   )
 })

--- a/tests/testthat/test_misc.R
+++ b/tests/testthat/test_misc.R
@@ -98,3 +98,11 @@ test_that('correct mtry', {
 
 })
 
+# ----------------------------------------------------------------------------
+
+test_that('model type functions message informatively with unknown implementation', {
+  expect_snapshot(
+    bag_tree() %>%
+      set_engine("rpart")
+  )
+})

--- a/tests/testthat/test_proportional_hazards.R
+++ b/tests/testthat/test_proportional_hazards.R
@@ -1,7 +1,6 @@
 test_that("printing", {
-  expect_output(
-    print(proportional_hazards()),
-    "Proportional Hazards Model Specification \\(censored regression\\)"
+  expect_snapshot(
+    proportional_hazards()
   )
 })
 
@@ -19,7 +18,9 @@ test_that("bad input", {
 
 test_that("wrong fit interface", {
   expect_error(
-    proportional_hazards() %>% fit_xy(),
+    expect_message(
+      proportional_hazards() %>% fit_xy()
+    ),
     "must use the formula interface"
   )
 })

--- a/tests/testthat/test_survival_reg.R
+++ b/tests/testthat/test_survival_reg.R
@@ -1,12 +1,16 @@
 
 test_that("primary argument", {
-  normal <- survival_reg(dist = "lnorm")
+  expect_message(
+    normal <- survival_reg(dist = "lnorm")
+  )
   expect_equal(
     normal$args,
     list(dist = rlang::quo("lnorm"))
   )
 
-  dist_v <- survival_reg(dist = tune())
+  expect_message(
+    dist_v <- survival_reg(dist = tune())
+  )
   expect_equal(
     dist_v$args,
     list(dist = rlang::quo(tune()))
@@ -26,7 +30,9 @@ test_that("bad input", {
 
 test_that("wrong fit interface", {
   expect_error(
-    survival_reg() %>% fit_xy(),
+    expect_message(
+      survival_reg() %>% fit_xy()
+    ),
     "must use the formula interface"
   )
 })

--- a/tests/testthat/test_translate.R
+++ b/tests/testthat/test_translate.R
@@ -269,18 +269,3 @@ test_that("arguments (svm_rbf)", {
   expect_snapshot(translate_args(rbf_sigma %>% set_engine("kernlab")))
 })
 
-# printing with unloaded extensions --------------------------------------------
-test_that("print methods warn with unloaded extensions", {
-  skip_if_not_installed("rules")
-
-  expect_snapshot(C5_rules(engine = "C5.0"))
-  expect_snapshot(C5_rules(engine = "C5.0") %>% translate())
-
-  # TODO: ideally, we'd check that the prompt goes away on load,
-  # but i see the error "package 'parsnip' required by 'rules' could not be found"
-  # on devtools::test() :(
-  #
-  # library(rules)
-  # expect_snapshot(C5_rules(engine = "C5.0"))
-  # expect_snapshot(C5_rules(engine = "C5.0") %>% translate())
-})

--- a/tests/testthat/test_translate.R
+++ b/tests/testthat/test_translate.R
@@ -269,3 +269,18 @@ test_that("arguments (svm_rbf)", {
   expect_snapshot(translate_args(rbf_sigma %>% set_engine("kernlab")))
 })
 
+# printing with unloaded extensions --------------------------------------------
+test_that("print methods warn with unloaded extensions", {
+  skip_if_not_installed("rules")
+
+  expect_snapshot(C5_rules(engine = "C5.0"))
+  expect_snapshot(C5_rules(engine = "C5.0") %>% translate())
+
+  # TODO: ideally, we'd check that the prompt goes away on load,
+  # but i see the error "package 'parsnip' required by 'rules' could not be found"
+  # on devtools::test() :(
+  #
+  # library(rules)
+  # expect_snapshot(C5_rules(engine = "C5.0"))
+  # expect_snapshot(C5_rules(engine = "C5.0") %>% translate())
+})


### PR DESCRIPTION
Closes #731.

I've had a few moments of confusion as I've familiarized with parsnip where I unknowingly specify a model specification/engine/mode combination that requires an extension package, and only come across failures later on in a modeling pipeline. This seems to be the source of confusion in #544 as well.

This PR refines print methods to nudge users to load an extension package if it's needed.

``` r
# warns informatively when it ought to:
library(parsnip)

C5_rules()
#> parsnip could not locate an implementation for `C5_rules` classification model specifications using the `C5.0` engine.
#> ℹ The parsnip extension package rules implements support for this specification.
#> ℹ Please install (if needed) and load to continue.
#> 
#> C5.0 Model Specification (classification)
#> 
#> Computational engine: C5.0

C5_rules(engine = "C5.0") %>% translate()
#> parsnip could not locate an implementation for `C5_rules` classification model specifications using the `C5.0` engine.
#> ℹ The parsnip extension package rules implements support for this specification.
#> ℹ Please install (if needed) and load to continue.
#> 
#> C5.0 Model Specification (classification)
#> 
#> Computational engine: C5.0

# doesn't prompt and prints out the call as before if the implementing extension is loaded:
library(rules)

C5_rules()
#> C5.0 Model Specification (classification)
#> 
#> Computational engine: C5.0

C5_rules(engine = "C5.0") %>% translate()
#> C5.0 Model Specification (classification)
#> 
#> Computational engine: C5.0 
#> 
#> Model fit template:
#> rules::c5_fit(x = missing_arg(), y = missing_arg(), weights = missing_arg())

# otherwise behaves the same as before:
linear_reg() %>% translate()
#> Linear Regression Model Specification (regression)
#> 
#> Computational engine: lm 
#> 
#> Model fit template:
#> stats::lm(formula = missing_arg(), data = missing_arg(), weights = missing_arg())

linear_reg()
#> Linear Regression Model Specification (regression)
#> 
#> Computational engine: lm
```

<sup>Created on 2022-05-27 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

[EDIT: updated reprex and explanation to reflect changes re: Julia's edits]