### PR TITLE
remove README.md from .Rbuildignore

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -11,7 +11,6 @@ derby.log
 ^logs$
 ^tests/testthat/logs$
 ^revdep$
-^README\.md$
 ^issue_template.md$
 ^README\.Rmd$
 ^\.github$


### PR DESCRIPTION
This PR removes `README.md` from `.Rbuildignore` making it so it will show up on CRAN and within the Package Manager UI.