### PR TITLE
document that main arguments are captured as quosures

### DIFF
--- a/man-roxygen/spec-details.R
+++ b/man-roxygen/spec-details.R
@@ -6,3 +6,12 @@
 #'
 #' The model is not trained or fit until the [`fit()`][fit.model_spec()] function is used
 #' with the data.
+#'
+#' Each of the arguments defaulting to `NULL` in this function are captured
+#' as [quosures][rlang::`topic-quosure`]. To pass values programmatically,
+#' use the [injection operator][rlang::`!!`] like so:
+#'
+#' ``` r
+#' value <- 1
+#' model_type(argument = !!value)
+#' ```

--- a/man/C5_rules.Rd
+++ b/man/C5_rules.Rd
@@ -45,6 +45,14 @@ arguments.
 
 The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.
+
+Each of the arguments defaulting to \code{NULL} in this function are captured
+as \link[rlang:`topic-quosure`]{quosures}. To pass values programmatically,
+use the \link[rlang:`!!`]{injection operator} like so:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
+model_type(argument = !!value)
+}\if{html}{\out{</div>}}
 }
 \examples{
 show_engines("C5_rules")

--- a/man/auto_ml.Rd
+++ b/man/auto_ml.Rd
@@ -32,6 +32,14 @@ arguments.
 
 The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.
+
+Each of the arguments defaulting to \code{NULL} in this function are captured
+as \link[rlang:`topic-quosure`]{quosures}. To pass values programmatically,
+use the \link[rlang:`!!`]{injection operator} like so:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
+model_type(argument = !!value)
+}\if{html}{\out{</div>}}
 }
 \references{
 \url{https://www.tidymodels.org}, \href{https://www.tmwr.org/}{\emph{Tidy Modeling with R}}, \href{https://www.tidymodels.org/find/parsnip/}{searchable table of parsnip models}

--- a/man/bag_mars.Rd
+++ b/man/bag_mars.Rd
@@ -46,6 +46,14 @@ arguments.
 
 The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.
+
+Each of the arguments defaulting to \code{NULL} in this function are captured
+as \link[rlang:`topic-quosure`]{quosures}. To pass values programmatically,
+use the \link[rlang:`!!`]{injection operator} like so:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
+model_type(argument = !!value)
+}\if{html}{\out{</div>}}
 }
 \references{
 \url{https://www.tidymodels.org}, \href{https://www.tmwr.org/}{\emph{Tidy Modeling with R}}, \href{https://www.tidymodels.org/find/parsnip/}{searchable table of parsnip models}

--- a/man/bag_mlp.Rd
+++ b/man/bag_mlp.Rd
@@ -44,6 +44,14 @@ arguments.
 
 The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.
+
+Each of the arguments defaulting to \code{NULL} in this function are captured
+as \link[rlang:`topic-quosure`]{quosures}. To pass values programmatically,
+use the \link[rlang:`!!`]{injection operator} like so:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
+model_type(argument = !!value)
+}\if{html}{\out{</div>}}
 }
 \references{
 \url{https://www.tidymodels.org}, \href{https://www.tmwr.org/}{\emph{Tidy Modeling with R}}, \href{https://www.tidymodels.org/find/parsnip/}{searchable table of parsnip models}

--- a/man/bag_tree.Rd
+++ b/man/bag_tree.Rd
@@ -51,6 +51,14 @@ arguments.
 
 The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.
+
+Each of the arguments defaulting to \code{NULL} in this function are captured
+as \link[rlang:`topic-quosure`]{quosures}. To pass values programmatically,
+use the \link[rlang:`!!`]{injection operator} like so:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
+model_type(argument = !!value)
+}\if{html}{\out{</div>}}
 }
 \references{
 \url{https://www.tidymodels.org}, \href{https://www.tmwr.org/}{\emph{Tidy Modeling with R}}, \href{https://www.tidymodels.org/find/parsnip/}{searchable table of parsnip models}

--- a/man/bart.Rd
+++ b/man/bart.Rd
@@ -65,6 +65,14 @@ arguments.
 
 The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.
+
+Each of the arguments defaulting to \code{NULL} in this function are captured
+as \link[rlang:`topic-quosure`]{quosures}. To pass values programmatically,
+use the \link[rlang:`!!`]{injection operator} like so:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
+model_type(argument = !!value)
+}\if{html}{\out{</div>}}
 }
 \examples{
 show_engines("bart")

--- a/man/boost_tree.Rd
+++ b/man/boost_tree.Rd
@@ -71,6 +71,14 @@ arguments.
 
 The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.
+
+Each of the arguments defaulting to \code{NULL} in this function are captured
+as \link[rlang:`topic-quosure`]{quosures}. To pass values programmatically,
+use the \link[rlang:`!!`]{injection operator} like so:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
+model_type(argument = !!value)
+}\if{html}{\out{</div>}}
 }
 \examples{
 show_engines("boost_tree")

--- a/man/cubist_rules.Rd
+++ b/man/cubist_rules.Rd
@@ -76,6 +76,14 @@ arguments.
 
 The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.
+
+Each of the arguments defaulting to \code{NULL} in this function are captured
+as \link[rlang:`topic-quosure`]{quosures}. To pass values programmatically,
+use the \link[rlang:`!!`]{injection operator} like so:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
+model_type(argument = !!value)
+}\if{html}{\out{</div>}}
 }
 \references{
 \url{https://www.tidymodels.org}, \href{https://www.tmwr.org/}{\emph{Tidy Modeling with R}}, \href{https://www.tidymodels.org/find/parsnip/}{searchable table of parsnip models}

--- a/man/decision_tree.Rd
+++ b/man/decision_tree.Rd
@@ -46,6 +46,14 @@ arguments.
 
 The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.
+
+Each of the arguments defaulting to \code{NULL} in this function are captured
+as \link[rlang:`topic-quosure`]{quosures}. To pass values programmatically,
+use the \link[rlang:`!!`]{injection operator} like so:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
+model_type(argument = !!value)
+}\if{html}{\out{</div>}}
 }
 \examples{
 show_engines("decision_tree")

--- a/man/discrim_flexible.Rd
+++ b/man/discrim_flexible.Rd
@@ -45,6 +45,14 @@ arguments.
 
 The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.
+
+Each of the arguments defaulting to \code{NULL} in this function are captured
+as \link[rlang:`topic-quosure`]{quosures}. To pass values programmatically,
+use the \link[rlang:`!!`]{injection operator} like so:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
+model_type(argument = !!value)
+}\if{html}{\out{</div>}}
 }
 \references{
 \url{https://www.tidymodels.org}, \href{https://www.tmwr.org/}{\emph{Tidy Modeling with R}}, \href{https://www.tidymodels.org/find/parsnip/}{searchable table of parsnip models}

--- a/man/discrim_linear.Rd
+++ b/man/discrim_linear.Rd
@@ -45,6 +45,14 @@ arguments.
 
 The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.
+
+Each of the arguments defaulting to \code{NULL} in this function are captured
+as \link[rlang:`topic-quosure`]{quosures}. To pass values programmatically,
+use the \link[rlang:`!!`]{injection operator} like so:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
+model_type(argument = !!value)
+}\if{html}{\out{</div>}}
 }
 \references{
 \url{https://www.tidymodels.org}, \href{https://www.tmwr.org/}{\emph{Tidy Modeling with R}}, \href{https://www.tidymodels.org/find/parsnip/}{searchable table of parsnip models}

--- a/man/discrim_quad.Rd
+++ b/man/discrim_quad.Rd
@@ -41,6 +41,14 @@ arguments.
 
 The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.
+
+Each of the arguments defaulting to \code{NULL} in this function are captured
+as \link[rlang:`topic-quosure`]{quosures}. To pass values programmatically,
+use the \link[rlang:`!!`]{injection operator} like so:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
+model_type(argument = !!value)
+}\if{html}{\out{</div>}}
 }
 \references{
 \url{https://www.tidymodels.org}, \href{https://www.tmwr.org/}{\emph{Tidy Modeling with R}}, \href{https://www.tidymodels.org/find/parsnip/}{searchable table of parsnip models}

--- a/man/discrim_regularized.Rd
+++ b/man/discrim_regularized.Rd
@@ -56,6 +56,14 @@ arguments.
 
 The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.
+
+Each of the arguments defaulting to \code{NULL} in this function are captured
+as \link[rlang:`topic-quosure`]{quosures}. To pass values programmatically,
+use the \link[rlang:`!!`]{injection operator} like so:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
+model_type(argument = !!value)
+}\if{html}{\out{</div>}}
 }
 \references{
 \url{https://www.tidymodels.org}, \href{https://www.tmwr.org/}{\emph{Tidy Modeling with R}}, \href{https://www.tidymodels.org/find/parsnip/}{searchable table of parsnip models}

--- a/man/gen_additive_mod.Rd
+++ b/man/gen_additive_mod.Rd
@@ -44,6 +44,14 @@ arguments.
 
 The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.
+
+Each of the arguments defaulting to \code{NULL} in this function are captured
+as \link[rlang:`topic-quosure`]{quosures}. To pass values programmatically,
+use the \link[rlang:`!!`]{injection operator} like so:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
+model_type(argument = !!value)
+}\if{html}{\out{</div>}}
 }
 \examples{
 show_engines("gen_additive_mod")

--- a/man/linear_reg.Rd
+++ b/man/linear_reg.Rd
@@ -44,6 +44,14 @@ arguments.
 
 The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.
+
+Each of the arguments defaulting to \code{NULL} in this function are captured
+as \link[rlang:`topic-quosure`]{quosures}. To pass values programmatically,
+use the \link[rlang:`!!`]{injection operator} like so:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
+model_type(argument = !!value)
+}\if{html}{\out{</div>}}
 }
 \examples{
 show_engines("linear_reg")

--- a/man/logistic_reg.Rd
+++ b/man/logistic_reg.Rd
@@ -55,6 +55,14 @@ arguments.
 The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.
 
+Each of the arguments defaulting to \code{NULL} in this function are captured
+as \link[rlang:`topic-quosure`]{quosures}. To pass values programmatically,
+use the \link[rlang:`!!`]{injection operator} like so:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
+model_type(argument = !!value)
+}\if{html}{\out{</div>}}
+
 This model fits a classification model for binary outcomes; for
 multiclass outcomes, see \code{\link[=multinom_reg]{multinom_reg()}}.
 }

