### PR TITLE
Switch column order of `multi_predict()` result for `multinom_reg(engine = "glmnet")`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: parsnip
 Title: A Common API to Modeling and Analysis Functions
-Version: 1.0.3.9000
+Version: 1.0.3.9002
 Authors@R: c(
     person("Max", "Kuhn", , "max@rstudio.com", role = c("aut", "cre")),
     person("Davis", "Vaughan", , "davis@rstudio.com", role = "aut"),

--- a/R/multinom_reg.R
+++ b/R/multinom_reg.R
@@ -236,12 +236,13 @@ multi_predict._multnet <-
       names(pred) <- NULL
       pred <- map_dfr(pred, function(x) x)
       pred$penalty <- rep(penalty, each = nrow(new_data))
+      pred <- dplyr::relocate(pred, penalty)
     } else {
       pred <-
         tibble(
           .row = rep(1:nrow(new_data), length(penalty)),
-          .pred_class = factor(as.vector(pred), levels = object$lvl),
-          penalty = rep(penalty, each = nrow(new_data))
+          penalty = rep(penalty, each = nrow(new_data)),
+          .pred_class = factor(as.vector(pred), levels = object$lvl)
         )
     }
 


### PR DESCRIPTION
Closes #859 

The corresponding test in extratest is update here:

This PR is to be merged before the one on extratests.

``` r
library(parsnip)
data("hpc_data", package = "modeldata", envir = rlang::current_env())

mr_spec <- multinom_reg(penalty = 0.1) %>% set_engine("glmnet")
f_fit <- fit(mr_spec, class ~ protocol + log(compounds) + input_fields,
             data = hpc_data)
f_pred_class <- multi_predict(f_fit, hpc_data, penalty = c(0.01, 0.1), 
                              type = "class")
f_pred_class$.pred[[1]]
#> # A tibble: 2 × 2
#>   penalty .pred_class
#>     <dbl> <fct>      
#> 1    0.01 VF         
#> 2    0.1  VF

f_pred_prob <- multi_predict(f_fit, hpc_data, penalty = c(0.01, 0.1), 
                             type = "prob")
f_pred_prob$.pred[[1]]
#> # A tibble: 2 × 5
#>   penalty .pred_VF .pred_F .pred_M .pred_L
#>     <dbl>    <dbl>   <dbl>   <dbl>   <dbl>
#> 1    0.01    0.464   0.287   0.174  0.0758
#> 2    0.1     0.488   0.325   0.124  0.0625
```

<sup>Created on 2023-01-26 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>