### PR TITLE
Fix test on translating `path_values` to `lambda` for glmnet

### DIFF
--- a/tests/testthat/_snaps/translate.md
+++ b/tests/testthat/_snaps/translate.md
@@ -512,17 +512,6 @@
 ---
 
     Code
-      translate_args(basic %>% set_engine("glmnet", path_values = 4:2))
-    Condition
-      Error in `.check_glmnet_penalty_fit()`:
-      ! For the glmnet engine, `penalty` must be a single number (or a value of `tune()`).
-      * There are 0 values for `penalty`.
-      * To try multiple values for total regularization, use the tune package.
-      * To predict multiple penalties, use `multi_predict()`
-
----
-
-    Code
       translate_args(mixture %>% set_engine("spark"))
     Output
       $x
@@ -606,6 +595,29 @@
       $nlambda
       <quosure>
       expr: ^10
+      env:  empty
+      
+      $family
+      [1] "gaussian"
+      
+
+---
+
+    Code
+      translate_args(penalty %>% set_engine("glmnet", path_values = 4:2))
+    Output
+      $x
+      missing_arg()
+      
+      $y
+      missing_arg()
+      
+      $weights
+      missing_arg()
+      
+      $lambda
+      <quosure>
+      expr: ^4:2
       env:  empty
       
       $family

--- a/tests/testthat/test_translate.R
+++ b/tests/testthat/test_translate.R
@@ -84,7 +84,6 @@ test_that("arguments (linear_reg)", {
   expect_snapshot(translate_args(basic %>% set_engine("spark")))
   expect_snapshot(translate_args(basic %>% set_engine("spark", max_iter = 20)))
   expect_snapshot(translate_args(basic %>% set_engine("glmnet")), error = TRUE)
-  expect_snapshot(translate_args(basic %>% set_engine("glmnet", path_values = 4:2)), error = TRUE)
 
   expect_snapshot(translate_args(mixture %>% set_engine("spark")))
   expect_snapshot(translate_args(mixture_v %>% set_engine("spark")))
@@ -92,6 +91,7 @@ test_that("arguments (linear_reg)", {
 
   expect_snapshot(translate_args(penalty %>% set_engine("glmnet")))
   expect_snapshot(translate_args(penalty %>% set_engine("glmnet", nlambda = 10)))
+  expect_snapshot(translate_args(penalty %>% set_engine("glmnet", path_values = 4:2)))
   expect_snapshot(translate_args(penalty %>% set_engine("spark")))
 })
 


### PR DESCRIPTION
The snapshot previously just captured the error message about the missing penalty value, now it shows that `path_values` gets translated to `lambda` as it should.