### PR TITLE
warn with >2 levels on `logistic_reg()` fit

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,7 +9,7 @@
 * Fixed bug with prediction from a boosted tree model fitted with `"xgboost"` using a custom objective function (#875).
 
 * Several internal functions (to help work with `Surv` objects) were added as a standalone file that can be used in other packages via `usethis::use_standalone("tidymodels/parsnip")`. 
-
+* `logistic_reg()` will now warn at `fit()` when the outcome has more than two levels (#545).
 
 # parsnip 1.0.4
 

--- a/R/misc.R
+++ b/R/misc.R
@@ -346,7 +346,7 @@ check_outcome <- function(y, spec) {
       rlang::abort("For a classification model, the outcome should be a factor.")
     }
 
-    if (inherits(spec, "logistic_reg") && length(levels(y)) > 2) {
+    if (inherits(spec, "logistic_reg") && is.atomic(y) && length(levels(y)) > 2) {
       # warn rather than error since some engines handle this case by binning
       # all but the first level as the non-event, so this may be intended
       cli::cli_warn(c(

--- a/R/misc.R
+++ b/R/misc.R
@@ -345,6 +345,17 @@ check_outcome <- function(y, spec) {
     if (!outcome_is_factor) {
       rlang::abort("For a classification model, the outcome should be a factor.")
     }
+
+    if (inherits(spec, "logistic_reg") && length(levels(y)) > 2) {
+      # warn rather than error since some engines handle this case by binning
+      # all but the first level as the non-event, so this may be intended
+      cli::cli_warn(c(
+        "!" = "Logistic regression is intended for modeling binary outcomes, \\
+               but there are {length(levels(y))} levels in the outcome.",
+        "i" = "If this is unintended, adjust outcome levels accordingly or \\
+               see the {.fn multinom_reg} function."
+      ))
+    }
   }
 
   if (spec$mode == "censored regression") {

--- a/tests/testthat/_snaps/logistic_reg.md
+++ b/tests/testthat/_snaps/logistic_reg.md
@@ -15,3 +15,17 @@
       Computational engine: glmnet 
       
 
+# bad input
+
+    Code
+      res <- mtcars %>% dplyr::mutate(cyl = as.factor(cyl)) %>% fit(logistic_reg(),
+      cyl ~ mpg, data = .)
+    Condition
+      Warning:
+      ! Logistic regression is intended for modeling binary outcomes, but there are 3 levels in the outcome.
+      i If this is unintended, adjust outcome levels accordingly or see the `multinom_reg()` function.
+      Warning:
+      glm.fit: algorithm did not converge
+      Warning:
+      glm.fit: fitted probabilities numerically 0 or 1 occurred
+

--- a/tests/testthat/test_logistic_reg.R
+++ b/tests/testthat/test_logistic_reg.R
@@ -16,6 +16,13 @@ test_that('bad input', {
   expect_error(translate(logistic_reg(x = hpc[,1:3], y = hpc$class) %>% set_engine(engine = "glmnet")))
   expect_error(translate(logistic_reg(formula = y ~ x) %>% set_engine(engine = "glm")))
   expect_error(translate(logistic_reg(mixture = 0.5) %>% set_engine(engine = "LiblineaR")))
+
+  expect_snapshot(
+    res <-
+      mtcars %>%
+      dplyr::mutate(cyl = as.factor(cyl)) %>%
+      fit(logistic_reg(), cyl ~ mpg, data = .)
+  )
 })
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Closes #545.🐧 Warns rather than errors since some engines bin the non-first-level outcome levels as the non-event.

Locating this check inside of `check_outcome` rather than `translate.logistic_reg()` since we don't yet have access to the outcome at the point. :/