### PR TITLE
Tests for survival models

### DIFF
--- a/tests/testthat/_snaps/translate.md
+++ b/tests/testthat/_snaps/translate.md
@@ -1895,6 +1895,13 @@
       env:  empty
       
 
+# arguments (survival_reg)
+
+    Code
+      basic %>% translate_args()
+    Output
+      list()
+
 # arguments (svm_linear)
 
     Code

--- a/tests/testthat/_snaps/translate.md
+++ b/tests/testthat/_snaps/translate.md
@@ -1527,6 +1527,24 @@
       min_rows(5, data, 5)
       
 
+# arguments (proportional_hazards)
+
+    Code
+      basic %>% translate_args()
+    Output
+      list()
+
+---
+
+    Code
+      basic_incomplete %>% translate_args()
+    Condition
+      Error in `.check_glmnet_penalty_fit()`:
+      ! For the glmnet engine, `penalty` must be a single number (or a value of `tune()`).
+      * There are 0 values for `penalty`.
+      * To try multiple values for total regularization, use the tune package.
+      * To predict multiple penalties, use `multi_predict()`
+
 # arguments (rand_forest)
 
     Code

--- a/tests/testthat/test_translate.R
+++ b/tests/testthat/test_translate.R
@@ -199,6 +199,22 @@ test_that("arguments (nearest_neighbor)", {
   expect_snapshot(translate_args(dist_power %>% set_engine("kknn")))
 })
 
+
+# translate.proportional_hazards ------------------------------------------
+test_that("arguments (proportional_hazards)", {
+  suppressMessages({
+    basic <- proportional_hazards(penalty = 0.1) %>% set_engine("glmnet")
+    basic_incomplete <- proportional_hazards() %>% set_engine("glmnet")
+  })
+
+  # this is empty because the engines are not defined in parsnip
+  expect_snapshot(basic %>% translate_args())
+  # but we can check for the error if there is no penalty for glmnet
+  expect_snapshot(error = TRUE,
+    basic_incomplete %>% translate_args()
+  )
+})
+
 # translate.rand_forest --------------------------------------------------------
 test_that("arguments (rand_forest)", {
   basic <- rand_forest(mode = "regression")

--- a/tests/testthat/test_translate.R
+++ b/tests/testthat/test_translate.R
@@ -253,6 +253,17 @@ test_that("arguments (surv_reg)", {
   expect_snapshot(translate_args(dist_v %>% set_engine("flexsurv")))
 })
 
+# translate.survival_reg -----------------------------------------------------------
+test_that("arguments (survival_reg)", {
+  suppressMessages({
+    basic <- survival_reg()
+  })
+
+  # this is empty because the engines are not defined in parsnip
+  expect_snapshot(basic %>% translate_args())
+
+})
+
 # translate.svm_linear ---------------------------------------------------------
 test_that("arguments (svm_linear)", {
   basic <- svm_linear(mode = "regression")


### PR DESCRIPTION
This tests the error message for trying to use `proportional_hazards()` with the `glmnet` engine _without_ a penalty value because that's the thing the `translate()` method for PH models does in addition to the default translate() method.

The rest of the tests for `proportional_hazards()` and `survival_reg()` is more of a placeholder because parsnip does not have any engines for these models. The actual tests on primary and engine args for those models are in censored, see https://github.com/tidymodels/censored/pull/208.