### PR TITLE
address GHA failures

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -54,7 +54,7 @@ jobs:
           extra-packages: rcmdcheck
 
       - name: Install dev reticulate
-        run: pak::pkg_install('rstudio/reticulate')
+        run: pak::pkg_install('reticulate')
         shell: Rscript {0}
 
       - name: Install Miniconda

--- a/.github/workflows/old-tensorflow.yaml
+++ b/.github/workflows/old-tensorflow.yaml
@@ -49,7 +49,7 @@ jobs:
           extra-packages: rcmdcheck
 
       - name: Install dev reticulate
-        run: pak::pkg_install('rstudio/reticulate')
+        run: pak::pkg_install('reticulate')
         shell: Rscript {0}
 
       - name: Install Miniconda


### PR DESCRIPTION
Attempting to address GHA failures. 

At the moment, looking like pak "install planning" failures. Looks like there's been a release of reticulate since we started using the dev version, so trying to install the CRAN version first.