--- a/man/mars.Rd
+++ b/man/mars.Rd
@@ -46,6 +46,14 @@ arguments.
 
 The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.
+
+Each of the arguments defaulting to \code{NULL} in this function are captured
+as \link[rlang:`topic-quosure`]{quosures}. To pass values programmatically,
+use the \link[rlang:`!!`]{injection operator} like so:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
+model_type(argument = !!value)
+}\if{html}{\out{</div>}}
 }
 \examples{
 show_engines("mars")

--- a/man/mlp.Rd
+++ b/man/mlp.Rd
@@ -61,6 +61,14 @@ arguments.
 
 The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.
+
+Each of the arguments defaulting to \code{NULL} in this function are captured
+as \link[rlang:`topic-quosure`]{quosures}. To pass values programmatically,
+use the \link[rlang:`!!`]{injection operator} like so:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
+model_type(argument = !!value)
+}\if{html}{\out{</div>}}
 }
 \examples{
 show_engines("mlp")

--- a/man/multinom_reg.Rd
+++ b/man/multinom_reg.Rd
@@ -54,6 +54,14 @@ arguments.
 The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.
 
+Each of the arguments defaulting to \code{NULL} in this function are captured
+as \link[rlang:`topic-quosure`]{quosures}. To pass values programmatically,
+use the \link[rlang:`!!`]{injection operator} like so:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
+model_type(argument = !!value)
+}\if{html}{\out{</div>}}
+
 This model fits a classification model for multiclass outcomes; for
 binary outcomes, see \code{\link[=logistic_reg]{logistic_reg()}}.
 }

