### PR TITLE
update snaps to remove tibble print suggestion

### DIFF
--- a/tests/testthat/_snaps/translate.md
+++ b/tests/testthat/_snaps/translate.md
@@ -2131,7 +2131,6 @@
     Output
       # A tibble: 0 x 3
       # ... with 3 variables: user <chr>, parsnip <chr>, engine <chr>
-      # i Use `colnames()` to see all variable names
 
 ---
 


### PR DESCRIPTION
Looks like this won't print in non-interactive sessions post-pillar 1.8.1!