### PR TITLE
Consolidate glmnet predict methods

### DIFF
--- a/R/glmnet.R
+++ b/R/glmnet.R
@@ -1,0 +1,146 @@
+# glmnet call stack using `predict()` when object has
+# classes "_<glmnet-class>" and "model_fit":
+#
+#  predict()
+# 	predict._<glmnet-class>(penalty = NULL)    <-- checks and sets penalty
+#    predict.model_fit()                       <-- checks for extra vars in ...
+#     predict_numeric()
+#      predict_numeric._<glmnet-class>()
+#       predict_numeric.model_fit()
+#        predict.<glmnet-class>()
+
+
+# glmnet call stack using `multi_predict` when object has
+# classes "_<glmnet-class>" and "model_fit":
+#
+# 	multi_predict()
+#    multi_predict._<glmnet-class>(penalty = NULL)
+#      predict._<glmnet-class>(multi = TRUE)   <-- checks and sets penalty
+#       predict.model_fit()                    <-- checks for extra vars in ...
+#        predict_raw()
+#         predict_raw._<glmnet-class>()
+#          predict_raw.model_fit(opts = list(s = penalty))
+#           predict.<glmnet-class>()
+
+
+predict_glmnet <- function(object,
+                           new_data,
+                           type = NULL,
+                           opts = list(),
+                           penalty = NULL,
+                           multi = FALSE,
+                           ...) {
+
+  if (any(names(enquos(...)) == "newdata")) {
+    rlang::abort("Did you mean to use `new_data` instead of `newdata`?")
+  }
+
+  # See discussion in https://github.com/tidymodels/parsnip/issues/195
+  if (is.null(penalty) & !is.null(object$spec$args$penalty)) {
+    penalty <- object$spec$args$penalty
+  }
+
+  object$spec$args$penalty <- .check_glmnet_penalty_predict(penalty, object, multi)
+
+  object$spec <- eval_args(object$spec)
+  predict.model_fit(object, new_data = new_data, type = type, opts = opts, ...)
+}
+
+predict_numeric_glmnet <- function(object, new_data, ...) {
+  if (any(names(enquos(...)) == "newdata"))
+    rlang::abort("Did you mean to use `new_data` instead of `newdata`?")
+
+  object$spec <- eval_args(object$spec)
+  predict_numeric.model_fit(object, new_data = new_data, ...)
+}
+
+predict_class_glmnet <- function(object, new_data, ...) {
+  if (any(names(enquos(...)) == "newdata"))
+    rlang::abort("Did you mean to use `new_data` instead of `newdata`?")
+
+  object$spec <- eval_args(object$spec)
+  predict_class.model_fit(object, new_data = new_data, ...)
+}
+
+predict_classprob_glmnet <- function(object, new_data, ...) {
+  if (any(names(enquos(...)) == "newdata"))
+    rlang::abort("Did you mean to use `new_data` instead of `newdata`?")
+
+  object$spec <- eval_args(object$spec)
+  predict_classprob.model_fit(object, new_data = new_data, ...)
+}
+
+predict_raw_glmnet <- function(object, new_data, opts = list(), ...)  {
+  if (any(names(enquos(...)) == "newdata"))
+    rlang::abort("Did you mean to use `new_data` instead of `newdata`?")
+
+  object$spec <- eval_args(object$spec)
+
+  opts$s <- object$spec$args$penalty
+
+  predict_raw.model_fit(object, new_data = new_data, opts = opts, ...)
+}
+
+
+
+
+multi_predict_glmnet <- function(object,
+                                 new_data,
+                                 type = NULL,
+                                 penalty = NULL,
+                                 ...) {
+
+  if (any(names(enquos(...)) == "newdata")) {
+    rlang::abort("Did you mean to use `new_data` instead of `newdata`?")
+  }
+
+  if (object$spec$mode == "classification") {
+    if (is_quosure(penalty)) {
+      penalty <- eval_tidy(penalty)
+    }
+  }
+
+  dots <- list(...)
+
+  object$spec <- eval_args(object$spec)
+
+  if (is.null(penalty)) {
+    # See discussion in https://github.com/tidymodels/parsnip/issues/195
+    if (!is.null(object$spec$args$penalty)) {
+      penalty <- object$spec$args$penalty
+    } else {
+      penalty <- object$fit$lambda
+    }
+  }
+
+  if (object$spec$mode == "classification") {
+    if (is.null(type))
+      type <- "class"
+    if (!(type %in% c("class", "prob", "link", "raw"))) {
+      rlang::abort("`type` should be either 'class', 'link', 'raw', or 'prob'.")
+    }
+    if (type == "prob")
+      dots$type <- "response"
+    else
+      dots$type <- type
+  }
+
+  pred <- predict(object, new_data = new_data, type = "raw",
+                  opts = dots, penalty = penalty, multi = TRUE)
+
+  model_type <- class(object$spec)[1]
+  res <- switch(model_type,
+    "linear_reg" = format_glmnet_multi_linear_reg(pred, penalty = penalty),
+    "logistic_reg" = format_glmnet_multi_logistic_reg(pred,
+                                                      penalty = penalty,
+                                                      type = dots$type,
+                                                      lvl = object$lvl),
+    "multinom_reg" = format_glmnet_multi_multinom_reg(pred,
+                                                      penalty = penalty,
+                                                      type = type,
+                                                      n_rows = nrow(new_data),
+                                                      lvl = object$lvl)
+  )
+
+  res
+}