--- a/man/naive_Bayes.Rd
+++ b/man/naive_Bayes.Rd
@@ -45,6 +45,14 @@ arguments.
 
 The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.
+
+Each of the arguments defaulting to \code{NULL} in this function are captured
+as \link[rlang:`topic-quosure`]{quosures}. To pass values programmatically,
+use the \link[rlang:`!!`]{injection operator} like so:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
+model_type(argument = !!value)
+}\if{html}{\out{</div>}}
 }
 \references{
 \url{https://www.tidymodels.org}, \href{https://www.tmwr.org/}{\emph{Tidy Modeling with R}}, \href{https://www.tidymodels.org/find/parsnip/}{searchable table of parsnip models}

--- a/man/nearest_neighbor.Rd
+++ b/man/nearest_neighbor.Rd
@@ -50,6 +50,14 @@ arguments.
 
 The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.
+
+Each of the arguments defaulting to \code{NULL} in this function are captured
+as \link[rlang:`topic-quosure`]{quosures}. To pass values programmatically,
+use the \link[rlang:`!!`]{injection operator} like so:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
+model_type(argument = !!value)
+}\if{html}{\out{</div>}}
 }
 \examples{
 show_engines("nearest_neighbor")

--- a/man/pls.Rd
+++ b/man/pls.Rd
@@ -43,6 +43,14 @@ arguments.
 
 The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.
+
+Each of the arguments defaulting to \code{NULL} in this function are captured
+as \link[rlang:`topic-quosure`]{quosures}. To pass values programmatically,
+use the \link[rlang:`!!`]{injection operator} like so:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
+model_type(argument = !!value)
+}\if{html}{\out{</div>}}
 }
 \references{
 \url{https://www.tidymodels.org}, \href{https://www.tmwr.org/}{\emph{Tidy Modeling with R}}, \href{https://www.tidymodels.org/find/parsnip/}{searchable table of parsnip models}

--- a/man/poisson_reg.Rd
+++ b/man/poisson_reg.Rd
@@ -48,6 +48,14 @@ arguments.
 
 The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.
+
+Each of the arguments defaulting to \code{NULL} in this function are captured
+as \link[rlang:`topic-quosure`]{quosures}. To pass values programmatically,
+use the \link[rlang:`!!`]{injection operator} like so:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
+model_type(argument = !!value)
+}\if{html}{\out{</div>}}
 }
 \references{
 \url{https://www.tidymodels.org}, \href{https://www.tmwr.org/}{\emph{Tidy Modeling with R}}, \href{https://www.tidymodels.org/find/parsnip/}{searchable table of parsnip models}

--- a/man/proportional_hazards.Rd
+++ b/man/proportional_hazards.Rd
@@ -50,6 +50,14 @@ arguments.
 The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.
 
+Each of the arguments defaulting to \code{NULL} in this function are captured
+as \link[rlang:`topic-quosure`]{quosures}. To pass values programmatically,
+use the \link[rlang:`!!`]{injection operator} like so:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
+model_type(argument = !!value)
+}\if{html}{\out{</div>}}
+
 Since survival models typically involve censoring (and require the use of
 \code{\link[survival:Surv]{survival::Surv()}} objects), the \code{\link[=fit.model_spec]{fit.model_spec()}} function will require that the
 survival model be specified via the formula interface.

--- a/man/rand_forest.Rd
+++ b/man/rand_forest.Rd
@@ -48,6 +48,14 @@ arguments.
 
 The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.
+
+Each of the arguments defaulting to \code{NULL} in this function are captured
+as \link[rlang:`topic-quosure`]{quosures}. To pass values programmatically,
+use the \link[rlang:`!!`]{injection operator} like so:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
+model_type(argument = !!value)
+}\if{html}{\out{</div>}}
 }
 \examples{
 show_engines("rand_forest")

--- a/man/rule_fit.Rd
+++ b/man/rule_fit.Rd
@@ -79,6 +79,14 @@ arguments.
 
 The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.
+
+Each of the arguments defaulting to \code{NULL} in this function are captured
+as \link[rlang:`topic-quosure`]{quosures}. To pass values programmatically,
+use the \link[rlang:`!!`]{injection operator} like so:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
+model_type(argument = !!value)
+}\if{html}{\out{</div>}}
 }
 \examples{
 show_engines("rule_fit")

--- a/man/surv_reg.Rd
+++ b/man/surv_reg.Rd
@@ -38,6 +38,14 @@ arguments.
 The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.
 
+Each of the arguments defaulting to \code{NULL} in this function are captured
+as \link[rlang:`topic-quosure`]{quosures}. To pass values programmatically,
+use the \link[rlang:`!!`]{injection operator} like so:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
+model_type(argument = !!value)
+}\if{html}{\out{</div>}}
+
 Since survival models typically involve censoring (and require the use of
 \code{\link[survival:Surv]{survival::Surv()}} objects), the \code{\link[=fit.model_spec]{fit.model_spec()}} function will require that the
 survival model be specified via the formula interface.

