### PR TITLE
remove check on newdata typo in glmnet functions

### DIFF
--- a/R/aaa_models.R
+++ b/R/aaa_models.R
@@ -423,6 +423,7 @@ spec_has_pred_type <- function(object, type) {
   possible_preds <- names(object$spec$method$pred)
   any(possible_preds == type)
 }
+
 check_spec_pred_type <- function(object, type) {
   if (!spec_has_pred_type(object, type)) {
     possible_preds <- names(object$spec$method$pred)
@@ -435,14 +436,12 @@ check_spec_pred_type <- function(object, type) {
   invisible(NULL)
 }
 
-
 check_pkg_val <- function(pkg) {
   if (rlang::is_missing(pkg) || length(pkg) != 1 || !is.character(pkg)) {
     rlang::abort("Please supply a single character value for the package name.")
   }
   invisible(NULL)
 }
-
 
 check_interface_val <- function(x) {
   exp_interf <- c("data.frame", "formula", "matrix")

--- a/R/glmnet.R
+++ b/R/glmnet.R
@@ -34,11 +34,6 @@ predict_glmnet <- function(object,
                            penalty = NULL,
                            multi = FALSE,
                            ...) {
-
-  if (any(names(enquos(...)) == "newdata")) {
-    rlang::abort("Did you mean to use `new_data` instead of `newdata`?")
-  }
-
   # See discussion in https://github.com/tidymodels/parsnip/issues/195
   if (is.null(penalty) & !is.null(object$spec$args$penalty)) {
     penalty <- object$spec$args$penalty
@@ -51,37 +46,21 @@ predict_glmnet <- function(object,
 }
 
 predict_numeric_glmnet <- function(object, new_data, ...) {
-  if (any(names(enquos(...)) == "newdata")) {
-    rlang::abort("Did you mean to use `new_data` instead of `newdata`?")
-  }
-
   object$spec <- eval_args(object$spec)
   predict_numeric.model_fit(object, new_data = new_data, ...)
 }
 
 predict_class_glmnet <- function(object, new_data, ...) {
-  if (any(names(enquos(...)) == "newdata")) {
-    rlang::abort("Did you mean to use `new_data` instead of `newdata`?")
-  }
-
   object$spec <- eval_args(object$spec)
   predict_class.model_fit(object, new_data = new_data, ...)
 }
 
 predict_classprob_glmnet <- function(object, new_data, ...) {
-  if (any(names(enquos(...)) == "newdata")) {
-    rlang::abort("Did you mean to use `new_data` instead of `newdata`?")
-  }
-
   object$spec <- eval_args(object$spec)
   predict_classprob.model_fit(object, new_data = new_data, ...)
 }
 
 predict_raw_glmnet <- function(object, new_data, opts = list(), ...)  {
-  if (any(names(enquos(...)) == "newdata")) {
-    rlang::abort("Did you mean to use `new_data` instead of `newdata`?")
-  }
-
   object$spec <- eval_args(object$spec)
 
   opts$s <- object$spec$args$penalty


### PR DESCRIPTION
closes  #877 

`predict_glmnet()` calls `predict.model_fit()` which checks this via `check_pred_type_dots()` so we don't need it in `predict_glmnet()`.

The `predict_<type>()` methods don't run this check. I think generally users are supposed to use `predict(type = <type>)` rather than `predict_<type>()` but the `predict_<type>()` functions are exported. If we think this check is important to have also when directly calling `predict_<type>()`, I'd suggest we add it to the method for `model_fit` objects but since it's not glmnet-specific, I have removed it here. 

`multi_predict()` does not have a central `model_fit` method (because it doesn't apply to all models) so I have left the check in the glmnet-specific method.

The tests for glmnet engines live in extratests, those checks pass locally and will be run on CI once this is merged.
