### PR TITLE
reuse results of long-running checks

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -52,6 +52,7 @@ Suggests:
     MASS,
     Matrix,
     mgcv,
+    mockr,
     modeldata,
     nlme,
     prodlim,

--- a/tests/testthat/test-intermediate.R
+++ b/tests/testthat/test-intermediate.R
@@ -1,0 +1,27 @@
+test_that("multiplication works", {
+
+  tune_env <- rlang::new_environment()
+  rlang::env_bind(tune_env, progress_env = rlang::new_environment())
+
+  mockr::local_mock(
+    get_tune_env = function() {tune_env},
+    can_have_intermediate_result = function() {TRUE}
+  )
+
+  expect_false(has_intermediate_result("boopety_bop"))
+  expect_null(set_intermediate_result("boopety_bop", 1L))
+  expect_true(has_intermediate_result("boopety_bop"))
+  expect_equal(get_intermediate_result("boopety_bop"), 1L)
+  expect_equal(tune_env$progress_env$intermediate_results$boopety_bop[[1]], 1L)
+
+  # can handle `NULL` results
+  expect_false(has_intermediate_result("beepety_boop"))
+  expect_null(set_intermediate_result("beepety_boop", NULL))
+  expect_true(has_intermediate_result("beepety_boop"))
+  expect_null(get_intermediate_result("beepety_boop"))
+  expect_null(tune_env$progress_env$intermediate_results$beepety_boop[[1]])
+
+  # previous intermediate result wasn't reset:
+  expect_true(has_intermediate_result("boopety_bop"))
+  expect_equal(get_intermediate_result("boopety_bop"), 1L)
+})


### PR DESCRIPTION
``` r
library(tidymodels)
```

Within the call:

``` r
res <- fit_resamples(linear_reg(), mpg ~ ., bootstraps(mtcars, 3))
```

The internal `check_spec_mode_engine_val()` helper is called 6 times, twice per resample. It’s always passed the same arguments, and as such will always give the same answer across resamples. Because of an inner join and some manipulation of environments, calls to this check end up accounting for \~10% of the runtime of the above code.

This PR is a proof-of-concept for some tools to hook into the new `tune_env` machinery in order to reuse intermediate results, like those outputted by `check_spec_mode_engine_val()`. With main dev tune and main dev parsnip:

``` r
bench::mark(
  fit_resamples(linear_reg(), mpg ~ ., bootstraps(mtcars, 100)),
  iterations = 10
) %>%
  select(median, mem_alloc)
#> → A | warning: prediction from a rank-deficient fit may be misleading
#> There were issues with some computations   A: x1
#> 
#> # A tibble: 1 × 2
#>     median mem_alloc
#>   <bch:tm> <bch:byt>
#> 1    8.73s     167MB
```

With main dev tune and this PR to parsnip:

``` r
bench::mark(
  fit_resamples(linear_reg(), mpg ~ ., bootstraps(mtcars, 100)),
  iterations = 10
) %>%
  select(median, mem_alloc)
#> → A | warning: prediction from a rank-deficient fit may be misleading
#> There were issues with some computations   A: x1
#> 
#> # A tibble: 1 × 2
#>     median mem_alloc
#>   <bch:tm> <bch:byt>
#> 1    7.86s     123MB
```

There are quite a few analogous changes that could be made to other internal helpers—a few percent here and there could go a long way to reducing the “tidymodels overhead” drastically.

None of this machinery kicks in when tune isn't installed or there's no active `tune_env`.

<sup>Created on 2023-02-28 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>