--- a/man/survival_reg.Rd
+++ b/man/survival_reg.Rd
@@ -34,6 +34,14 @@ arguments.
 The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.
 
+Each of the arguments defaulting to \code{NULL} in this function are captured
+as \link[rlang:`topic-quosure`]{quosures}. To pass values programmatically,
+use the \link[rlang:`!!`]{injection operator} like so:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
+model_type(argument = !!value)
+}\if{html}{\out{</div>}}
+
 Since survival models typically involve censoring (and require the use of
 \code{\link[survival:Surv]{survival::Surv()}} objects), the \code{\link[=fit.model_spec]{fit.model_spec()}} function will require that the
 survival model be specified via the formula interface.

--- a/man/svm_linear.Rd
+++ b/man/svm_linear.Rd
@@ -40,6 +40,14 @@ arguments.
 
 The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.
+
+Each of the arguments defaulting to \code{NULL} in this function are captured
+as \link[rlang:`topic-quosure`]{quosures}. To pass values programmatically,
+use the \link[rlang:`!!`]{injection operator} like so:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
+model_type(argument = !!value)
+}\if{html}{\out{</div>}}
 }
 \examples{
 show_engines("svm_linear")

--- a/man/svm_poly.Rd
+++ b/man/svm_poly.Rd
@@ -52,6 +52,14 @@ arguments.
 
 The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.
+
+Each of the arguments defaulting to \code{NULL} in this function are captured
+as \link[rlang:`topic-quosure`]{quosures}. To pass values programmatically,
+use the \link[rlang:`!!`]{injection operator} like so:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
+model_type(argument = !!value)
+}\if{html}{\out{</div>}}
 }
 \examples{
 show_engines("svm_poly")

--- a/man/svm_rbf.Rd
+++ b/man/svm_rbf.Rd
@@ -50,6 +50,14 @@ arguments.
 
 The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} function is used
 with the data.
+
+Each of the arguments defaulting to \code{NULL} in this function are captured
+as \link[rlang:`topic-quosure`]{quosures}. To pass values programmatically,
+use the \link[rlang:`!!`]{injection operator} like so:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
+model_type(argument = !!value)
+}\if{html}{\out{</div>}}
 }
 \examples{
 show_engines("svm_rbf")


### PR DESCRIPTION
Closes #662.🦀

If we think the `model_type()` pseudocode may be confusing for folks, we could make this into a proper template that could take the name of the model type function as an input. :)