### PR TITLE
glmnet: Require users to set `penalty` value for `poisson_reg()`

### DIFF
--- a/R/poisson_reg.R
+++ b/R/poisson_reg.R
@@ -86,6 +86,7 @@ translate.poisson_reg <- function(x, engine = x$engine, ...) {
   x <- translate.default(x, engine, ...)
 
   if (engine == "glmnet") {
+    .check_glmnet_penalty_fit(x)
     # See discussion in https://github.com/tidymodels/parsnip/issues/195
     x$method$fit$args$lambda <- NULL
     # Since the `fit` information is gone for the penalty, we need to have an


### PR DESCRIPTION
closes  #757

I'll add the corresponding test to the other glmnet tests for `poisson_reg()` in extratests.

``` r
library(poissonreg)
#> Loading required package: parsnip

# These should both fail in translate()

poisson_reg(penalty = c(0.01, 0.1)) %>% 
  set_engine("glmnet") %>% 
  fit(count ~ (.)^2, data = seniors)
#> Error in `.check_glmnet_penalty_fit()` at parsnip/R/poisson_reg.R:89:4:
#> ! For the glmnet engine, `penalty` must be a single number (or a value of `tune()`).
#> • There are 2 values for `penalty`.
#> • To try multiple values for total regularization, use the tune package.
#> • To predict multiple penalties, use `multi_predict()`

poisson_reg() %>% 
  set_engine("glmnet") %>% 
  fit(count ~ (.)^2, data = seniors)
#> Error in `.check_glmnet_penalty_fit()` at parsnip/R/poisson_reg.R:89:4:
#> ! For the glmnet engine, `penalty` must be a single number (or a value of `tune()`).
#> • There are 0 values for `penalty`.
#> • To try multiple values for total regularization, use the tune package.
#> • To predict multiple penalties, use `multi_predict()`
```

<sup>Created on 2023-01-22 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>