### PR TITLE
docs and `tunable_boost_tree` adjustments re: lightgbm bagging

### DIFF
--- a/R/tunable.R
+++ b/R/tunable.R
@@ -222,14 +222,15 @@ tunable_boost_tree <- function(x, ...) {
       list(list(pkg = "dials", fun = "sample_prop"))
     res$call_info[res$name == "learn_rate"] <-
       list(list(pkg = "dials", fun = "learn_rate", range = c(-3, -1/2)))
-  } else {
-    if (x$engine == "C5.0") {
+  } else if (x$engine == "C5.0") {
       res <- add_engine_parameters(res, c5_boost_engine_args)
       res$call_info[res$name == "trees"] <-
         list(list(pkg = "dials", fun = "trees", range = c(1, 100)))
       res$call_info[res$name == "sample_size"] <-
         list(list(pkg = "dials", fun = "sample_prop"))
-    }
+  } else if (x$engine == "lightgbm") {
+      res$call_info[res$name == "sample_size"] <-
+        list(list(pkg = "dials", fun = "sample_prop"))
   }
   res
 }

--- a/man/details_boost_tree_lightgbm.Rd
+++ b/man/details_boost_tree_lightgbm.Rd
@@ -158,6 +158,28 @@ and \code{"lightgbm"} (via the bonsai package)—the user can pass the
 within [0,1].
 }
 
+\subsection{Bagging}{
+
+The \code{sample_size} argument is translated to the \code{bagging_fraction}
+parameter in the \code{param} argument of \code{lgb.train}. The argument is
+interpreted by lightgbm as a \emph{proportion} rather than a count, so bonsai
+internally reparameterizes the \code{sample_size} argument with
+\code{\link[dials:trees]{dials::sample_prop()}} during tuning.
+
+To effectively enable bagging, the user would also need to set the
+\code{bagging_freq} argument to lightgbm. \code{bagging_freq} defaults to 0, which
+means bagging is disabled, and a \code{bagging_freq} argument of \code{k} means
+that the booster will perform bagging at every \code{k}th boosting iteration.
+Thus, by default, the \code{sample_size} argument would be ignored without
+setting this argument manually. Other boosting libraries, like xgboost,
+do not have an analogous argument to \code{bagging_freq} and use \code{k = 1} when
+the analogue to \code{bagging_fraction} is in (0,1). \emph{bonsai will thus
+automatically set} \code{bagging_freq = 1} \emph{in} \code{set_engine("lightgbm", ...)}
+if \code{sample_size} (i.e. \code{bagging_fraction}) is not equal to 1 and no
+\code{bagging_freq} value is supplied. This default can be overridden by
+setting the \code{bagging_freq} argument to \code{set_engine()} manually.
+}
+
 \subsection{Verbosity}{
 
 bonsai quiets much of the logging output from

--- a/man/rmd/boost_tree_lightgbm.Rmd
+++ b/man/rmd/boost_tree_lightgbm.Rmd
@@ -74,6 +74,12 @@ Non-numeric predictors (i.e., factors) are internally converted to numeric. In t
 ```{r child = "template-mtry-prop.Rmd"}
 ```
 
+### Bagging
+
+The `sample_size` argument is translated to the `bagging_fraction` parameter in the `param` argument of `lgb.train`. The argument is interpreted by lightgbm as a _proportion_ rather than a count, so bonsai internally reparameterizes the `sample_size` argument with [dials::sample_prop()] during tuning. 
+
+To effectively enable bagging, the user would also need to set the `bagging_freq` argument to lightgbm. `bagging_freq` defaults to 0, which means bagging is disabled, and a `bagging_freq` argument of `k` means that the booster will perform bagging at every `k`th boosting iteration. Thus, by default, the `sample_size` argument would be ignored without setting this argument manually. Other boosting libraries, like xgboost, do not have an analogous argument to `bagging_freq` and use `k = 1` when the analogue to `bagging_fraction` is in $(0, 1)$. _bonsai will thus automatically set_ `bagging_freq = 1` _in_ `set_engine("lightgbm", ...)` if `sample_size` (i.e. `bagging_fraction`) is not equal to 1 and no `bagging_freq` value is supplied. This default can be overridden by setting the `bagging_freq` argument to `set_engine()` manually.
+
 ### Verbosity
 
 bonsai quiets much of the logging output from [lightgbm::lgb.train()] by default. With default settings, logged warnings and errors will still be passed on to the user. To print out all logs during training, set `quiet = TRUE`.

--- a/man/rmd/boost_tree_lightgbm.md
+++ b/man/rmd/boost_tree_lightgbm.md
@@ -121,6 +121,12 @@ parsnip and its extensions accommodate this parameterization using the `counts` 
 
 `mtry` is a main model argument for \\code{\\link[=boost_tree]{boost_tree()}} and \\code{\\link[=rand_forest]{rand_forest()}}, and thus should not have an engine-specific interface. So, regardless of engine, `counts` defaults to `TRUE`. For engines that support the proportion interpretation---currently `"xgboost"`, `"xrf"` (via the rules package), and `"lightgbm"` (via the bonsai package)---the user can pass the `counts = FALSE` argument to `set_engine()` to supply `mtry` values within $[0, 1]$.
 
+### Bagging
+
+The `sample_size` argument is translated to the `bagging_fraction` parameter in the `param` argument of `lgb.train`. The argument is interpreted by lightgbm as a _proportion_ rather than a count, so bonsai internally reparameterizes the `sample_size` argument with [dials::sample_prop()] during tuning. 
+
+To effectively enable bagging, the user would also need to set the `bagging_freq` argument to lightgbm. `bagging_freq` defaults to 0, which means bagging is disabled, and a `bagging_freq` argument of `k` means that the booster will perform bagging at every `k`th boosting iteration. Thus, by default, the `sample_size` argument would be ignored without setting this argument manually. Other boosting libraries, like xgboost, do not have an analogous argument to `bagging_freq` and use `k = 1` when the analogue to `bagging_fraction` is in $(0, 1)$. _bonsai will thus automatically set_ `bagging_freq = 1` _in_ `set_engine("lightgbm", ...)` if `sample_size` (i.e. `bagging_fraction`) is not equal to 1 and no `bagging_freq` value is supplied. This default can be overridden by setting the `bagging_freq` argument to `set_engine()` manually.
+
 ### Verbosity
 
 bonsai quiets much of the logging output from [lightgbm::lgb.train()] by default. With default settings, logged warnings and errors will still be passed on to the user. To print out all logs during training, set `quiet = TRUE`.


### PR DESCRIPTION
Some adjustments to effectively enable + document the `sample_size` argument for the lightgbm engine. Will be followed up by a PR in bonsai—1/2 to close tidymodels/bonsai#30.

The gist:

https://github.com/tidymodels/parsnip/blob/713d617274b54a9f99c5b67c2cf52a7b0a3e431c/man/rmd/boost_tree_lightgbm.Rmd#L79-L81

Will PR as draft and we can come back to this after conf. :)