### PR TITLE
`load_libs()` with `engine == "earth"`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 * `.organize_glmnet_pred()` now expects predictions for a single penalty value (#876).
 
+* Fixed bug where model fits with `engine = "earth"` would fail when the package's namespace hadn't been attached (#251).
+
 * Fixed bug with prediction from a boosted tree model fitted with `"xgboost"` using a custom objective function (#875).
 
 * Several internal functions (to help work with `Surv` objects) were added as a standalone file that can be used in other packages via `usethis::use_standalone("tidymodels/parsnip")`. 

--- a/R/mars.R
+++ b/R/mars.R
@@ -86,6 +86,9 @@ translate.mars <- function(x, engine = x$engine, ...) {
     message("Used `engine = 'earth'` for translation.")
     engine <- "earth"
   }
+  if (engine == "earth") {
+    load_libs(x, quiet = TRUE, attach = TRUE)
+  }
   # If classification is being done, the `glm` options should be used. Check to
   # see if it is there and, if not, add the default value.
   if (x$mode == "classification") {


### PR DESCRIPTION
Closes #251.🏄

With this PR:

``` r
library(parsnip)

mars(
  mode = "classification",
  num_terms = 1,
  prod_degree = 1,
  prune_method = "backward"
) %>% 
  set_engine("earth") %>% 
  fit(Species ~ ., iris)
#> Loading required package: Formula
#> Loading required package: plotmo
#> Loading required package: plotrix
#> Loading required package: TeachingDemos
#> parsnip model object
#> 
#> GLM (family binomial, link logit):
#>            nulldev  df       dev  df   devratio     AIC iters converged
#> setosa     190.954 149   190.954 149          0     193     4         1
#> versicolor 190.954 149   190.954 149          0     193     4         1
#> virginica  190.954 149   190.954 149          0     193     4         1
#> 
#> Earth selected 1 of 15 terms, and 0 of 4 predictors (nprune=1)
#> Termination condition: Reached nk 21
#> Importance: Sepal.Length-unused, Sepal.Width-unused, Petal.Length-unused, ...
#> Number of terms at each degree of interaction: 1 (intercept only model)
#> 
#> Earth
#>                  GCV       RSS GRSq RSq
#> setosa     0.2252151  33.33333    0   0
#> versicolor 0.2252151  33.33333    0   0
#> virginica  0.2252151  33.33333    0   0
#> All        0.6756452 100.00000    0   0
```

<sup>Created on 2023-03-09 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>