### PR TITLE
`read_model_info_table()` only once

### DIFF
--- a/R/aaa_models.R
+++ b/R/aaa_models.R
@@ -37,14 +37,8 @@ pred_types <-
 
 # ------------------------------------------------------------------------------
 
-read_model_info_table <- function() {
-  model_info_table <-
-    utils::read.delim(system.file("models.tsv", package = "parsnip"))
-
-  model_info_table
-}
-
-model_info_table <- read_model_info_table()
+model_info_table <-
+  utils::read.delim(system.file("models.tsv", package = "parsnip"))
 
 # ------------------------------------------------------------------------------
 

--- a/R/aaa_models.R
+++ b/R/aaa_models.R
@@ -44,6 +44,8 @@ read_model_info_table <- function() {
   model_info_table
 }
 
+model_info_table <- read_model_info_table()
+
 # ------------------------------------------------------------------------------
 
 #' Working with the parsnip model environment
@@ -228,7 +230,7 @@ check_spec_mode_engine_val <- function(cls, eng, mode, call = caller_env()) {
   # are contained in a different package
   model_info_parsnip_only <-
     dplyr::inner_join(
-      read_model_info_table() %>% dplyr::filter(is.na(pkg)) %>% dplyr::select(-pkg),
+      model_info_table %>% dplyr::filter(is.na(pkg)) %>% dplyr::select(-pkg),
       model_info %>% dplyr::mutate(model = cls),
       by = c("model", "engine", "mode")
     )

--- a/R/misc.R
+++ b/R/misc.R
@@ -69,7 +69,7 @@ mode_filter_condition <- function(mode, user_specified_mode) {
 #' * the `model_info_table` of "pre-registered" model specifications
 #'
 #' to determine whether a model is well-specified. See
-#' `parsnip:::read_model_info_table()` for this table.
+#' `parsnip:::model_info_table` for this table.
 #'
 #' `spec_is_loaded()` checks only against the current parsnip model environment.
 #'

--- a/R/misc.R
+++ b/R/misc.R
@@ -99,7 +99,7 @@ spec_is_possible <- function(spec,
 
   all_model_info <-
     dplyr::full_join(
-      read_model_info_table(),
+      model_info_table,
       rlang::env_get(get_model_env(), cls) %>% dplyr::mutate(model = cls),
       by = c("model", "engine", "mode")
     )
@@ -183,7 +183,7 @@ prompt_missing_implementation <- function(spec,
   }
 
   all <-
-    read_model_info_table() %>%
+    model_info_table %>%
     dplyr::filter(model == cls, !!mode_condition, !!engine_condition, !is.na(pkg)) %>%
     dplyr::select(-model)
 

--- a/man/extension-check-helpers.Rd
+++ b/man/extension-check-helpers.Rd
@@ -48,7 +48,7 @@ specified the engine or mode, respectively.
 }
 
 to determine whether a model is well-specified. See
-\code{parsnip:::read_model_info_table()} for this table.
+\code{parsnip:::model_info_table} for this table.
 
 \code{spec_is_loaded()} checks only against the current parsnip model environment.
 


### PR DESCRIPTION
The `read_model_info_table()` helper is called 3 times per fit, and is read from file each time.

``` r
library(tidymodels)

bt <- bootstraps(mtcars, 100)

bm <- 
  bench::mark(
    total = 
      fit_resamples(linear_reg(), mpg ~ ., bt),
    read_model_info_table = 
      replicate(300, parsnip:::read_model_info_table()),
    check = FALSE
  )
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.

bm
#> # A tibble: 2 × 6
#>   expression                 min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>            <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 total                    5.94s    5.94s     0.168      57MB     8.92
#> 2 read_model_info_table 215.87ms 219.19ms     4.57     25.1MB     3.04
```

As a percentage of total time, the check takes:

``` r
100 * as.numeric(bm$median[2]) / as.numeric(bm$median[1])
#> [1] 3.887301
```

This PR proposes, instead, assigning the function output directly into the namespace once and then referring to its output from then on.

<sup>Created on 2023-03-08 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>