### PR TITLE
address dev dplyr join warnings

### DIFF
--- a/R/linear_reg.R
+++ b/R/linear_reg.R
@@ -243,7 +243,11 @@ multi_predict._elnet <-
     pred <- as_tibble(pred)
     pred$.row <- 1:nrow(pred)
     pred <- gather(pred, group, .pred, -.row)
-    pred <- full_join(param_key, pred, by = "group", multiple = "all")
+    if (utils::packageVersion("dplyr") >= "1.0.99.9000") {
+      pred <- full_join(param_key, pred, by = "group", multiple = "all")
+    } else {
+      pred <- full_join(param_key, pred, by = "group")
+    }
     pred$group <- NULL
     pred <- arrange(pred, .row, penalty)
     .row <- pred$.row

--- a/R/linear_reg.R
+++ b/R/linear_reg.R
@@ -243,7 +243,7 @@ multi_predict._elnet <-
     pred <- as_tibble(pred)
     pred$.row <- 1:nrow(pred)
     pred <- gather(pred, group, .pred, -.row)
-    pred <- full_join(param_key, pred, by = "group")
+    pred <- full_join(param_key, pred, by = "group", multiple = "all")
     pred$group <- NULL
     pred <- arrange(pred, .row, penalty)
     .row <- pred$.row

--- a/R/logistic_reg.R
+++ b/R/logistic_reg.R
@@ -296,7 +296,7 @@ multi_predict._lognet <-
         pred <- pred[, c(".row", "group", paste0(".pred_", object$lvl))]
       }
     }
-    pred <- full_join(param_key, pred, by = "group")
+    pred <- full_join(param_key, pred, by = "group", multiple = "all")
     pred$group <- NULL
     pred <- arrange(pred, .row, penalty)
     .row <- pred$.row

--- a/R/logistic_reg.R
+++ b/R/logistic_reg.R
@@ -296,7 +296,11 @@ multi_predict._lognet <-
         pred <- pred[, c(".row", "group", paste0(".pred_", object$lvl))]
       }
     }
-    pred <- full_join(param_key, pred, by = "group", multiple = "all")
+    if (utils::packageVersion("dplyr") >= "1.0.99.9000") {
+      pred <- full_join(param_key, pred, by = "group", multiple = "all")
+    } else {
+      pred <- full_join(param_key, pred, by = "group")
+    }
     pred$group <- NULL
     pred <- arrange(pred, .row, penalty)
     .row <- pred$.row


### PR DESCRIPTION
Related to, but doesn't fully fix, tidymodels/tune#526.

``` r
# devtools::install_github("tidyverse/dplyr")

library(tidymodels)

workflow(
  preprocessor = mpg ~ .,
  spec = linear_reg(engine = 'glmnet', penalty = tune(), mixture = 1)
) %>% 
  tune_grid(resamples = vfold_cv(mtcars))
#> # Tuning results
#> # 10-fold cross-validation 
#> # A tibble: 10 × 4
#>    splits         id     .metrics          .notes          
#>    <list>         <chr>  <list>            <list>          
#>  1 <split [28/4]> Fold01 <tibble [20 × 5]> <tibble [0 × 3]>
#>  2 <split [28/4]> Fold02 <tibble [20 × 5]> <tibble [0 × 3]>
#>  3 <split [29/3]> Fold03 <tibble [20 × 5]> <tibble [0 × 3]>
#>  4 <split [29/3]> Fold04 <tibble [20 × 5]> <tibble [0 × 3]>
#>  5 <split [29/3]> Fold05 <tibble [20 × 5]> <tibble [0 × 3]>
#>  6 <split [29/3]> Fold06 <tibble [20 × 5]> <tibble [0 × 3]>
#>  7 <split [29/3]> Fold07 <tibble [20 × 5]> <tibble [0 × 3]>
#>  8 <split [29/3]> Fold08 <tibble [20 × 5]> <tibble [0 × 3]>
#>  9 <split [29/3]> Fold09 <tibble [20 × 5]> <tibble [0 × 3]>
#> 10 <split [29/3]> Fold10 <tibble [20 × 5]> <tibble [0 × 3]>
```

<sup>Created on 2022-07-20 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

If this fix looks like the right move, we'll need to apply in [at least a few](https://github.com/search?q=org%3Atidymodels+param_key&type=code) other places, likely worth testing all `multi_predict` methods.