### PR TITLE
add `set_glmnet_penalty_path()`

### DIFF
--- a/R/glmnet.R
+++ b/R/glmnet.R
@@ -131,3 +131,23 @@ multi_predict_glmnet <- function(object,
 
   res
 }
+
+
+# -------------------------------------------------------------------------
+
+
+set_glmnet_penalty_path <- function(x) {
+  if (any(names(x$eng_args) == "path_values")) {
+    # Since we decouple the parsnip `penalty` argument from being the same
+    # as the glmnet `lambda` value, `path_values` allows users to set the
+    # path differently from the default that glmnet uses. See
+    # https://github.com/tidymodels/parsnip/issues/431
+    x$method$fit$args$lambda <- x$eng_args$path_values
+    x$eng_args$path_values <- NULL
+    x$method$fit$args$path_values <- NULL
+  } else {
+    # See discussion in https://github.com/tidymodels/parsnip/issues/195
+    x$method$fit$args$lambda <- NULL
+  }
+  x
+}

--- a/R/linear_reg.R
+++ b/R/linear_reg.R
@@ -67,18 +67,7 @@ translate.linear_reg <- function(x, engine = x$engine, ...) {
   if (engine == "glmnet") {
     # See https://parsnip.tidymodels.org/reference/glmnet-details.html
     .check_glmnet_penalty_fit(x)
-    if (any(names(x$eng_args) == "path_values")) {
-      # Since we decouple the parsnip `penalty` argument from being the same
-      # as the glmnet `lambda` value, `path_values` allows users to set the
-      # path differently from the default that glmnet uses. See
-      # https://github.com/tidymodels/parsnip/issues/431
-      x$method$fit$args$lambda <- x$eng_args$path_values
-      x$eng_args$path_values <- NULL
-      x$method$fit$args$path_values <- NULL
-    } else {
-      # See discussion in https://github.com/tidymodels/parsnip/issues/195
-      x$method$fit$args$lambda <- NULL
-    }
+    x <- set_glmnet_penalty_path(x)
     # Since the `fit` information is gone for the penalty, we need to have an
     # evaluated value for the parameter.
     x$args$penalty <- rlang::eval_tidy(x$args$penalty)

--- a/R/logistic_reg.R
+++ b/R/logistic_reg.R
@@ -78,18 +78,7 @@ translate.logistic_reg <- function(x, engine = x$engine, ...) {
   if (engine == "glmnet") {
     # See https://parsnip.tidymodels.org/reference/glmnet-details.html
     .check_glmnet_penalty_fit(x)
-    if (any(names(x$eng_args) == "path_values")) {
-      # Since we decouple the parsnip `penalty` argument from being the same
-      # as the glmnet `lambda` value, `path_values` allows users to set the
-      # path differently from the default that glmnet uses. See
-      # https://github.com/tidymodels/parsnip/issues/431
-      x$method$fit$args$lambda <- x$eng_args$path_values
-      x$eng_args$path_values <- NULL
-      x$method$fit$args$path_values <- NULL
-    } else {
-      # See discussion in https://github.com/tidymodels/parsnip/issues/195
-      x$method$fit$args$lambda <- NULL
-    }
+    x <- set_glmnet_penalty_path(x)
     # Since the `fit` information is gone for the penalty, we need to have an
     # evaluated value for the parameter.
     x$args$penalty <- rlang::eval_tidy(x$args$penalty)

--- a/R/poisson_reg.R
+++ b/R/poisson_reg.R
@@ -88,18 +88,7 @@ translate.poisson_reg <- function(x, engine = x$engine, ...) {
   if (engine == "glmnet") {
     # See https://parsnip.tidymodels.org/reference/glmnet-details.html
     .check_glmnet_penalty_fit(x)
-    if (any(names(x$eng_args) == "path_values")) {
-      # Since we decouple the parsnip `penalty` argument from being the same
-      # as the glmnet `lambda` value, `path_values` allows users to set the
-      # path differently from the default that glmnet uses. See
-      # https://github.com/tidymodels/parsnip/issues/431
-      x$method$fit$args$lambda <- x$eng_args$path_values
-      x$eng_args$path_values <- NULL
-      x$method$fit$args$path_values <- NULL
-    } else {
-      # See discussion in https://github.com/tidymodels/parsnip/issues/195
-      x$method$fit$args$lambda <- NULL
-    }
+    x <- set_glmnet_penalty_path(x)
     # Since the `fit` information is gone for the penalty, we need to have an
     # evaluated value for the parameter.
     x$args$penalty <- rlang::eval_tidy(x$args$penalty)

--- a/R/proportional_hazards.R
+++ b/R/proportional_hazards.R
@@ -88,18 +88,7 @@ translate.proportional_hazards <- function(x, engine = x$engine, ...) {
   if (engine == "glmnet") {
     # See https://parsnip.tidymodels.org/reference/glmnet-details.html
     .check_glmnet_penalty_fit(x)
-    if (any(names(x$eng_args) == "path_values")) {
-      # Since we decouple the parsnip `penalty` argument from being the same
-      # as the glmnet `lambda` value, `path_values` allows users to set the
-      # path differently from the default that glmnet uses. See
-      # https://github.com/tidymodels/parsnip/issues/431
-      x$method$fit$args$lambda <- x$eng_args$path_values
-      x$eng_args$path_values <- NULL
-      x$method$fit$args$path_values <- NULL
-    } else {
-      # See discussion in https://github.com/tidymodels/parsnip/issues/195
-      x$method$fit$args$lambda <- NULL
-    }
+    x <- set_glmnet_penalty_path(x)
     # Since the `fit` information is gone for the penalty, we need to have an
     # evaluated value for the parameter.
     x$args$penalty <- rlang::eval_tidy(x$args$penalty)


### PR DESCRIPTION
closes #891

This PR is to reduce code duplication. I've picked `set_glmnet_penalty_path()` sorta in keeping with `.check_glmnet_penalty*()` (sans the dot, since we don't export it). I think it's a decent name but I'm happy to consider other suggestions, too!