### PR TITLE
audit uses of `tibble()` and `as_tibble()`

### DIFF
--- a/R/aaa_models.R
+++ b/R/aaa_models.R
@@ -560,38 +560,38 @@ set_new_model <- function(model) {
   current <- get_model_env()
 
   set_env_val("models", unique(c(current$models, model)))
-  set_env_val(model, dplyr::tibble(engine = character(0), mode = character(0)))
+  set_env_val(model, tibble::new_tibble(list(engine = character(0), mode = character(0))))
   set_env_val(
     paste0(model, "_pkgs"),
-    dplyr::tibble(engine = character(0), pkg = list(), mode = character(0))
+    tibble::new_tibble(list(engine = character(0), pkg = list(), mode = character(0)))
   )
   set_env_val(paste0(model, "_modes"), "unknown")
   set_env_val(
     paste0(model, "_args"),
-    dplyr::tibble(
+    tibble::new_tibble(list(
       engine = character(0),
       parsnip = character(0),
       original = character(0),
       func = list(),
       has_submodel = logical(0)
-    )
+    ))
   )
   set_env_val(
     paste0(model, "_fit"),
-    dplyr::tibble(
+    tibble::new_tibble(list(
       engine = character(0),
       mode = character(0),
       value = list()
-    )
+    ))
   )
   set_env_val(
     paste0(model, "_predict"),
-    dplyr::tibble(
+    tibble::new_tibble(list(
       engine = character(0),
       mode = character(0),
       type = character(0),
       value = list()
-    )
+    ))
   )
 
   invisible(NULL)
@@ -630,7 +630,7 @@ set_model_engine <- function(model, mode, eng) {
   check_eng_val(eng)
   check_mode_for_new_engine(model, eng, mode)
 
-  new_eng <- dplyr::tibble(engine = eng, mode = mode)
+  new_eng <- tibble::new_tibble(list(engine = eng, mode = mode), nrow = 1)
   old_eng <- get_from_env(model)
 
   engs <-
@@ -659,13 +659,13 @@ set_model_arg <- function(model, eng, parsnip, original, func, has_submodel) {
   old_args <- get_from_env(paste0(model, "_args"))
 
   new_arg <-
-    dplyr::tibble(
+    tibble::new_tibble(list(
       engine = eng,
       parsnip = parsnip,
       original = original,
       func = list(func),
       has_submodel = has_submodel
-    )
+    ), nrow = 1)
 
   updated <- try(dplyr::bind_rows(old_args, new_arg), silent = TRUE)
   if (inherits(updated, "try-error")) {
@@ -838,11 +838,11 @@ set_fit <- function(model, mode, eng, value) {
   check_unregistered(model, mode, eng)
 
   new_fit <-
-    dplyr::tibble(
+    tibble::new_tibble(list(
       engine = eng,
       mode = mode,
       value = list(value)
-    )
+    ), nrow = 1)
 
   if (!is_discordant_info(model, mode, eng, new_fit)) {
     return(invisible(NULL))
@@ -889,11 +889,9 @@ set_pred <- function(model, mode, eng, type, value) {
   model_info <- get_from_env(model)
 
   new_pred <-
-    dplyr::tibble(
-      engine = eng,
-      mode = mode,
-      type = type,
-      value = list(value)
+    tibble::new_tibble(
+      list(engine = eng, mode = mode, type = type, value = list(value)),
+      nrow = 1
     )
 
   pred_check <- is_discordant_info(model, mode, eng, new_pred, pred_type = type, component = "predict")
@@ -1089,7 +1087,7 @@ set_encoding <- function(model, mode, eng, options) {
   check_mode_val(mode)
   check_encodings(options)
 
-  keys   <- tibble::tibble(model = model, engine = eng, mode = mode)
+  keys   <- tibble::new_tibble(list(model = model, engine = eng, mode = mode), nrow = 1)
   options <- tibble::as_tibble(options)
   new_values <- dplyr::bind_cols(keys, options)
 


### PR DESCRIPTION
Same idea as https://github.com/tidymodels/tune/pull/637. :) Only implemented in model registration code—this doesn't have much of a user-facing effect, but makes `devtools::load_all()` feel a bit snappier.

``` r
bench::mark(
  load_all = devtools::load_all()
)
#> ℹ Loading parsnip
#> # A tibble: 1 × 13
#>   expression      min   median itr/s…¹ mem_a…² gc/se…³ n_itr  n_gc total…⁴
#>   <bch:expr> <bch:tm> <bch:tm>   <dbl> <bch:b>   <dbl> <int> <dbl> <bch:t>
#> 1 load_all       1.9s     1.9s   0.526  26.6MB    3.68     1     7    1.9s
#> # … with 4 more variables: result <list>, memory <list>, time <list>,
#> #   gc <list>, and abbreviated variable names ¹​`itr/sec`, ²​mem_alloc,
#> #   ³​`gc/sec`, ⁴​total_time
#> # ℹ Use `colnames()` to see all variable names
```

With this PR:

``` r
#> # A tibble: 1 × 13
#>   expression      min   median itr/s…¹ mem_a…² gc/se…³ n_itr  n_gc total…⁴
#>   <bch:expr> <bch:tm> <bch:tm>   <dbl> <bch:b>   <dbl> <int> <dbl> <bch:t>
#> 1 load_all      1.53s    1.53s   0.639    26MB    3.10     1     5   1.61s
#> # … with 4 more variables: result <list>, memory <list>, time <list>,
#> #   gc <list>, and abbreviated variable names ¹​`itr/sec`, ²​mem_alloc,
#> #   ³​`gc/sec`, ⁴​total_time
#> # ℹ Use `colnames()` to see all variable names
```