### PR TITLE
Typos: cheap -> cheaply; and can -> which

### DIFF
--- a/vignettes/articles/Submodels.Rmd
+++ b/vignettes/articles/Submodels.Rmd
@@ -16,7 +16,7 @@ library(ggplot2)
 theme_set(theme_bw())
 ```
 
-Some R packages can create predictions from models that are different than the one that was fit. For example, if a boosted tree is fit with 10 iterations of boosting, the model can usually make predictions on _submodels_ that have less than 10 trees (all other parameters being static). This is helpful for model tuning since you can cheap evaluate tuning parameter combinations and can often results in a large speed-up in the computations. 
+Some R packages can create predictions from models that are different than the one that was fit. For example, if a boosted tree is fit with 10 iterations of boosting, the model can usually make predictions on _submodels_ that have less than 10 trees (all other parameters being static). This is helpful for model tuning since you can cheaply evaluate tuning parameter combinations which often results in a large speed-up in the computations. 
 
 In `parsnip`, there is a method called `multi_predict()` that can do this. It's current methods are:
 


### PR DESCRIPTION
I think there was some mix-up with this sentence.