### PR TITLE
add reference to bundle in docs

### DIFF
--- a/man/details_auto_ml_h2o.Rd
+++ b/man/details_auto_ml_h2o.Rd
@@ -92,5 +92,12 @@ h2o will automatically shut down the local h2o instance started by R
 when R is terminated. To manually stop the h2o server, run
 \code{h2o::h2o.shutdown()}.
 }
+
+\subsection{Saving model fits}{
+
+Models fitted with this engine may require native serialization methods
+to be properly saved and/or passed between R sessions. To learn more
+about preparing fitted models for serialization, see the bundle package.
+}
 }
 \keyword{internal}

--- a/man/details_boost_tree_h2o.Rd
+++ b/man/details_boost_tree_h2o.Rd
@@ -175,5 +175,12 @@ h2o will automatically shut down the local h2o instance started by R
 when R is terminated. To manually stop the h2o server, run
 \code{h2o::h2o.shutdown()}.
 }
+
+\subsection{Saving model fits}{
+
+Models fitted with this engine may require native serialization methods
+to be properly saved and/or passed between R sessions. To learn more
+about preparing fitted models for serialization, see the bundle package.
+}
 }
 \keyword{internal}

--- a/man/details_boost_tree_lightgbm.Rd
+++ b/man/details_boost_tree_lightgbm.Rd
@@ -69,7 +69,7 @@ The \strong{bonsai} extension package is required to fit this model.
 ## 
 ## Model fit template:
 ## bonsai::train_lightgbm(x = missing_arg(), y = missing_arg(), 
-##     feature_fraction = integer(), num_iterations = integer(), 
+##     feature_fraction_bynode = integer(), num_iterations = integer(), 
 ##     min_data_in_leaf = integer(), max_depth = integer(), learning_rate = numeric(), 
 ##     min_gain_to_split = numeric(), verbose = -1, num_threads = 0, 
 ##     seed = sample.int(10^5, 1), deterministic = TRUE)
@@ -103,7 +103,7 @@ The \strong{bonsai} extension package is required to fit this model.
 ## 
 ## Model fit template:
 ## bonsai::train_lightgbm(x = missing_arg(), y = missing_arg(), 
-##     feature_fraction = integer(), num_iterations = integer(), 
+##     feature_fraction_bynode = integer(), num_iterations = integer(), 
 ##     min_data_in_leaf = integer(), max_depth = integer(), learning_rate = numeric(), 
 ##     min_gain_to_split = numeric(), verbose = -1, num_threads = 0, 
 ##     seed = sample.int(10^5, 1), deterministic = TRUE)
@@ -156,6 +156,13 @@ to \code{TRUE}. For engines that support the proportion interpretation
 \code{"lightgbm"} via the bonsai package) the user can pass the
 \code{counts = FALSE} argument to \code{set_engine()} to supply \code{mtry} values
 within [0,1].
+}
+
+\subsection{Saving model fits}{
+
+Models fitted with this engine may require native serialization methods
+to be properly saved and/or passed between R sessions. To learn more
+about preparing fitted models for serialization, see the bundle package.
 }
 
 \subsection{Bagging}{

--- a/man/details_boost_tree_xgboost.Rd
+++ b/man/details_boost_tree_xgboost.Rd
@@ -240,6 +240,13 @@ the outcome. To use a different loss, pass the \code{objective} argument to
 \code{\link[=set_engine]{set_engine()}} directly.
 }
 
+\subsection{Saving model fits}{
+
+Models fitted with this engine may require native serialization methods
+to be properly saved and/or passed between R sessions. To learn more
+about preparing fitted models for serialization, see the bundle package.
+}
+
 }
 
 \subsection{Examples}{

--- a/man/details_linear_reg_h2o.Rd
+++ b/man/details_linear_reg_h2o.Rd
@@ -90,5 +90,12 @@ h2o will automatically shut down the local h2o instance started by R
 when R is terminated. To manually stop the h2o server, run
 \code{h2o::h2o.shutdown()}.
 }
+
+\subsection{Saving model fits}{
+
+Models fitted with this engine may require native serialization methods
+to be properly saved and/or passed between R sessions. To learn more
+about preparing fitted models for serialization, see the bundle package.
+}
 }
 \keyword{internal}

