### PR TITLE
missing pkg specification for #752

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,30 @@
 # parsnip (development version)
 
+## Model Specification Changes
 
 * Enable the use of case weights for models that support them. 
 
-* Added a `glm_grouped()` function to convert long data to the grouped format required by `glm()` for logistic regression. 
-
 * `show_model_info()` now indicates which models can utilize case weights. 
+
+* Model type functions will now message informatively if a needed parsnip extension package is not loaded (#731).
+
+* Refactored internals of model specification printing functions. These changes are non-breaking for extension packages, but the new `print_model_spec()` helper is exported for use in extensions if desired (#739).
+
+## Bug fixes
+
+* Fixed bug where previously set engine arguments would propagate through `update()` methods despite `fresh = TRUE` (#704).
+
+* Fixed a bug where an error would be thrown if arguments to model functions were namespaced (#745).
+
+* `predict(type = "prob")` will now provide an error if the outcome variable has a level called `"class"` (#720).
+
+*  An inconsistency for probability type predictions for two-class GAM models was fixed (#708)
+
+* Fixed translated printing for `null_model()` (#752)
+
+## Other changes
+
+* Added a `glm_grouped()` function to convert long data to the grouped format required by `glm()` for logistic regression. 
 
 * `xgb_train()` now allows for case weights 
 
@@ -13,19 +32,7 @@
 
 * Exported `xgb_predict()` which wraps xgboost's `predict()` method for use with parsnip extension packages (#688).
 
-* Fixed bug where previously set engine arguments would propagate through `update()` methods despite `fresh = TRUE` (#704).
-
-*  An inconsistency for probability type predictions for two-class GAM models was fixed (#708)
-
-* `predict(type = "prob")` will now provide an error if the outcome variable has a level called `"class"` (#720).
-
 * Added a developer function, `.model_param_name_key` that translates names of tuning parameters.
-
-* Model type functions will now message informatively if a needed parsnip extension package is not loaded (#731).
-
-* Fixed a bug where an error would be thrown if arguments to model functions were namespaced (#745).
-
-* Refactored internals of model specification printing functions. These changes are non-breaking for extension packages, but the new `print_model_spec()` helper is exported for use in extensions if desired (#739).
 
 
 # parsnip 0.2.1

--- a/R/nullmodel_data.R
+++ b/R/nullmodel_data.R
@@ -16,7 +16,7 @@ set_fit(
   value = list(
     interface = "matrix",
     protect = c("x", "y"),
-    func = c(fun = "nullmodel"),
+    func = c(fun = "nullmodel", pkg = "parsnip"),
     defaults = list()
   )
 )
@@ -40,7 +40,7 @@ set_fit(
   value = list(
     interface = "matrix",
     protect = c("x", "y"),
-    func = c(fun = "nullmodel"),
+    func = c(fun = "nullmodel", pkg = "parsnip"),
     defaults = list()
   )
 )

--- a/tests/testthat/_snaps/nullmodel.md
+++ b/tests/testthat/_snaps/nullmodel.md
@@ -1,0 +1,21 @@
+# null_model printing
+
+    Code
+      print(null_model(mode = "classification"))
+    Output
+      Null Model Specification (classification)
+      
+
+---
+
+    Code
+      print(null_model(mode = "classification") %>% set_engine("parsnip") %>%
+        translate())
+    Output
+      Null Model Specification (classification)
+      
+      Computational engine: parsnip 
+      
+      Model fit template:
+      parsnip::nullmodel(x = missing_arg(), y = missing_arg())
+

--- a/tests/testthat/test_nullmodel.R
+++ b/tests/testthat/test_nullmodel.R
@@ -111,4 +111,18 @@ test_that('classification', {
   expect_true(!is.null(null_model$fit))
 })
 
+# ------------------------------------------------------------------------------
+
+test_that('null_model printing', {
+  expect_snapshot(print(null_model(mode = "classification")))
+  expect_snapshot(
+    print(
+      null_model(mode = "classification") %>%
+        set_engine("parsnip") %>%
+        translate()
+    )
+  )
+})
+
+
 


### PR DESCRIPTION
Closes #752

There was no `pkg` slot in the `set_fit()` call which errored `print.model_spec()`. 