### PR TITLE
`load_libs()` with `engine == "kknn"` and factor predictors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * Made `fit()` behave consistently with respect to missingness in the classification setting. Previously, `fit()` erroneously raised an error about the class of the outcome when there were no complete cases, and now always passes along complete cases to be handled by the modeling function (#888).
 
+* Fixed bug where model fits with factor predictors and `engine = "kknn"` would fail when the package's namespace hadn't been attached (#264).
+
 * `.organize_glmnet_pred()` now expects predictions for a single penalty value (#876).
 
 * Fixed bug with prediction from a boosted tree model fitted with `"xgboost"` using a custom objective function (#875).

--- a/R/nearest_neighbor.R
+++ b/R/nearest_neighbor.R
@@ -120,6 +120,7 @@ translate.nearest_neighbor <- function(x, engine = x$engine, ...) {
   arg_vals <- x$method$fit$args
 
   if (engine == "kknn") {
+    load_libs(x, quiet = TRUE, attach = TRUE)
 
     if (!any(names(arg_vals) == "ks") || is_missing_arg(arg_vals$ks)) {
       arg_vals$ks <- 5


### PR DESCRIPTION
Closes #264. :) Same story as in #913.


``` r
library(parsnip)

mtcars$am <- as.factor(mtcars$am)
mtcars$cyl <- as.factor(mtcars$cyl)

nearest_neighbor() %>%  
  set_mode("classification") %>%
  set_engine("kknn") %>%
  fit(am ~ ., data = mtcars)
#> parsnip model object
#> 
#> 
#> Call:
#> kknn::train.kknn(formula = am ~ ., data = data, ks = min_rows(5,     data, 5))
#> 
#> Type of response variable: nominal
#> Minimal misclassification: 0.09375
#> Best kernel: optimal
#> Best k: 5
```

<sup>Created on 2023-03-09 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>