--- a/man/details_logistic_reg_h2o.Rd
+++ b/man/details_logistic_reg_h2o.Rd
@@ -109,5 +109,12 @@ h2o will automatically shut down the local h2o instance started by R
 when R is terminated. To manually stop the h2o server, run
 \code{h2o::h2o.shutdown()}.
 }
+
+\subsection{Saving model fits}{
+
+Models fitted with this engine may require native serialization methods
+to be properly saved and/or passed between R sessions. To learn more
+about preparing fitted models for serialization, see the bundle package.
+}
 }
 \keyword{internal}

--- a/man/details_logistic_reg_keras.Rd
+++ b/man/details_logistic_reg_keras.Rd
@@ -62,6 +62,13 @@ variance of one.
 The underlying model implementation does not allow for case weights.
 }
 
+\subsection{Saving model fits}{
+
+Models fitted with this engine may require native serialization methods
+to be properly saved and/or passed between R sessions. To learn more
+about preparing fitted models for serialization, see the bundle package.
+}
+
 \subsection{Examples}{
 
 The “Fitting and Predicting with parsnip” article contains

--- a/man/details_mlp_h2o.Rd
+++ b/man/details_mlp_h2o.Rd
@@ -158,5 +158,12 @@ h2o will automatically shut down the local h2o instance started by R
 when R is terminated. To manually stop the h2o server, run
 \code{h2o::h2o.shutdown()}.
 }
+
+\subsection{Saving model fits}{
+
+Models fitted with this engine may require native serialization methods
+to be properly saved and/or passed between R sessions. To learn more
+about preparing fitted models for serialization, see the bundle package.
+}
 }
 \keyword{internal}

--- a/man/details_mlp_keras.Rd
+++ b/man/details_mlp_keras.Rd
@@ -102,6 +102,13 @@ variance of one.
 The underlying model implementation does not allow for case weights.
 }
 
+\subsection{Saving model fits}{
+
+Models fitted with this engine may require native serialization methods
+to be properly saved and/or passed between R sessions. To learn more
+about preparing fitted models for serialization, see the bundle package.
+}
+
 \subsection{Examples}{
 
 The “Fitting and Predicting with parsnip” article contains

--- a/man/details_multinom_reg_keras.Rd
+++ b/man/details_multinom_reg_keras.Rd
@@ -61,6 +61,13 @@ variance of one.
 The underlying model implementation does not allow for case weights.
 }
 
+\subsection{Saving model fits}{
+
+Models fitted with this engine may require native serialization methods
+to be properly saved and/or passed between R sessions. To learn more
+about preparing fitted models for serialization, see the bundle package.
+}
+
 \subsection{Examples}{
 
 The “Fitting and Predicting with parsnip” article contains

--- a/man/details_naive_Bayes_h2o.Rd
+++ b/man/details_naive_Bayes_h2o.Rd
@@ -75,5 +75,12 @@ h2o will automatically shut down the local h2o instance started by R
 when R is terminated. To manually stop the h2o server, run
 \code{h2o::h2o.shutdown()}.
 }
+
+\subsection{Saving model fits}{
+
+Models fitted with this engine may require native serialization methods
+to be properly saved and/or passed between R sessions. To learn more
+about preparing fitted models for serialization, see the bundle package.
+}
 }
 \keyword{internal}

--- a/man/details_poisson_reg_h2o.Rd
+++ b/man/details_poisson_reg_h2o.Rd
@@ -95,5 +95,12 @@ h2o will automatically shut down the local h2o instance started by R
 when R is terminated. To manually stop the h2o server, run
 \code{h2o::h2o.shutdown()}.
 }
+
+\subsection{Saving model fits}{
+
+Models fitted with this engine may require native serialization methods
+to be properly saved and/or passed between R sessions. To learn more
+about preparing fitted models for serialization, see the bundle package.
+}
 }
 \keyword{internal}

--- a/man/details_rand_forest_h2o.Rd
+++ b/man/details_rand_forest_h2o.Rd
@@ -114,5 +114,12 @@ h2o will automatically shut down the local h2o instance started by R
 when R is terminated. To manually stop the h2o server, run
 \code{h2o::h2o.shutdown()}.
 }
