### PR TITLE
Tests for `poisson_reg()`

### DIFF
--- a/tests/testthat/_snaps/poisson_reg.md
+++ b/tests/testthat/_snaps/poisson_reg.md
@@ -1,0 +1,46 @@
+# updating
+
+    Code
+      poisson_reg(penalty = 1) %>% set_engine("glmnet", lambda.min.ratio = 0.001) %>%
+        update(mixture = tune())
+    Message
+      ! parsnip could not locate an implementation for `poisson_reg` model specifications using the `glmnet` engine.
+      i The parsnip extension package poissonreg implements support for this specification.
+      i Please install (if needed) and load to continue.
+    Output
+      Poisson Regression Model Specification (regression)
+      
+      Main Arguments:
+        penalty = 1
+        mixture = tune()
+      
+      Engine-Specific Arguments:
+        lambda.min.ratio = 0.001
+      
+      Computational engine: glmnet 
+      
+
+# bad input
+
+    Code
+      poisson_reg(mode = "bogus")
+    Condition
+      Error in `poisson_reg()`:
+      ! 'bogus' is not a known mode for model `poisson_reg()`.
+
+---
+
+    Code
+      translate(poisson_reg(mode = "regression"), engine = NULL)
+    Condition
+      Error in `translate.default()`:
+      ! Please set an engine.
+
+---
+
+    Code
+      poisson_reg(formula = y ~ x)
+    Condition
+      Error in `poisson_reg()`:
+      ! unused argument (formula = y ~ x)
+

--- a/tests/testthat/test-poisson_reg.R
+++ b/tests/testthat/test-poisson_reg.R
@@ -1,0 +1,13 @@
+test_that("updating", {
+  expect_snapshot(
+    poisson_reg(penalty = 1) %>%
+      set_engine("glmnet", lambda.min.ratio = 0.001) %>%
+      update(mixture = tune())
+  )
+})
+
+test_that("bad input", {
+  expect_snapshot(error = TRUE, poisson_reg(mode = "bogus"))
+  expect_snapshot(error = TRUE, translate(poisson_reg(mode = "regression"), engine = NULL))
+  expect_snapshot(error = TRUE, poisson_reg(formula = y ~ x))
+})


### PR DESCRIPTION
We generally try to put tests on the basic model function (like `poisson_reg()`) in parsnip since the model definitions now live here. This PR moves some of those tests from poissonreg to here.

The corresponding PR to remove them from poissonreg is: https://github.com/tidymodels/poissonreg/pull/55