### PR TITLE
make `will_make_matrix()` behave consistently for 0-length factors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # parsnip (development version)
 
+* Made `fit()` behave consistently with respect to missingness in the classification setting. Previously, `fit()` erroneously raised an error about the class of the outcome when there were no complete cases, and now always passes along complete cases to be handled by the modeling function.
+
 # parsnip 1.0.4
 
 * For censored regression models, a "reverse Kaplan-Meier" curve is computed for the censoring distribution. This can be used when evaluating this type of model (#855).

--- a/R/convert_data.R
+++ b/R/convert_data.R
@@ -324,7 +324,7 @@ make_formula <- function(x, y, short = TRUE) {
 
 
 will_make_matrix <- function(y) {
-  if (is.matrix(y) | is.vector(y))
+  if (is.matrix(y) | is.vector(y) | (is.factor(y) & length(y) == 0))
     return(FALSE)
   cls <- unique(unlist(lapply(y, class)))
   if (length(cls) > 1)

--- a/R/convert_data.R
+++ b/R/convert_data.R
@@ -324,7 +324,7 @@ make_formula <- function(x, y, short = TRUE) {
 
 
 will_make_matrix <- function(y) {
-  if (is.matrix(y) | is.vector(y) | (is.factor(y) & length(y) == 0))
+  if (is.matrix(y) | is.vector(y) | is.factor(y))
     return(FALSE)
   cls <- unique(unlist(lapply(y, class)))
   if (length(cls) > 1)

--- a/tests/testthat/test_convert_data.R
+++ b/tests/testthat/test_convert_data.R
@@ -346,6 +346,14 @@ test_that("numeric x and factor y", {
     .convert_form_to_xy_new(observed, new_data = head(hpc))$x
   )
 
+  expect_no_error(
+    observed2 <- .convert_form_to_xy_fit(class ~ ., data = hpc %>% mutate(x = NA))
+  )
+  expect_equal(hpc$class[logical()], observed2$y)
+  expect_s3_class(observed2$terms, "terms")
+  expect_equal(expected$xlevels, observed2$xlevels)
+  expect_null(observed2$weights)
+  expect_null(observed2$offset)
 })
 
 test_that("bad args", {


### PR DESCRIPTION
Closes #883, more context there!🪲

With CRAN version:

``` r
parsnip:::will_make_matrix(factor("a"))
#> [1] FALSE
parsnip:::will_make_matrix(factor(character()))
#> [1] TRUE
```

With this PR:

``` r
parsnip:::will_make_matrix(factor("a"))
#> [1] FALSE
parsnip:::will_make_matrix(factor(character()))
#> [1] FALSE
```

<sup>Created on 2023-02-23 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
