### PR TITLE
Enable `fit_xy()` for censored regression

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: parsnip
 Title: A Common API to Modeling and Analysis Functions
-Version: 1.0.2.9000
+Version: 1.0.2.9001
 Authors@R: c(
     person("Max", "Kuhn", , "max@rstudio.com", role = c("aut", "cre")),
     person("Davis", "Vaughan", , "davis@rstudio.com", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # parsnip (development version)
 
-* The matrix interface for fitting `fit_xy()` now works for the `"censored regression"`" mode (#829).
+* The matrix interface for fitting `fit_xy()` now works for the `"censored regression"` mode (#829).
 
 # parsnip 1.0.2
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # parsnip (development version)
 
+* The matrix interface for fitting `fit_xy()` now works for the `"censored regression"`" mode.
+
 # parsnip 1.0.2
 
 * A bagged neural network model was added (`bag_mlp()`). Engine implementations will live in the baguette package. 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # parsnip (development version)
 
-* The matrix interface for fitting `fit_xy()` now works for the `"censored regression"`" mode.
+* The matrix interface for fitting `fit_xy()` now works for the `"censored regression"`" mode (#829).
 
 # parsnip 1.0.2
 

--- a/R/fit.R
+++ b/R/fit.R
@@ -228,10 +228,6 @@ fit_xy.model_spec <-
       rlang::abort("Please set the mode in the model specification.")
     }
 
-    if (object$mode == "censored regression") {
-      rlang::abort("Models for censored regression must use the formula interface.")
-    }
-
     if (inherits(object, "surv_reg")) {
       rlang::abort("Survival models must use the formula interface.")
     }
@@ -408,9 +404,10 @@ check_xy_interface <- function(x, y, cl, model) {
     inher(x, c("data.frame", "matrix"), cl)
   }
 
-  # `y` can be a vector (which is not a class), or a factor (which is not a vector)
+  # `y` can be a vector (which is not a class), or a factor or
+  # Surv object (which are not vectors)
   if (!is.null(y) && !is.vector(y))
-    inher(y, c("data.frame", "matrix", "factor"), cl)
+    inher(y, c("data.frame", "matrix", "factor", "Surv"), cl)
 
   # rule out spark data sets that don't use the formula interface
   if (inherits(x, "tbl_spark") | inherits(y, "tbl_spark"))

--- a/R/misc.R
+++ b/R/misc.R
@@ -330,6 +330,10 @@ check_outcome <- function(y, spec) {
     if (!all(map_lgl(y, is.factor))) {
       rlang::abort("For a classification model, the outcome should be a factor.")
     }
+  } else if (spec$mode == "censored regression") {
+    if (!inherits(y, "Surv")) {
+      rlang::abort("For a censored regression model, the outcome should be a `Surv` object.")
+    }
   }
   invisible(NULL)
 }

--- a/tests/testthat/test_proportional_hazards.R
+++ b/tests/testthat/test_proportional_hazards.R
@@ -9,12 +9,3 @@ test_that("updating", {
 test_that("bad input", {
   expect_error(proportional_hazards(mode = ", classification"))
 })
-
-test_that("wrong fit interface", {
-  expect_error(
-    expect_message(
-      proportional_hazards() %>% fit_xy()
-    ),
-    "must use the formula interface"
-  )
-})

--- a/tests/testthat/test_survival_reg.R
+++ b/tests/testthat/test_survival_reg.R
@@ -30,12 +30,3 @@ test_that("updating", {
 test_that("bad input", {
   expect_error(survival_reg(mode = ", classification"))
 })
-
-test_that("wrong fit interface", {
-  expect_error(
-    expect_message(
-      survival_reg() %>% fit_xy()
-    ),
-    "must use the formula interface"
-  )
-})


### PR DESCRIPTION
This PR enables the matrix interface via `fit_xy()` for the `"censored regression"` mode.

Tests for this are in censored: https://github.com/tidymodels/censored/pull/225