+
+\subsection{Saving model fits}{
+
+Models fitted with this engine may require native serialization methods
+to be properly saved and/or passed between R sessions. To learn more
+about preparing fitted models for serialization, see the bundle package.
+}
 }
 \keyword{internal}

--- a/man/details_rule_fit_h2o.Rd
+++ b/man/details_rule_fit_h2o.Rd
@@ -130,5 +130,12 @@ h2o will automatically shut down the local h2o instance started by R
 when R is terminated. To manually stop the h2o server, run
 \code{h2o::h2o.shutdown()}.
 }
+
+\subsection{Saving model fits}{
+
+Models fitted with this engine may require native serialization methods
+to be properly saved and/or passed between R sessions. To learn more
+about preparing fitted models for serialization, see the bundle package.
+}
 }
 \keyword{internal}

--- a/man/rmd/auto_ml_h2o.Rmd
+++ b/man/rmd/auto_ml_h2o.Rmd
@@ -45,3 +45,8 @@ auto_ml() %>%
 
 ```{r child = "template-h2o-init.Rmd"}
 ```
+
+## Saving model fits
+
+```{r child = "template-bundle.Rmd"}
+```

--- a/man/rmd/auto_ml_h2o.md
+++ b/man/rmd/auto_ml_h2o.md
@@ -71,3 +71,8 @@ To use the h2o engine with tidymodels, please run `h2o::h2o.init()` first. By de
 You can control the number of threads in the thread pool used by h2o with the `nthreads` argument. By default, it uses all CPUs on the host. This is different from the usual parallel processing mechanism in tidymodels for tuning, while tidymodels parallelizes over resamples, h2o parallelizes over hyperparameter combinations for a given resample. 
 
 h2o will automatically shut down the local h2o instance started by R when R is terminated. To manually stop the h2o server, run `h2o::h2o.shutdown()`. 
+
+## Saving model fits
+
+
+Models fitted with this engine may require native serialization methods to be properly saved and/or passed between R sessions. To learn more about preparing fitted models for serialization, see the bundle package.

--- a/man/rmd/boost_tree_h2o.Rmd
+++ b/man/rmd/boost_tree_h2o.Rmd
@@ -75,3 +75,8 @@ Non-numeric predictors (i.e., factors) are internally converted to numeric. In t
 
 ```{r child = "template-h2o-init.Rmd"}
 ```
+
+## Saving model fits
+
+```{r child = "template-bundle.Rmd"}
+```

--- a/man/rmd/boost_tree_h2o.md
+++ b/man/rmd/boost_tree_h2o.md
@@ -132,3 +132,8 @@ To use the h2o engine with tidymodels, please run `h2o::h2o.init()` first. By de
 You can control the number of threads in the thread pool used by h2o with the `nthreads` argument. By default, it uses all CPUs on the host. This is different from the usual parallel processing mechanism in tidymodels for tuning, while tidymodels parallelizes over resamples, h2o parallelizes over hyperparameter combinations for a given resample. 
 
 h2o will automatically shut down the local h2o instance started by R when R is terminated. To manually stop the h2o server, run `h2o::h2o.shutdown()`. 
+
+## Saving model fits
+
+
+Models fitted with this engine may require native serialization methods to be properly saved and/or passed between R sessions. To learn more about preparing fitted models for serialization, see the bundle package.

--- a/man/rmd/boost_tree_lightgbm.Rmd
+++ b/man/rmd/boost_tree_lightgbm.Rmd
@@ -74,6 +74,11 @@ Non-numeric predictors (i.e., factors) are internally converted to numeric. In t
 ```{r child = "template-mtry-prop.Rmd"}
 ```
 
+### Saving model fits
+
+```{r child = "template-bundle.Rmd"}
+```
+
 ### Bagging
 
 The `sample_size` argument is translated to the `bagging_fraction` parameter in the `param` argument of `lgb.train`. The argument is interpreted by lightgbm as a _proportion_ rather than a count, so bonsai internally reparameterizes the `sample_size` argument with [dials::sample_prop()] during tuning. 

