### PR TITLE
pass weights to xgboost internal validation set

### DIFF
--- a/R/boost_tree.R
+++ b/R/boost_tree.R
@@ -432,7 +432,12 @@ as_xgb_data <- function(x, y, validation = 0, weights = NULL, event_level = "fir
       # Split data
       m <- floor(n * (1 - validation)) + 1
       trn_index <- sample(1:n, size = max(m, 2))
-      val_data <- xgboost::xgb.DMatrix(x[-trn_index,], label = y[-trn_index], missing = NA)
+      val_info_list <- list(label = y[-trn_index])
+      if (!is.null(weights)) {
+        val_info_list$weight <- weights[-trn_index]
+      }
+
+      val_data <- xgboost::xgb.DMatrix(x[-trn_index,], info = val_info_list, missing = NA)
       watch_list <- list(validation = val_data)
 
       info_list <- list(label = y[trn_index])


### PR DESCRIPTION
In response to https://github.com/tidymodels/parsnip/pull/771#issuecomment-1231991055

This pull request passes case weights to the interval validation set of `xgboost`. This causes test failures here:

https://github.com/tidymodels/parsnip/blob/e1eb30a6f6704bd0a3cf61736ea1d26e1d8eb081/tests/testthat/test_boost_tree_xgboost.R#L409

and here.

https://github.com/tidymodels/parsnip/blob/e1eb30a6f6704bd0a3cf61736ea1d26e1d8eb081/tests/testthat/test_boost_tree_xgboost.R#L449

Seems like the original intention was to not pass case weights to the internal validation set? 
