### PR TITLE
print `(unknown mode)` instead of `(unknown)`

### DIFF
--- a/R/print.R
+++ b/R/print.R
@@ -13,7 +13,9 @@ print_model_spec <- function(x, cls = class(x)[1], desc = get_model_desc(cls), .
     prompt_missing_implementation(spec = structure(x, class = cls), prompt = cli::cli_inform)
   }
 
-  cat(desc, " Model Specification (", x$mode, ")\n\n", sep = "")
+  mode <- switch(x$mode, unknown = "unknown mode", x$mode)
+
+  cat(desc, " Model Specification (", mode, ")\n\n", sep = "")
   model_printer(x, ...)
 
   if (is_printable_spec(x)) {

--- a/tests/testthat/_snaps/boost_tree.md
+++ b/tests/testthat/_snaps/boost_tree.md
@@ -4,7 +4,7 @@
       boost_tree(trees = 1) %>% set_engine("C5.0", noGlobalPruning = TRUE) %>% update(
         trees = tune(), noGlobalPruning = tune())
     Output
-      Boosted Tree Model Specification (unknown)
+      Boosted Tree Model Specification (unknown mode)
       
       Main Arguments:
         trees = tune()

--- a/tests/testthat/_snaps/decision_tree.md
+++ b/tests/testthat/_snaps/decision_tree.md
@@ -4,7 +4,7 @@
       decision_tree(cost_complexity = 0.1) %>% set_engine("rpart", model = FALSE) %>%
         update(cost_complexity = tune(), model = tune())
     Output
-      Decision Tree Model Specification (unknown)
+      Decision Tree Model Specification (unknown mode)
       
       Main Arguments:
         cost_complexity = tune()

--- a/tests/testthat/_snaps/mars.md
+++ b/tests/testthat/_snaps/mars.md
@@ -3,7 +3,7 @@
     Code
       expr1 %>% update(num_terms = tune(), nk = tune())
     Output
-      MARS Model Specification (unknown)
+      MARS Model Specification (unknown mode)
       
       Main Arguments:
         num_terms = tune()

--- a/tests/testthat/_snaps/misc.md
+++ b/tests/testthat/_snaps/misc.md
@@ -71,7 +71,7 @@
       i The parsnip extension packages censored and baguette implement support for this specification.
       i Please install (if needed) and load to continue.
     Output
-      Bagged Decision Tree Model Specification (unknown)
+      Bagged Decision Tree Model Specification (unknown mode)
       
       Main Arguments:
         cost_complexity = 0
@@ -89,7 +89,7 @@
       i The parsnip extension packages censored and baguette implement support for this specification.
       i Please install (if needed) and load to continue.
     Output
-      Bagged Decision Tree Model Specification (unknown)
+      Bagged Decision Tree Model Specification (unknown mode)
       
       Main Arguments:
         cost_complexity = 0

--- a/tests/testthat/_snaps/model_basics.md
+++ b/tests/testthat/_snaps/model_basics.md
@@ -7,7 +7,7 @@
       i The parsnip extension package baguette implements support for this specification.
       i Please install (if needed) and load to continue.
     Output
-      Bagged MARS Model Specification (unknown)
+      Bagged MARS Model Specification (unknown mode)
       
       Computational engine: earth 
       
@@ -21,7 +21,7 @@
       i The parsnip extension packages censored and baguette implement support for this specification.
       i Please install (if needed) and load to continue.
     Output
-      Bagged Decision Tree Model Specification (unknown)
+      Bagged Decision Tree Model Specification (unknown mode)
       
       Main Arguments:
         cost_complexity = 0
@@ -35,7 +35,7 @@
     Code
       print(bart())
     Output
-      BART Model Specification (unknown)
+      BART Model Specification (unknown mode)
       
       Computational engine: dbarts 
       
@@ -45,7 +45,7 @@
     Code
       print(boost_tree())
     Output
-      Boosted Tree Model Specification (unknown)
+      Boosted Tree Model Specification (unknown mode)
       
       Computational engine: xgboost 
       
@@ -83,7 +83,7 @@
     Code
       print(decision_tree())
     Output
-      Decision Tree Model Specification (unknown)
+      Decision Tree Model Specification (unknown mode)
       
       Computational engine: rpart 
       
@@ -149,7 +149,7 @@
     Code
       print(gen_additive_mod())
     Output
-      GAM Model Specification (unknown)
+      GAM Model Specification (unknown mode)
       
       Computational engine: mgcv 
       
@@ -179,7 +179,7 @@
     Code
       print(mars())
     Output
-      MARS Model Specification (unknown)
+      MARS Model Specification (unknown mode)
       
       Computational engine: earth 
       
@@ -189,7 +189,7 @@
     Code
       print(mlp())
     Output
-      Single Layer Neural Network Model Specification (unknown)
+      Single Layer Neural Network Model Specification (unknown mode)
       
       Computational engine: nnet 
       
@@ -223,7 +223,7 @@
     Code
       print(nearest_neighbor())
     Output
-      K-Nearest Neighbor Model Specification (unknown)
+      K-Nearest Neighbor Model Specification (unknown mode)
       
       Computational engine: kknn 
       
@@ -245,7 +245,7 @@
       i The parsnip extension package plsmod implements support for this specification.
       i Please install (if needed) and load to continue.
     Output
-      PLS Model Specification (unknown)
+      PLS Model Specification (unknown mode)
       
       Computational engine: mixOmics 
       
@@ -283,7 +283,7 @@
     Code
       print(rand_forest())
     Output
-      Random Forest Model Specification (unknown)
+      Random Forest Model Specification (unknown mode)
       
       Computational engine: ranger 
       
@@ -297,7 +297,7 @@
       i The parsnip extension packages agua and rules implement support for this specification.
       i Please install (if needed) and load to continue.
     Output
-      RuleFit Model Specification (unknown)
+      RuleFit Model Specification (unknown mode)
       
       Computational engine: xrf 
       
@@ -321,7 +321,7 @@
     Code
       print(svm_linear())
     Output
-      Linear Support Vector Machine Model Specification (unknown)
+      Linear Support Vector Machine Model Specification (unknown mode)
       
       Computational engine: LiblineaR 
       
@@ -331,7 +331,7 @@
     Code
       print(svm_poly())
     Output
-      Polynomial Support Vector Machine Model Specification (unknown)
+      Polynomial Support Vector Machine Model Specification (unknown mode)
       
       Computational engine: kernlab 
       
@@ -341,7 +341,7 @@
     Code
       print(svm_rbf())
     Output
-      Radial Basis Function Support Vector Machine Model Specification (unknown)
+      Radial Basis Function Support Vector Machine Model Specification (unknown mode)
       
       Computational engine: kernlab 
       

--- a/tests/testthat/_snaps/nearest_neighbor.md
+++ b/tests/testthat/_snaps/nearest_neighbor.md
@@ -4,7 +4,7 @@
       nearest_neighbor(neighbors = 5) %>% set_engine("kknn", scale = FALSE) %>%
         update(neighbors = tune(), scale = tune())
     Output
-      K-Nearest Neighbor Model Specification (unknown)
+      K-Nearest Neighbor Model Specification (unknown mode)
       
       Main Arguments:
         neighbors = tune()

--- a/tests/testthat/_snaps/print.md
+++ b/tests/testthat/_snaps/print.md
@@ -3,7 +3,7 @@
     Code
       svm_poly()
     Output
-      Polynomial Support Vector Machine Model Specification (unknown)
+      Polynomial Support Vector Machine Model Specification (unknown mode)
       
       Computational engine: kernlab 
       
@@ -13,7 +13,7 @@
     Code
       boost_tree(mtry = 5)
     Output
-      Boosted Tree Model Specification (unknown)
+      Boosted Tree Model Specification (unknown mode)
       
       Main Arguments:
         mtry = 5


### PR DESCRIPTION
The model spec printing method calls out the spec’s mode:

``` r
library(parsnip)
  
boost_tree(mode = "regression")
#> Boosted Tree Model Specification (regression)
#> 
#> Computational engine: xgboost
```

When the `mode` is `"unknown"`, the output `(unknown)` beside the model spec’s type is ambiguous.

``` r
boost_tree()
#> Boosted Tree Model Specification (unknown)
#> 
#> Computational engine: xgboost
```

This PR proposes printing `(unknown mode)` instead:

``` r
boost_tree()
#> Boosted Tree Model Specification (unknown mode)
#> 
#> Computational engine: xgboost
```

<sup>Created on 2022-09-21 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>