### PR TITLE
make lightgbm's `num_leaves` engine arg tunable

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,7 +41,7 @@ Imports:
 Suggests: 
     C50,
     covr,
-    dials (>= 0.1.0),
+    dials (>= 1.0.0.9001),
     earth,
     ggrepel,
     keras,
@@ -76,3 +76,5 @@ LazyData: true
 Roxygen: list(markdown = TRUE)
 Config/testthat/edition: 3
 RoxygenNote: 7.2.1.9000
+Remotes: 
+    tidymodels/dials#256

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 * The matrix interface for fitting `fit_xy()` now works for the `"censored regression"` mode (#829).
 
+* The `num_leaves` argument of `boost_tree()`s `lightgbm` engine (via the bonsai package) is now tunable.
+
+
 # parsnip 1.0.2
 
 * A bagged neural network model was added (`bag_mlp()`). Engine implementations will live in the baguette package. 

--- a/R/tunable.R
+++ b/R/tunable.R
@@ -94,6 +94,19 @@ xgboost_engine_args <-
     component_id = "engine"
   )
 
+lightgbm_engine_args <-
+  tibble::tibble(
+    name = c(
+      "num_leaves"
+    ),
+    call_info = list(
+      list(pkg = "dials", fun = "num_leaves")
+    ),
+    source = "model_spec",
+    component = "boost_tree",
+    component_id = "engine"
+  )
+
 ranger_engine_args <-
   tibble::tibble(
     name = c(
@@ -244,6 +257,7 @@ tunable_boost_tree <- function(x, ...) {
     res$call_info[res$name == "sample_size"] <-
       list(list(pkg = "dials", fun = "sample_prop"))
   } else if (x$engine == "lightgbm") {
+    res <- add_engine_parameters(res, lightgbm_engine_args)
     res$call_info[res$name == "sample_size"] <-
       list(list(pkg = "dials", fun = "sample_prop"))
   }


### PR DESCRIPTION
This PR makes use of https://github.com/tidymodels/dials/pull/256 to make the `num_leaves` engine arg of lightgbm tunable. 

Having the news bullet here instead of bonsai feels a little off but I guess it's the best place?