### PR TITLE
check outcome class conditional on whether `y` is atomic

### DIFF
--- a/R/misc.R
+++ b/R/misc.R
@@ -322,21 +322,29 @@ new_model_spec <- function(cls, args, eng_args, mode, user_specified_mode = TRUE
 check_outcome <- function(y, spec) {
   if (spec$mode == "unknown") {
     return(invisible(NULL))
-  } else if (spec$mode == "regression") {
+  }
+
+  if (spec$mode == "regression") {
     outcome_is_numeric <- if (is.atomic(y)) {is.numeric(y)} else {all(map_lgl(y, is.numeric))}
     if (!outcome_is_numeric) {
       rlang::abort("For a regression model, the outcome should be numeric.")
     }
-  } else if (spec$mode == "classification") {
+  }
+
+  if (spec$mode == "classification") {
     outcome_is_factor <- if (is.atomic(y)) {is.factor(y)} else {all(map_lgl(y, is.factor))}
     if (!outcome_is_factor) {
       rlang::abort("For a classification model, the outcome should be a factor.")
     }
-  } else if (spec$mode == "censored regression") {
-    if (!inherits(y, "Surv")) {
+  }
+
+  if (spec$mode == "censored regression") {
+    outcome_is_surv <- inherits(y, "Surv")
+    if (!outcome_is_surv) {
       rlang::abort("For a censored regression model, the outcome should be a `Surv` object.")
     }
   }
+
   invisible(NULL)
 }
 

--- a/R/misc.R
+++ b/R/misc.R
@@ -323,11 +323,13 @@ check_outcome <- function(y, spec) {
   if (spec$mode == "unknown") {
     return(invisible(NULL))
   } else if (spec$mode == "regression") {
-    if (!all(map_lgl(y, is.numeric))) {
+    outcome_is_numeric <- if (is.atomic(y)) {is.numeric(y)} else {all(map_lgl(y, is.numeric))}
+    if (!outcome_is_numeric) {
       rlang::abort("For a regression model, the outcome should be numeric.")
     }
   } else if (spec$mode == "classification") {
-    if (!all(map_lgl(y, is.factor))) {
+    outcome_is_factor <- if (is.atomic(y)) {is.factor(y)} else {all(map_lgl(y, is.factor))}
+    if (!outcome_is_factor) {
       rlang::abort("For a classification model, the outcome should be a factor.")
     }
   } else if (spec$mode == "censored regression") {


### PR DESCRIPTION
😮

With CRAN parsnip:

``` r
library(tidymodels)

set.seed(1)
dat <- tibble(x = rnorm(1e7), y = x + rnorm(1e7, sd = .2))

system.time({
  linear_reg() %>%
    fit(y ~ x, dat)
})
#>    user  system elapsed 
#>   4.108   0.158   4.267
```

<sup>Created on 2022-10-28 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

With this PR:

``` r
library(tidymodels)

set.seed(1)
dat <- tibble(x = rnorm(1e7), y = x + rnorm(1e7, sd = .2))

system.time({
  linear_reg() %>%
    fit(y ~ x, dat)
})
#>    user  system elapsed 
#>   1.251   0.187   1.442
```

<sup>Created on 2022-10-28 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

Closes #834.

`check_outcome` is a bit conditional-heavy, though I have trouble imagining how these could be converted to switch- or tibbled-based logic elegantly.