--- a/man/rmd/boost_tree_lightgbm.md
+++ b/man/rmd/boost_tree_lightgbm.md
@@ -57,7 +57,7 @@ boost_tree(
 ## 
 ## Model fit template:
 ## bonsai::train_lightgbm(x = missing_arg(), y = missing_arg(), 
-##     feature_fraction = integer(), num_iterations = integer(), 
+##     feature_fraction_bynode = integer(), num_iterations = integer(), 
 ##     min_data_in_leaf = integer(), max_depth = integer(), learning_rate = numeric(), 
 ##     min_gain_to_split = numeric(), verbose = -1, num_threads = 0, 
 ##     seed = sample.int(10^5, 1), deterministic = TRUE)
@@ -93,7 +93,7 @@ boost_tree(
 ## 
 ## Model fit template:
 ## bonsai::train_lightgbm(x = missing_arg(), y = missing_arg(), 
-##     feature_fraction = integer(), num_iterations = integer(), 
+##     feature_fraction_bynode = integer(), num_iterations = integer(), 
 ##     min_data_in_leaf = integer(), max_depth = integer(), learning_rate = numeric(), 
 ##     min_gain_to_split = numeric(), verbose = -1, num_threads = 0, 
 ##     seed = sample.int(10^5, 1), deterministic = TRUE)
@@ -120,6 +120,11 @@ Some engines, such as `"xgboost"`, `"xrf"`, and `"lightgbm"`, interpret their an
 parsnip and its extensions accommodate this parameterization using the `counts` argument: a logical indicating whether `mtry` should be interpreted as the number of predictors that will be randomly sampled at each split. `TRUE` indicates that `mtry` will be interpreted in its sense as a count, `FALSE` indicates that the argument will be interpreted in its sense as a proportion.
 
 `mtry` is a main model argument for \\code{\\link[=boost_tree]{boost_tree()}} and \\code{\\link[=rand_forest]{rand_forest()}}, and thus should not have an engine-specific interface. So, regardless of engine, `counts` defaults to `TRUE`. For engines that support the proportion interpretation (currently `"xgboost"` and `"xrf"`, via the rules package, and `"lightgbm"` via the bonsai package) the user can pass the `counts = FALSE` argument to `set_engine()` to supply `mtry` values within $[0, 1]$.
+
+### Saving model fits
+
+
+Models fitted with this engine may require native serialization methods to be properly saved and/or passed between R sessions. To learn more about preparing fitted models for serialization, see the bundle package.
 
 ### Bagging
 

--- a/man/rmd/boost_tree_xgboost.Rmd
+++ b/man/rmd/boost_tree_xgboost.Rmd
@@ -104,6 +104,11 @@ Note that, since the `validation` argument provides an alternative interface to 
 
 parsnip chooses the objective function based on the characteristics of the outcome. To use a different loss, pass the `objective` argument to [set_engine()] directly. 
 
+### Saving model fits
+
+```{r child = "template-bundle.Rmd"}
+```
+
 ## Examples 
 
 The "Fitting and Predicting with parsnip" article contains [examples](https://parsnip.tidymodels.org/articles/articles/Examples.html#boost-tree-xgboost) for `boost_tree()` with the `"xgboost"` engine.

--- a/man/rmd/boost_tree_xgboost.md
+++ b/man/rmd/boost_tree_xgboost.md
@@ -183,6 +183,11 @@ Note that, since the `validation` argument provides an alternative interface to 
 
 parsnip chooses the objective function based on the characteristics of the outcome. To use a different loss, pass the `objective` argument to [set_engine()] directly. 
 
+### Saving model fits
+
+
+Models fitted with this engine may require native serialization methods to be properly saved and/or passed between R sessions. To learn more about preparing fitted models for serialization, see the bundle package.
+
 ## Examples 
 
 The "Fitting and Predicting with parsnip" article contains [examples](https://parsnip.tidymodels.org/articles/articles/Examples.html#boost-tree-xgboost) for `boost_tree()` with the `"xgboost"` engine.

--- a/man/rmd/linear_reg_h2o.Rmd
+++ b/man/rmd/linear_reg_h2o.Rmd
@@ -50,3 +50,8 @@ By default, [h2o::h2o.glm()] uses the argument `standardize = TRUE` to center an
 
 ```{r child = "template-h2o-init.Rmd"}
 ```
+
+## Saving model fits
+
+```{r child = "template-bundle.Rmd"}
+```

--- a/man/rmd/linear_reg_h2o.md
+++ b/man/rmd/linear_reg_h2o.md
@@ -64,3 +64,8 @@ To use the h2o engine with tidymodels, please run `h2o::h2o.init()` first. By de
 You can control the number of threads in the thread pool used by h2o with the `nthreads` argument. By default, it uses all CPUs on the host. This is different from the usual parallel processing mechanism in tidymodels for tuning, while tidymodels parallelizes over resamples, h2o parallelizes over hyperparameter combinations for a given resample. 
 
 h2o will automatically shut down the local h2o instance started by R when R is terminated. To manually stop the h2o server, run `h2o::h2o.shutdown()`. 
+
+## Saving model fits
+
+
+Models fitted with this engine may require native serialization methods to be properly saved and/or passed between R sessions. To learn more about preparing fitted models for serialization, see the bundle package.

--- a/man/rmd/logistic_reg_h2o.Rmd
+++ b/man/rmd/logistic_reg_h2o.Rmd
@@ -60,3 +60,8 @@ By default, [h2o::h2o.glm()] uses the argument `standardize = TRUE` to center an
 
 ```{r child = "template-h2o-init.Rmd"}
 ```
+
+## Saving model fits
+
+```{r child = "template-bundle.Rmd"}
+```

--- a/man/rmd/logistic_reg_h2o.md
+++ b/man/rmd/logistic_reg_h2o.md
@@ -84,3 +84,8 @@ To use the h2o engine with tidymodels, please run `h2o::h2o.init()` first. By de
 You can control the number of threads in the thread pool used by h2o with the `nthreads` argument. By default, it uses all CPUs on the host. This is different from the usual parallel processing mechanism in tidymodels for tuning, while tidymodels parallelizes over resamples, h2o parallelizes over hyperparameter combinations for a given resample. 
 
 h2o will automatically shut down the local h2o instance started by R when R is terminated. To manually stop the h2o server, run `h2o::h2o.shutdown()`. 
+
+## Saving model fits
+
+
+Models fitted with this engine may require native serialization methods to be properly saved and/or passed between R sessions. To learn more about preparing fitted models for serialization, see the bundle package.

--- a/man/rmd/logistic_reg_keras.Rmd
+++ b/man/rmd/logistic_reg_keras.Rmd
@@ -47,6 +47,11 @@ logistic_reg(penalty = double(1)) %>%
 ```{r child = "template-no-case-weights.Rmd"}
 ```
 
+## Saving model fits
+
+```{r child = "template-bundle.Rmd"}
+```
+
 ## Examples 
 
 The "Fitting and Predicting with parsnip" article contains [examples](https://parsnip.tidymodels.org/articles/articles/Examples.html#logistic-reg-keras) for `logistic_reg()` with the `"keras"` engine.

--- a/man/rmd/logistic_reg_keras.md
+++ b/man/rmd/logistic_reg_keras.md
@@ -51,6 +51,11 @@ scale each so that each predictor has mean zero and a variance of one.
 
 The underlying model implementation does not allow for case weights. 
 
+## Saving model fits
+
+
+Models fitted with this engine may require native serialization methods to be properly saved and/or passed between R sessions. To learn more about preparing fitted models for serialization, see the bundle package.
+
 ## Examples 
 
 The "Fitting and Predicting with parsnip" article contains [examples](https://parsnip.tidymodels.org/articles/articles/Examples.html#logistic-reg-keras) for `logistic_reg()` with the `"keras"` engine.

--- a/man/rmd/mlp_h2o.Rmd
+++ b/man/rmd/mlp_h2o.Rmd
@@ -86,3 +86,7 @@ By default, [h2o::h2o.deeplearning()] uses the argument `standardize = TRUE` to 
 ```{r child = "template-h2o-init.Rmd"}
 ```
 
+## Saving model fits
+
+```{r child = "template-bundle.Rmd"}
+```

--- a/man/rmd/mlp_h2o.md
+++ b/man/rmd/mlp_h2o.md
@@ -132,3 +132,7 @@ You can control the number of threads in the thread pool used by h2o with the `n
 
 h2o will automatically shut down the local h2o instance started by R when R is terminated. To manually stop the h2o server, run `h2o::h2o.shutdown()`. 
 
+## Saving model fits
+
+
+Models fitted with this engine may require native serialization methods to be properly saved and/or passed between R sessions. To learn more about preparing fitted models for serialization, see the bundle package.

--- a/man/rmd/mlp_keras.Rmd
+++ b/man/rmd/mlp_keras.Rmd
@@ -66,6 +66,11 @@ mlp(
 ```{r child = "template-no-case-weights.Rmd"}
 ```
 
+## Saving model fits
+
+```{r child = "template-bundle.Rmd"}
+```
+
 ## Examples 
 
 The "Fitting and Predicting with parsnip" article contains [examples](https://parsnip.tidymodels.org/articles/articles/Examples.html#mlp-keras) for `mlp()` with the `"keras"` engine.

--- a/man/rmd/mlp_keras.md
+++ b/man/rmd/mlp_keras.md
@@ -102,6 +102,11 @@ scale each so that each predictor has mean zero and a variance of one.
 
 The underlying model implementation does not allow for case weights. 
 
+## Saving model fits
+
+
+Models fitted with this engine may require native serialization methods to be properly saved and/or passed between R sessions. To learn more about preparing fitted models for serialization, see the bundle package.
+
 ## Examples 
 
 The "Fitting and Predicting with parsnip" article contains [examples](https://parsnip.tidymodels.org/articles/articles/Examples.html#mlp-keras) for `mlp()` with the `"keras"` engine.

--- a/man/rmd/multinom_reg_keras.Rmd
+++ b/man/rmd/multinom_reg_keras.Rmd
@@ -47,6 +47,11 @@ multinom_reg(penalty = double(1)) %>%
 ```{r child = "template-no-case-weights.Rmd"}
 ```
 
+## Saving model fits
+
+```{r child = "template-bundle.Rmd"}
+```
+
 ## Examples 
 
 The "Fitting and Predicting with parsnip" article contains [examples](https://parsnip.tidymodels.org/articles/articles/Examples.html#multinom-reg-keras) for `multinom_reg()` with the `"keras"` engine.

--- a/man/rmd/multinom_reg_keras.md
+++ b/man/rmd/multinom_reg_keras.md
@@ -51,6 +51,11 @@ scale each so that each predictor has mean zero and a variance of one.
 
 The underlying model implementation does not allow for case weights. 
 
+## Saving model fits
+
+
+Models fitted with this engine may require native serialization methods to be properly saved and/or passed between R sessions. To learn more about preparing fitted models for serialization, see the bundle package.
+
 ## Examples 
 
 The "Fitting and Predicting with parsnip" article contains [examples](https://parsnip.tidymodels.org/articles/articles/Examples.html#multinom-reg-keras) for `multinom_reg()` with the `"keras"` engine.

--- a/man/rmd/naive_Bayes_h2o.Rmd
+++ b/man/rmd/naive_Bayes_h2o.Rmd
@@ -50,3 +50,8 @@ naive_Bayes(Laplace = numeric(0)) %>%
 
 ```{r child = "template-h2o-init.Rmd"}
 ```
+
+## Saving model fits
+
+```{r child = "template-bundle.Rmd"}
+```

--- a/man/rmd/naive_Bayes_h2o.md
+++ b/man/rmd/naive_Bayes_h2o.md
@@ -57,3 +57,8 @@ To use the h2o engine with tidymodels, please run `h2o::h2o.init()` first. By de
 You can control the number of threads in the thread pool used by h2o with the `nthreads` argument. By default, it uses all CPUs on the host. This is different from the usual parallel processing mechanism in tidymodels for tuning, while tidymodels parallelizes over resamples, h2o parallelizes over hyperparameter combinations for a given resample. 
 
 h2o will automatically shut down the local h2o instance started by R when R is terminated. To manually stop the h2o server, run `h2o::h2o.shutdown()`. 
+
+## Saving model fits
+
+
+Models fitted with this engine may require native serialization methods to be properly saved and/or passed between R sessions. To learn more about preparing fitted models for serialization, see the bundle package.

--- a/man/rmd/poisson_reg_h2o.Rmd
+++ b/man/rmd/poisson_reg_h2o.Rmd
@@ -54,3 +54,8 @@ By default, `h2o::h2o.glm()` uses the argument `standardize = TRUE` to center an
 
 ```{r child = "template-h2o-init.Rmd"}
 ```
+
+## Saving model fits
+
+```{r child = "template-bundle.Rmd"}
+```

--- a/man/rmd/poisson_reg_h2o.md
+++ b/man/rmd/poisson_reg_h2o.md
@@ -68,3 +68,8 @@ To use the h2o engine with tidymodels, please run `h2o::h2o.init()` first. By de
 You can control the number of threads in the thread pool used by h2o with the `nthreads` argument. By default, it uses all CPUs on the host. This is different from the usual parallel processing mechanism in tidymodels for tuning, while tidymodels parallelizes over resamples, h2o parallelizes over hyperparameter combinations for a given resample. 
 
 h2o will automatically shut down the local h2o instance started by R when R is terminated. To manually stop the h2o server, run `h2o::h2o.shutdown()`. 
+
+## Saving model fits
+
+
+Models fitted with this engine may require native serialization methods to be properly saved and/or passed between R sessions. To learn more about preparing fitted models for serialization, see the bundle package.

--- a/man/rmd/rand_forest_h2o.Rmd
+++ b/man/rmd/rand_forest_h2o.Rmd
@@ -64,3 +64,8 @@ rand_forest(
 
 ```{r child = "template-h2o-init.Rmd"}
 ```
+
+## Saving model fits
+
+```{r child = "template-bundle.Rmd"}
+```

--- a/man/rmd/rand_forest_h2o.md
+++ b/man/rmd/rand_forest_h2o.md
@@ -95,3 +95,8 @@ To use the h2o engine with tidymodels, please run `h2o::h2o.init()` first. By de
 You can control the number of threads in the thread pool used by h2o with the `nthreads` argument. By default, it uses all CPUs on the host. This is different from the usual parallel processing mechanism in tidymodels for tuning, while tidymodels parallelizes over resamples, h2o parallelizes over hyperparameter combinations for a given resample. 
 
 h2o will automatically shut down the local h2o instance started by R when R is terminated. To manually stop the h2o server, run `h2o::h2o.shutdown()`. 
+
+## Saving model fits
+
+
+Models fitted with this engine may require native serialization methods to be properly saved and/or passed between R sessions. To learn more about preparing fitted models for serialization, see the bundle package.

--- a/man/rmd/rule_fit_h2o.Rmd
+++ b/man/rmd/rule_fit_h2o.Rmd
@@ -82,3 +82,8 @@ rule_fit(
 
 ```{r child = "template-h2o-init.Rmd"}
 ```
+
+## Saving model fits
+
+```{r child = "template-bundle.Rmd"}
+```

--- a/man/rmd/rule_fit_h2o.md
+++ b/man/rmd/rule_fit_h2o.md
@@ -113,3 +113,8 @@ To use the h2o engine with tidymodels, please run `h2o::h2o.init()` first. By de
 You can control the number of threads in the thread pool used by h2o with the `nthreads` argument. By default, it uses all CPUs on the host. This is different from the usual parallel processing mechanism in tidymodels for tuning, while tidymodels parallelizes over resamples, h2o parallelizes over hyperparameter combinations for a given resample. 
 
 h2o will automatically shut down the local h2o instance started by R when R is terminated. To manually stop the h2o server, run `h2o::h2o.shutdown()`. 
+
+## Saving model fits
+
+
+Models fitted with this engine may require native serialization methods to be properly saved and/or passed between R sessions. To learn more about preparing fitted models for serialization, see the bundle package.

--- a/man/rmd/template-bundle.Rmd
+++ b/man/rmd/template-bundle.Rmd
@@ -1,0 +1,1 @@
+Models fitted with this engine may require native serialization methods to be properly saved and/or passed between R sessions. To learn more about preparing fitted models for serialization, see the bundle package.


### PR DESCRIPTION
With bundle now on CRAN, this PR adds a short template noting that the package exists in `?details_*` for engine that need native serialization. Closes #781.☃️

I didn't add a namespaced reference so we don't have to Suggest the package, and I didn't add a URL since it would redirect following the RStudio name change, though this template does feel a bit light as a result.

The lightgbm docfiles also contain an unrelated update, following up on the new release of bonsai.
