### PR TITLE
Setting the penalty for logistic and multinomial regression with glmnet

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: parsnip
 Title: A Common API to Modeling and Analysis Functions
-Version: 1.0.3.9000
+Version: 1.0.3.9001
 Authors@R: c(
     person("Max", "Kuhn", , "max@rstudio.com", role = c("aut", "cre")),
     person("Davis", "Vaughan", , "davis@rstudio.com", role = "aut"),

--- a/R/logistic_reg.R
+++ b/R/logistic_reg.R
@@ -271,8 +271,6 @@ multi_predict._lognet <-
       }
     }
 
-    dots$s <- penalty
-
     if (is.null(type))
       type <- "class"
     if (!(type %in% c("class", "prob", "link", "raw"))) {
@@ -284,7 +282,9 @@ multi_predict._lognet <-
       dots$type <- type
 
     object$spec <- eval_args(object$spec)
-    pred <- predict.model_fit(object, new_data = new_data, type = "raw", opts = dots)
+    pred <- predict._lognet(object, new_data = new_data, type = "raw",
+                            opts = dots, penalty = penalty, multi = TRUE)
+
     param_key <- tibble(group = colnames(pred), penalty = penalty)
     pred <- as_tibble(pred)
     pred$.row <- 1:nrow(pred)
@@ -340,6 +340,7 @@ predict_raw._lognet <- function(object, new_data, opts = list(), ...) {
     rlang::abort("Did you mean to use `new_data` instead of `newdata`?")
 
   object$spec <- eval_args(object$spec)
+  opts$s <- object$spec$args$penalty
   predict_raw.model_fit(object, new_data = new_data, opts = opts, ...)
 }
 

--- a/R/multinom_reg.R
+++ b/R/multinom_reg.R
@@ -200,6 +200,7 @@ multi_predict._multnet <-
       penalty <- eval_tidy(penalty)
 
     dots <- list(...)
+
     if (is.null(penalty)) {
       # See discussion in https://github.com/tidymodels/parsnip/issues/195
       if (!is.null(object$spec$args$penalty)) {
@@ -208,7 +209,6 @@ multi_predict._multnet <-
         penalty <- object$fit$lambda
       }
     }
-    dots$s <- penalty
 
     if (is.null(type))
       type <- "class"
@@ -221,7 +221,8 @@ multi_predict._multnet <-
       dots$type <- type
 
     object$spec <- eval_args(object$spec)
-    pred <- predict.model_fit(object, new_data = new_data, type = "raw", opts = dots)
+    pred <- predict._lognet(object, new_data = new_data, type = "raw",
+                            opts = dots, penalty = penalty, multi = TRUE)
 
     format_probs <- function(x) {
       x <- as_tibble(x)
@@ -268,5 +269,6 @@ predict_classprob._multnet <- function(object, new_data, ...) {
 #' @export
 predict_raw._multnet <- function(object, new_data, opts = list(), ...) {
   object$spec <- eval_args(object$spec)
+  opts$s <- object$spec$args$penalty
   predict_raw.model_fit(object, new_data = new_data, opts = opts, ...)
 }

--- a/R/multinom_reg.R
+++ b/R/multinom_reg.R
@@ -221,8 +221,8 @@ multi_predict._multnet <-
       dots$type <- type
 
     object$spec <- eval_args(object$spec)
-    pred <- predict._lognet(object, new_data = new_data, type = "raw",
-                            opts = dots, penalty = penalty, multi = TRUE)
+    pred <- predict._multnet(object, new_data = new_data, type = "raw",
+                             opts = dots, penalty = penalty, multi = TRUE)
 
     format_probs <- function(x) {
       x <- as_tibble(x)


### PR DESCRIPTION
closes #858 

This PR moves where we set `s`, glmnet's argument for the penalty value, from inside the relevant `multi_predict()` method into the relevant `predict_raw()` method. 

This means that now the default penalty value specified in the parsnip spec will be used when `penalty = NULL`, also for for `type = "raw"` (aka the original issue).

This also means that the call stack for `multi_predict()` for logistic and multinomial regression now follows that of linear regression and what happens in the code is what was laid out in the comments, e.g.,

https://github.com/tidymodels/parsnip/blob/2249cbb6fb2c3b2038ed8c660ff67bf2f9e06be7/R/logistic_reg.R#L209-L234

The tests are in extratests: https://github.com/tidymodels/extratests/pull/72

``` r
library(parsnip)

data(lending_club, package = "modeldata")

lr_spec <- logistic_reg(penalty = 0.123) %>% set_engine("glmnet")
f_fit <- fit(lr_spec, Class ~ log(funded_amnt) + int_rate + term,
             data = lending_club)
predict(f_fit, lending_club[1:5, ], type = "raw")
#>         s1
#> 1 2.894019
#> 2 2.894019
#> 3 2.894019
#> 4 2.894019
#> 5 2.894019

data("penguins", package = "modeldata")
penguins <- tidyr::drop_na(penguins)

mr_spec <- multinom_reg(penalty = 0.123) %>% set_engine("glmnet")
f_fit <- fit(mr_spec, species ~ island + bill_length_mm + bill_depth_mm,
             data = penguins)

predict(f_fit, penguins[1:5,], type = "raw")
#> , , 1
#> 
#>      Adelie Chinstrap    Gentoo
#> 1 -5.131312 -7.544642 -7.542310
#> 2 -5.229012 -7.544642 -6.800678
#> 3 -5.424412 -7.544642 -7.142970
#> 4 -4.545112 -7.544642 -7.884602
#> 5 -5.180162 -7.544642 -8.626234
```

<sup>Created on 2023-01-25 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>