--- a/R/glmnet.R
+++ b/R/glmnet.R
@@ -114,15 +114,17 @@ multi_predict_glmnet <- function(object,
   }
 
   if (object$spec$mode == "classification") {
-    if (is.null(type))
+    if (is.null(type)) {
       type <- "class"
+    }
     if (!(type %in% c("class", "prob", "link", "raw"))) {
       rlang::abort("`type` should be either 'class', 'link', 'raw', or 'prob'.")
     }
-    if (type == "prob")
+    if (type == "prob") {
       dots$type <- "response"
-    else
+    } else {
       dots$type <- type
+    }
   }
 
   pred <- predict(object, new_data = new_data, type = "raw",

--- a/R/glmnet.R
+++ b/R/glmnet.R
@@ -2,23 +2,27 @@
 # classes "_<glmnet-class>" and "model_fit":
 #
 #  predict()
-# 	predict._<glmnet-class>(penalty = NULL)    <-- checks and sets penalty
-#    predict.model_fit()                       <-- checks for extra vars in ...
-#     predict_numeric()
-#      predict_numeric._<glmnet-class>()
-#       predict_numeric.model_fit()
-#        predict.<glmnet-class>()
+#   predict._<glmnet-class>(penalty = NULL)
+#    predict_glmnet(penalty = NULL)             <-- checks and sets penalty
+#     predict.model_fit()                       <-- checks for extra vars in ...
+#      predict_numeric()
+#       predict_numeric._<glmnet-class>()
+#        predict_numeric_glmnet()
+#         predict_numeric.model_fit()
+#          predict.<glmnet-class>()
 
 
 # glmnet call stack using `multi_predict` when object has
 # classes "_<glmnet-class>" and "model_fit":
 #
-# 	multi_predict()
-#    multi_predict._<glmnet-class>(penalty = NULL)
-#      predict._<glmnet-class>(multi = TRUE)   <-- checks and sets penalty
-#       predict.model_fit()                    <-- checks for extra vars in ...
-#        predict_raw()
-#         predict_raw._<glmnet-class>()
+#  multi_predict()
+#   multi_predict._<glmnet-class>(penalty = NULL)
+#    predict._<glmnet-class>(multi = TRUE)
+#     predict_glmnet(multi = TRUE)            <-- checks and sets penalty
+#      predict.model_fit()                    <-- checks for extra vars in ...
+#       predict_raw()
+#        predict_raw._<glmnet-class>()
+#         predict_raw_glmnet()
 #          predict_raw.model_fit(opts = list(s = penalty))
 #           predict.<glmnet-class>()
 
@@ -47,32 +51,36 @@ predict_glmnet <- function(object,
 }
 
 predict_numeric_glmnet <- function(object, new_data, ...) {
-  if (any(names(enquos(...)) == "newdata"))
+  if (any(names(enquos(...)) == "newdata")) {
     rlang::abort("Did you mean to use `new_data` instead of `newdata`?")
+  }
 
   object$spec <- eval_args(object$spec)
   predict_numeric.model_fit(object, new_data = new_data, ...)
 }
 
 predict_class_glmnet <- function(object, new_data, ...) {
-  if (any(names(enquos(...)) == "newdata"))
+  if (any(names(enquos(...)) == "newdata")) {
     rlang::abort("Did you mean to use `new_data` instead of `newdata`?")
+  }
 
   object$spec <- eval_args(object$spec)
   predict_class.model_fit(object, new_data = new_data, ...)
 }
 
 predict_classprob_glmnet <- function(object, new_data, ...) {
-  if (any(names(enquos(...)) == "newdata"))
+  if (any(names(enquos(...)) == "newdata")) {
     rlang::abort("Did you mean to use `new_data` instead of `newdata`?")
+  }
 
   object$spec <- eval_args(object$spec)
   predict_classprob.model_fit(object, new_data = new_data, ...)
 }
 
 predict_raw_glmnet <- function(object, new_data, opts = list(), ...)  {
-  if (any(names(enquos(...)) == "newdata"))
+  if (any(names(enquos(...)) == "newdata")) {
     rlang::abort("Did you mean to use `new_data` instead of `newdata`?")
+  }
 
   object$spec <- eval_args(object$spec)
 
@@ -80,9 +88,6 @@ predict_raw_glmnet <- function(object, new_data, opts = list(), ...)  {
 
   predict_raw.model_fit(object, new_data = new_data, opts = opts, ...)
 }
-
-
-
 
 multi_predict_glmnet <- function(object,
                                  new_data,
@@ -131,7 +136,8 @@ multi_predict_glmnet <- function(object,
                   opts = dots, penalty = penalty, multi = TRUE)
 
   model_type <- class(object$spec)[1]
-  res <- switch(model_type,
+  res <- switch(
+    model_type,
     "linear_reg" = format_glmnet_multi_linear_reg(pred, penalty = penalty),
     "logistic_reg" = format_glmnet_multi_logistic_reg(pred,
                                                       penalty = penalty,

--- a/R/linear_reg.R
+++ b/R/linear_reg.R
@@ -156,94 +156,19 @@ check_args.linear_reg <- function(object) {
   res
 }
 
-# ------------------------------------------------------------------------------
-# glmnet call stack for linear regression using `predict` when object has
-# classes "_elnet" and "model_fit":
-#
-#  predict()
-# 	predict._elnet(penalty = NULL)   <-- checks and sets penalty
-#    predict.model_fit()             <-- checks for extra vars in ...
-#     predict_numeric()
-#      predict_numeric._elnet()
-#       predict_numeric.model_fit()
-#        predict.elnet()
-
-
-# glmnet call stack for linear regression using `multi_predict` when object has
-# classes "_elnet" and "model_fit":
-#
-# 	multi_predict()
-#    multi_predict._elnet(penalty = NULL)
-#      predict._elnet(multi = TRUE)          <-- checks and sets penalty
-#       predict.model_fit()                  <-- checks for extra vars in ...
-#        predict_raw()
-#         predict_raw._elnet()
-#          predict_raw.model_fit(opts = list(s = penalty))
-#           predict.elnet()
-
+#' @export
+predict._elnet <- predict_glmnet
 
 #' @export
-predict._elnet <-
-  function(object, new_data, type = NULL, opts = list(), penalty = NULL, multi = FALSE, ...) {
-    if (any(names(enquos(...)) == "newdata"))
-      rlang::abort("Did you mean to use `new_data` instead of `newdata`?")
-
-    # See discussion in https://github.com/tidymodels/parsnip/issues/195
-    if (is.null(penalty) & !is.null(object$spec$args$penalty)) {
-      penalty <- object$spec$args$penalty
-    }
-
-    object$spec$args$penalty <- .check_glmnet_penalty_predict(penalty, object, multi)
-
-    object$spec <- eval_args(object$spec)
-    predict.model_fit(object, new_data = new_data, type = type, opts = opts, ...)
-  }
+predict_numeric._elnet <- predict_numeric_glmnet
 
 #' @export
-predict_numeric._elnet <- function(object, new_data, ...) {
-  if (any(names(enquos(...)) == "newdata"))
-    rlang::abort("Did you mean to use `new_data` instead of `newdata`?")
-
-  object$spec <- eval_args(object$spec)
-  predict_numeric.model_fit(object, new_data = new_data, ...)
-}
-
-#' @export
-predict_raw._elnet <- function(object, new_data, opts = list(), ...)  {
-  if (any(names(enquos(...)) == "newdata"))
-    rlang::abort("Did you mean to use `new_data` instead of `newdata`?")
-
-  object$spec <- eval_args(object$spec)
-  opts$s <- object$spec$args$penalty
-  predict_raw.model_fit(object, new_data = new_data, opts = opts, ...)
-}
+predict_raw._elnet <- predict_raw_glmnet
 
 #' @export
 #'@rdname multi_predict
 #' @param penalty A numeric vector of penalty values.
-multi_predict._elnet <-
-  function(object, new_data, type = NULL, penalty = NULL, ...) {
-    if (any(names(enquos(...)) == "newdata"))
-      rlang::abort("Did you mean to use `new_data` instead of `newdata`?")
-
-    dots <- list(...)
-
-    object$spec <- eval_args(object$spec)
-
-    if (is.null(penalty)) {
-      # See discussion in https://github.com/tidymodels/parsnip/issues/195
-      if (!is.null(object$spec$args$penalty)) {
-        penalty <- object$spec$args$penalty
-      } else {
-        penalty <- object$fit$lambda
-      }
-    }
-
-    pred <- predict._elnet(object, new_data = new_data, type = "raw",
-                           opts = dots, penalty = penalty, multi = TRUE)
-
-    format_glmnet_multi_linear_reg(pred, penalty = penalty)
-  }
+multi_predict._elnet <- multi_predict_glmnet
 
 format_glmnet_multi_linear_reg <- function(pred, penalty) {
   param_key <- tibble(group = colnames(pred), penalty = penalty)

--- a/R/multinom_reg.R
+++ b/R/multinom_reg.R
@@ -143,114 +143,22 @@ organize_nnet_prob <- function(x, object) {
 
 
 # ------------------------------------------------------------------------------
-# glmnet call stack for multinomial regression using `predict` when object has
-# classes "_multnet" and "model_fit" (for class predictions):
-#
-#  predict()
-# 	predict._multnet(penalty = NULL)   <-- checks and sets penalty
-#    predict.model_fit()               <-- checks for extra vars in ...
-#     predict_class()
-#      predict_class._multnet()
-#       predict.multnet()
-
-
-# glmnet call stack for multinomial regression using `multi_predict` when object has
-# classes "_multnet" and "model_fit" (for class predictions):
-#
-# 	multi_predict()
-#    multi_predict._multnet(penalty = NULL)
-#      predict._multnet(multi = TRUE)          <-- checks and sets penalty
-#       predict.model_fit()                    <-- checks for extra vars in ...
-#        predict_raw()
-#         predict_raw._multnet()
-#          predict_raw.model_fit(opts = list(s = penalty))
-#           predict.multnet()
-
-# ------------------------------------------------------------------------------
 
 #' @export
-predict._multnet <-
-  function(object, new_data, type = NULL, opts = list(), penalty = NULL, multi = FALSE, ...) {
-
-    # See discussion in https://github.com/tidymodels/parsnip/issues/195
-    if (is.null(penalty) & !is.null(object$spec$args$penalty)) {
-      penalty <- object$spec$args$penalty
-    }
-
-    object$spec$args$penalty <- .check_glmnet_penalty_predict(penalty, object, multi)
-
-    object$spec <- eval_args(object$spec)
-    res <- predict.model_fit(
-      object = object,
-      new_data = new_data,
-      type = type,
-      opts = opts
-    )
-    res
-  }
+predict._multnet <- predict_glmnet
 
 #' @export
 #' @rdname multi_predict
-multi_predict._multnet <-
-  function(object, new_data, type = NULL, penalty = NULL, ...) {
-    if (any(names(enquos(...)) == "newdata"))
-      rlang::abort("Did you mean to use `new_data` instead of `newdata`?")
-
-    if (is_quosure(penalty))
-      penalty <- eval_tidy(penalty)
-
-    dots <- list(...)
-
-    if (is.null(penalty)) {
-      # See discussion in https://github.com/tidymodels/parsnip/issues/195
-      if (!is.null(object$spec$args$penalty)) {
-        penalty <- object$spec$args$penalty
-      } else {
-        penalty <- object$fit$lambda
-      }
-    }
-
-    if (is.null(type))
-      type <- "class"
-    if (!(type %in% c("class", "prob", "link", "raw"))) {
-      rlang::abort("`type` should be either 'class', 'link', 'raw', or 'prob'.")
-    }
-    if (type == "prob")
-      dots$type <- "response"
-    else
-      dots$type <- type
-
-    object$spec <- eval_args(object$spec)
-    pred <- predict._multnet(object, new_data = new_data, type = "raw",
-                             opts = dots, penalty = penalty, multi = TRUE)
-
-    format_glmnet_multi_multinom_reg(
-      pred,
-      penalty = penalty,
-      type = type,
-      n_rows = nrow(new_data),
-      lvl = object$lvl
-    )
-  }
+multi_predict._multnet <- multi_predict_glmnet
 
 #' @export
-predict_class._multnet <- function(object, new_data, ...) {
-  object$spec <- eval_args(object$spec)
-  predict_class.model_fit(object, new_data = new_data, ...)
-}
+predict_class._multnet <- predict_class_glmnet
 
 #' @export
-predict_classprob._multnet <- function(object, new_data, ...) {
-  object$spec <- eval_args(object$spec)
-  predict_classprob.model_fit(object, new_data = new_data, ...)
-}
+predict_classprob._multnet <- predict_classprob_glmnet
 
 #' @export
-predict_raw._multnet <- function(object, new_data, opts = list(), ...) {
-  object$spec <- eval_args(object$spec)
-  opts$s <- object$spec$args$penalty
-  predict_raw.model_fit(object, new_data = new_data, opts = opts, ...)
-}
+predict_raw._multnet <- predict_raw_glmnet
 
 format_glmnet_multi_multinom_reg <- function(pred, penalty, type, n_rows, lvl) {
   format_probs <- function(x) {


### PR DESCRIPTION
This PR consolidates the different flavors of predict methods (`predict()`, `predict_<type>()` and `multi_predict()`) for different glmnet model types into one function per predict method flavor. 

The goal is to bring it all in one place to more easily maintain/apply changes. I'm currently not touching the class of the glmnet `model_fit` objects (yet?).

The glmnet tests in extratests run fine locally with this change. They'll run on CI when this in `main`.