### PR TITLE
Refactor `prepare_data()` 

### DIFF
--- a/R/predict.R
+++ b/R/predict.R
@@ -390,16 +390,14 @@ check_pred_type_dots <- function(object, type, ...) {
 #' @keywords internal
 #' @export
 prepare_data <- function(object, new_data) {
-  fit_interface <- object$spec$method$fit$interface
+  preproc_names <- names(object$preproc)
+  translate_from_formula_to_xy <- any(preproc_names == "terms", na.rm = TRUE)
+  translate_from_xy_to_formula <- any(preproc_names == "x_var", na.rm = TRUE)
 
-  pp_names <- names(object$preproc)
-  if (any(pp_names == "terms") | any(pp_names == "x_var")) {
-    # Translation code
-    if (fit_interface == "formula") {
-      new_data <- .convert_xy_to_form_new(object$preproc, new_data)
-    } else {
-      new_data <- .convert_form_to_xy_new(object$preproc, new_data)$x
-    }
+  if (translate_from_formula_to_xy) {
+    new_data <- .convert_form_to_xy_new(object$preproc, new_data)$x
+  } else if (translate_from_xy_to_formula) {
+    new_data <- .convert_xy_to_form_new(object$preproc, new_data)
   }
 
   remove_intercept <-
@@ -410,6 +408,7 @@ prepare_data <- function(object, new_data) {
     new_data <- new_data %>% dplyr::select(-dplyr::one_of("(Intercept)"))
   }
 
+  fit_interface <- object$spec$method$fit$interface
   switch(
     fit_interface,
     none = new_data,


### PR DESCRIPTION
`prepare_data()` is called within the `predict_<prediction type>().model_fit()` methods, on the `model_fit` and the `new_data`. If we converted the training data between different interfaces (matrix vs formula), we also convert the `new_data` at prediction time, via `.convert_form_to_xy_new()` and `.convert_xy_to_form_new()` respectively. Whether those get called is determined based on the objects in the `$preproc` of the fitted parsnip model.

I've refactored this here to use variable names for the conditions, to make it easier to understand which preproc items are linked to which conversion.

The main question for review is: is it okay to rely _only_ on the names of the preproc items? The previous version relied on them to decide _if_ any `.convert_*()` function should be applied. The refactored version also relies on them to decide which of them should be applied.
