### PR TITLE
speed up `get_model_spec()` helper

### DIFF
--- a/R/translate.R
+++ b/R/translate.R
@@ -109,11 +109,11 @@ get_model_spec <- function(model, mode, engine) {
 
   libs <- rlang::env_get(m_env, paste0(model, "_pkgs"))
   libs <- vctrs::vec_slice(libs$pkg, libs$engine == engine)
-  res$libs <- libs[[1L]]
+  res$libs <- if (length(libs) > 0) {libs[[1]]} else {NULL}
 
   fits <- rlang::env_get(m_env, paste0(model, "_fit"))
   fits <- vctrs::vec_slice(fits$value, fits$mode == mode & fits$engine == engine)
-  res$fit <- fits[[1L]]
+  res$fit <- if (length(fits) > 0) {fits[[1]]} else {NULL}
 
   preds <- rlang::env_get(m_env, paste0(model, "_predict"))
   where <- preds$mode == mode & preds$engine == engine

--- a/tests/testthat/test_translate.R
+++ b/tests/testthat/test_translate.R
@@ -309,4 +309,38 @@ test_that("translate tuning paramter names", {
   expect_snapshot_error(.model_param_name_key(1))
 })
 
+# ------------------------------------------------------------------------------
 
+test_that("get_model_spec helper", {
+  mod1 <- get_model_spec("linear_reg", "regression", "lm")
+
+  expect_type(mod1, "list")
+
+  expect_type(mod1$libs, "character")
+  expect_length(mod1$libs, 1)
+  expect_equal(mod1$libs, "stats")
+
+  expect_type(mod1$fit, "list")
+  expect_length(mod1$fit, 4)
+  expect_equal(names(mod1$fit), c("interface", "protect", "func", "defaults"))
+
+  expect_type(mod1$pred, "list")
+  expect_length(mod1$pred, 4)
+  expect_equal(names(mod1$pred), c("numeric", "conf_int", "pred_int", "raw"))
+
+  expect_type(mod1$pred$numeric, "list")
+  expect_length(mod1$pred$numeric, 4)
+  expect_equal(names(mod1$pred$numeric), c("pre", "post", "func", "args"))
+
+  expect_type(mod1$pred$conf_int, "list")
+  expect_length(mod1$pred$conf_int, 4)
+  expect_equal(names(mod1$pred$conf_int), c("pre", "post", "func", "args"))
+
+  expect_type(mod1$pred$pred_int, "list")
+  expect_length(mod1$pred$pred_int, 4)
+  expect_equal(names(mod1$pred$pred_int), c("pre", "post", "func", "args"))
+
+  expect_type(mod1$pred$raw, "list")
+  expect_length(mod1$pred$raw, 4)
+  expect_equal(names(mod1$pred$raw), c("pre", "post", "func", "args"))
+})


### PR DESCRIPTION
This PR speeds up the `get_model_spec()` helper. I'm first just pushing some new tests so we can run checks and ensure that results don't change.

This helper is called once per model specification fit (or translation).

``` r
library(tidymodels)

bt <- bootstraps(mtcars, 100)

bm <- 
  bench::mark(
    total = 
      fit_resamples(linear_reg(), mpg ~ ., bootstraps(mtcars, 100)),
    get_model_spec = 
      replicate(100, parsnip:::get_model_spec("linear_reg", "regression", "lm")),
    check = FALSE
  )
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.

bm
#> # A tibble: 2 × 6
#>   expression          min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>     <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 total              5.2s     5.2s     0.192   73.57MB    10.6 
#> 2 get_model_spec  258.6ms  342.9ms     2.92     2.42MB     7.29
```

As a percentage of total time, the helper takes a bit more than 6.5% of the evaluation time:

``` r
100 * as.numeric(bm$median[2]) / as.numeric(bm$median[1])
#> [1] 6.588154
```

The rewritten version of the helper is below (just for purposes of self-contained reprex):

``` r
get_model_spec2 <- function(model, mode, engine) {
  m_env <- get_model_env()
  env_obj <- rlang::env_names(m_env)
  env_obj <- grep(model, env_obj, value = TRUE)
  
  res <- list()
  
  libs <- rlang::env_get(m_env, paste0(model, "_pkgs"))
  libs <- vctrs::vec_slice(libs$pkg, libs$engine == engine)
  res$libs <- if (length(libs) > 0) {libs[[1]]} else {NULL}
  
  fits <- rlang::env_get(m_env, paste0(model, "_fit"))
  fits <- vctrs::vec_slice(fits$value, fits$mode == mode & fits$engine == engine)
  res$fit <- if (length(fits) > 0) {fits[[1]]} else {NULL}
  
  preds <- rlang::env_get(m_env, paste0(model, "_predict"))
  where <- preds$mode == mode & preds$engine == engine
  types <- vctrs::vec_slice(preds$type, where)
  values <- vctrs::vec_slice(preds$value, where)
  names(values) <- types
  res$pred <- values
  
  res
}
```

With benchmarks:

``` r
bm2 <- 
  bench::mark(
    old = parsnip:::get_model_spec("linear_reg", "regression", "lm"),
    new = get_model_spec2("linear_reg", "regression", "lm"),
    check = TRUE
  )
```

Note with `check = TRUE` in the above, `mark()` checks equality of the outputs. :) The new check is `as.numeric(bm2$median[1]) / as.numeric(bm2$median[2])` times faster than the old one:

``` r
as.numeric(bm2$median[1]) / as.numeric(bm2$median[2])
#> [1] 24.86973
```

<sup>Created on 2023-03-06 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

cc @DavisVaughan--thanks for the rewrite.🏄 Note that this reprex was generated with dev dplyr--quite a big speedup already with their changes.