### PR TITLE
`format_<prediction type>()` functions only format when necessary

### DIFF
--- a/R/predict.R
+++ b/R/predict.R
@@ -222,37 +222,19 @@ check_pred_type <- function(object, type, ...) {
 #' @export
 
 format_num <- function(x) {
-  if (inherits(x, "tbl_spark"))
+  if (inherits(x, "tbl_spark")) {
     return(x)
-
-  if (isTRUE(ncol(x) > 1) | is.data.frame(x)) {
-    x <- as_tibble(x, .name_repair = "minimal")
-    if (!any(grepl("^\\.pred", names(x)))) {
-      names(x) <- paste0(".pred_", names(x))
-    }
-  } else {
-    x <- tibble(.pred = unname(x))
   }
-
-  x
+  ensure_parsnip_format(x, ".pred", overwrite = FALSE)
 }
 
 #' @rdname format-internals
 #' @export
 format_class <- function(x) {
-  if (inherits(x, "tbl_spark"))
+  if (inherits(x, "tbl_spark")) {
     return(x)
-
-  if (isTRUE(ncol(x) > 1) | is.data.frame(x)) {
-    x <- as_tibble(x, .name_repair = "minimal")
-    if (!any(grepl("^\\.pred_class", names(x)))) {
-      names(x) <- ".pred_class"
-    }
-  } else {
-    x <- tibble(.pred_class = unname(x))
   }
-
-  x
+  ensure_parsnip_format(x, ".pred_class")
 }
 
 #' @rdname format-internals
@@ -269,64 +251,45 @@ format_classprobs <- function(x) {
 #' @rdname format-internals
 #' @export
 format_time <- function(x) {
-  if (isTRUE(ncol(x) > 1) | is.data.frame(x)) {
-    x <- as_tibble(x, .name_repair = "minimal")
-    if (!any(grepl("^\\.pred_time", names(x)))) {
-      names(x) <- paste0(".pred_time_", names(x))
-    }
-  } else {
-    x <- tibble(.pred_time = unname(x))
-  }
-
-  x
+  ensure_parsnip_format(x, ".pred_time", overwrite = FALSE)
 }
 
 #' @rdname format-internals
 #' @export
 format_survival <- function(x) {
-  if (isTRUE(ncol(x) > 1) | is.data.frame(x)) {
-    x <- as_tibble(x, .name_repair = "minimal")
-    if (!any(grepl("^\\.pred", names(x)))) {
-      names(x) <- ".pred"
-    }
-  } else {
-    x <- tibble(.pred = unname(x))
-  }
-
-  x
+  ensure_parsnip_format(x, ".pred")
 }
 
 #' @rdname format-internals
 #' @export
 format_linear_pred <- function(x) {
-  if (inherits(x, "tbl_spark"))
+  if (inherits(x, "tbl_spark")){
     return(x)
-
-  if (isTRUE(ncol(x) > 1) | is.data.frame(x)) {
-    x <- as_tibble(x, .name_repair = "minimal")
-    if (!any(grepl("^\\.pred_linear_pred", names(x)))) {
-      names(x) <- ".pred_linear_pred"
-    }
-  } else {
-    x <- tibble(.pred_linear_pred = unname(x))
   }
-
-  x
+  ensure_parsnip_format(x, ".pred_linear_pred")
 }
 
 #' @rdname format-internals
 #' @export
 format_hazard <- function(x) {
+  ensure_parsnip_format(x, ".pred")
+}
+
+ensure_parsnip_format <- function(x, col_name, overwrite = TRUE) {
   if (isTRUE(ncol(x) > 1) | is.data.frame(x)) {
     x <- as_tibble(x, .name_repair = "minimal")
-    if (!any(grepl("^\\.pred", names(x)))) {
-      names(x) <- ".pred"
+    if (!any(grepl(paste0("^\\", col_name), names(x)))) {
+      if (overwrite) {
+        names(x) <- col_name
+      } else {
+        names(x) <- paste(col_name, names(x), sep = "_")
+      }
     }
+  } else {
+    x <- tibble(unname(x))
+    names(x) <- col_name
+    x
   }
-  else {
-    x <- tibble(.pred_hazard = unname(x))
-  }
-
   x
 }
 

--- a/R/predict.R
+++ b/R/predict.R
@@ -243,7 +243,16 @@ format_class <- function(x) {
   if (inherits(x, "tbl_spark"))
     return(x)
 
-  tibble(.pred_class = unname(x))
+  if (isTRUE(ncol(x) > 1) | is.data.frame(x)) {
+    x <- as_tibble(x, .name_repair = "minimal")
+    if (!any(grepl("^\\.pred_class", names(x)))) {
+      names(x) <- ".pred_class"
+    }
+  } else {
+    x <- tibble(.pred_class = unname(x))
+  }
+
+  x
 }
 
 #' @rdname format-internals
@@ -277,7 +286,9 @@ format_time <- function(x) {
 format_survival <- function(x) {
   if (isTRUE(ncol(x) > 1) | is.data.frame(x)) {
     x <- as_tibble(x, .name_repair = "minimal")
-    names(x) <- ".pred"
+    if (!any(grepl("^\\.pred", names(x)))) {
+      names(x) <- ".pred"
+    }
   } else {
     x <- tibble(.pred = unname(x))
   }
@@ -293,7 +304,9 @@ format_linear_pred <- function(x) {
 
   if (isTRUE(ncol(x) > 1) | is.data.frame(x)) {
     x <- as_tibble(x, .name_repair = "minimal")
-    names(x) <- ".pred_linear_pred"
+    if (!any(grepl("^\\.pred_linear_pred", names(x)))) {
+      names(x) <- ".pred_linear_pred"
+    }
   } else {
     x <- tibble(.pred_linear_pred = unname(x))
   }
@@ -306,8 +319,11 @@ format_linear_pred <- function(x) {
 format_hazard <- function(x) {
   if (isTRUE(ncol(x) > 1) | is.data.frame(x)) {
     x <- as_tibble(x, .name_repair = "minimal")
-    names(x) <- ".pred"
-  } else {
+    if (!any(grepl("^\\.pred", names(x)))) {
+      names(x) <- ".pred"
+    }
+  }
+  else {
     x <- tibble(.pred_hazard = unname(x))
   }
 


### PR DESCRIPTION
closes  #263

The main part was done in #268 but since the issue was still open, this PR now extends it to newer prediction types.