### PR TITLE
address roxygen2 "unavailable topic" warnings

### DIFF
--- a/man-roxygen/spec-details.R
+++ b/man-roxygen/spec-details.R
@@ -8,8 +8,8 @@
 #' with the data.
 #'
 #' Each of the arguments in this function other than `mode` and `engine` are
-#' captured as [quosures][rlang::`topic-quosure`]. To pass values
-#' programmatically, use the [injection operator][rlang::`!!`] like so:
+#' captured as [quosures][rlang::topic-quosure]. To pass values
+#' programmatically, use the [injection operator][rlang::!!] like so:
 #'
 #' ``` r
 #' value <- 1

--- a/man/C5_rules.Rd
+++ b/man/C5_rules.Rd
@@ -47,8 +47,8 @@ The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} f
 with the data.
 
 Each of the arguments in this function other than \code{mode} and \code{engine} are
-captured as \link[rlang:`topic-quosure`]{quosures}. To pass values
-programmatically, use the \link[rlang:`!!`]{injection operator} like so:
+captured as \link[rlang:topic-quosure]{quosures}. To pass values
+programmatically, use the \link[rlang:injection-operator]{injection operator} like so:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
 C5_rules(argument = !!value)

--- a/man/auto_ml.Rd
+++ b/man/auto_ml.Rd
@@ -34,8 +34,8 @@ The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} f
 with the data.
 
 Each of the arguments in this function other than \code{mode} and \code{engine} are
-captured as \link[rlang:`topic-quosure`]{quosures}. To pass values
-programmatically, use the \link[rlang:`!!`]{injection operator} like so:
+captured as \link[rlang:topic-quosure]{quosures}. To pass values
+programmatically, use the \link[rlang:injection-operator]{injection operator} like so:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
 auto_ml(argument = !!value)

--- a/man/bag_mars.Rd
+++ b/man/bag_mars.Rd
@@ -48,8 +48,8 @@ The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} f
 with the data.
 
 Each of the arguments in this function other than \code{mode} and \code{engine} are
-captured as \link[rlang:`topic-quosure`]{quosures}. To pass values
-programmatically, use the \link[rlang:`!!`]{injection operator} like so:
+captured as \link[rlang:topic-quosure]{quosures}. To pass values
+programmatically, use the \link[rlang:injection-operator]{injection operator} like so:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
 bag_mars(argument = !!value)

--- a/man/bag_mlp.Rd
+++ b/man/bag_mlp.Rd
@@ -46,8 +46,8 @@ The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} f
 with the data.
 
 Each of the arguments in this function other than \code{mode} and \code{engine} are
-captured as \link[rlang:`topic-quosure`]{quosures}. To pass values
-programmatically, use the \link[rlang:`!!`]{injection operator} like so:
+captured as \link[rlang:topic-quosure]{quosures}. To pass values
+programmatically, use the \link[rlang:injection-operator]{injection operator} like so:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
 bag_mlp(argument = !!value)

--- a/man/bag_tree.Rd
+++ b/man/bag_tree.Rd
@@ -53,8 +53,8 @@ The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} f
 with the data.
 
 Each of the arguments in this function other than \code{mode} and \code{engine} are
-captured as \link[rlang:`topic-quosure`]{quosures}. To pass values
-programmatically, use the \link[rlang:`!!`]{injection operator} like so:
+captured as \link[rlang:topic-quosure]{quosures}. To pass values
+programmatically, use the \link[rlang:injection-operator]{injection operator} like so:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
 bag_tree(argument = !!value)

--- a/man/bart.Rd
+++ b/man/bart.Rd
@@ -67,8 +67,8 @@ The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} f
 with the data.
 
 Each of the arguments in this function other than \code{mode} and \code{engine} are
-captured as \link[rlang:`topic-quosure`]{quosures}. To pass values
-programmatically, use the \link[rlang:`!!`]{injection operator} like so:
+captured as \link[rlang:topic-quosure]{quosures}. To pass values
+programmatically, use the \link[rlang:injection-operator]{injection operator} like so:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
 bart(argument = !!value)

--- a/man/boost_tree.Rd
+++ b/man/boost_tree.Rd
@@ -73,8 +73,8 @@ The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} f
 with the data.
 
 Each of the arguments in this function other than \code{mode} and \code{engine} are
-captured as \link[rlang:`topic-quosure`]{quosures}. To pass values
-programmatically, use the \link[rlang:`!!`]{injection operator} like so:
+captured as \link[rlang:topic-quosure]{quosures}. To pass values
+programmatically, use the \link[rlang:injection-operator]{injection operator} like so:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
 boost_tree(argument = !!value)

--- a/man/cubist_rules.Rd
+++ b/man/cubist_rules.Rd
@@ -78,8 +78,8 @@ The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} f
 with the data.
 
 Each of the arguments in this function other than \code{mode} and \code{engine} are
-captured as \link[rlang:`topic-quosure`]{quosures}. To pass values
-programmatically, use the \link[rlang:`!!`]{injection operator} like so:
+captured as \link[rlang:topic-quosure]{quosures}. To pass values
+programmatically, use the \link[rlang:injection-operator]{injection operator} like so:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
 cubist_rules(argument = !!value)

--- a/man/decision_tree.Rd
+++ b/man/decision_tree.Rd
@@ -48,8 +48,8 @@ The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} f
 with the data.
 
 Each of the arguments in this function other than \code{mode} and \code{engine} are
-captured as \link[rlang:`topic-quosure`]{quosures}. To pass values
-programmatically, use the \link[rlang:`!!`]{injection operator} like so:
+captured as \link[rlang:topic-quosure]{quosures}. To pass values
+programmatically, use the \link[rlang:injection-operator]{injection operator} like so:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
 decision_tree(argument = !!value)

--- a/man/discrim_flexible.Rd
+++ b/man/discrim_flexible.Rd
@@ -47,8 +47,8 @@ The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} f
 with the data.
 
 Each of the arguments in this function other than \code{mode} and \code{engine} are
-captured as \link[rlang:`topic-quosure`]{quosures}. To pass values
-programmatically, use the \link[rlang:`!!`]{injection operator} like so:
+captured as \link[rlang:topic-quosure]{quosures}. To pass values
+programmatically, use the \link[rlang:injection-operator]{injection operator} like so:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
 discrim_flexible(argument = !!value)

--- a/man/discrim_linear.Rd
+++ b/man/discrim_linear.Rd
@@ -47,8 +47,8 @@ The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} f
 with the data.
 
 Each of the arguments in this function other than \code{mode} and \code{engine} are
-captured as \link[rlang:`topic-quosure`]{quosures}. To pass values
-programmatically, use the \link[rlang:`!!`]{injection operator} like so:
+captured as \link[rlang:topic-quosure]{quosures}. To pass values
+programmatically, use the \link[rlang:injection-operator]{injection operator} like so:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
 discrim_linear(argument = !!value)

--- a/man/discrim_quad.Rd
+++ b/man/discrim_quad.Rd
@@ -43,8 +43,8 @@ The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} f
 with the data.
 
 Each of the arguments in this function other than \code{mode} and \code{engine} are
-captured as \link[rlang:`topic-quosure`]{quosures}. To pass values
-programmatically, use the \link[rlang:`!!`]{injection operator} like so:
+captured as \link[rlang:topic-quosure]{quosures}. To pass values
+programmatically, use the \link[rlang:injection-operator]{injection operator} like so:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
 discrim_quad(argument = !!value)

--- a/man/discrim_regularized.Rd
+++ b/man/discrim_regularized.Rd
@@ -58,8 +58,8 @@ The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} f
 with the data.
 
 Each of the arguments in this function other than \code{mode} and \code{engine} are
-captured as \link[rlang:`topic-quosure`]{quosures}. To pass values
-programmatically, use the \link[rlang:`!!`]{injection operator} like so:
+captured as \link[rlang:topic-quosure]{quosures}. To pass values
+programmatically, use the \link[rlang:injection-operator]{injection operator} like so:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
 discrim_regularized(argument = !!value)

--- a/man/gen_additive_mod.Rd
+++ b/man/gen_additive_mod.Rd
@@ -46,8 +46,8 @@ The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} f
 with the data.
 
 Each of the arguments in this function other than \code{mode} and \code{engine} are
-captured as \link[rlang:`topic-quosure`]{quosures}. To pass values
-programmatically, use the \link[rlang:`!!`]{injection operator} like so:
+captured as \link[rlang:topic-quosure]{quosures}. To pass values
+programmatically, use the \link[rlang:injection-operator]{injection operator} like so:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
 gen_additive_mod(argument = !!value)

--- a/man/linear_reg.Rd
+++ b/man/linear_reg.Rd
@@ -46,8 +46,8 @@ The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} f
 with the data.
 
 Each of the arguments in this function other than \code{mode} and \code{engine} are
-captured as \link[rlang:`topic-quosure`]{quosures}. To pass values
-programmatically, use the \link[rlang:`!!`]{injection operator} like so:
+captured as \link[rlang:topic-quosure]{quosures}. To pass values
+programmatically, use the \link[rlang:injection-operator]{injection operator} like so:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
 linear_reg(argument = !!value)

--- a/man/logistic_reg.Rd
+++ b/man/logistic_reg.Rd
@@ -56,8 +56,8 @@ The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} f
 with the data.
 
 Each of the arguments in this function other than \code{mode} and \code{engine} are
-captured as \link[rlang:`topic-quosure`]{quosures}. To pass values
-programmatically, use the \link[rlang:`!!`]{injection operator} like so:
+captured as \link[rlang:topic-quosure]{quosures}. To pass values
+programmatically, use the \link[rlang:injection-operator]{injection operator} like so:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
 logistic_reg(argument = !!value)

--- a/man/mars.Rd
+++ b/man/mars.Rd
@@ -48,8 +48,8 @@ The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} f
 with the data.
 
 Each of the arguments in this function other than \code{mode} and \code{engine} are
-captured as \link[rlang:`topic-quosure`]{quosures}. To pass values
-programmatically, use the \link[rlang:`!!`]{injection operator} like so:
+captured as \link[rlang:topic-quosure]{quosures}. To pass values
+programmatically, use the \link[rlang:injection-operator]{injection operator} like so:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
 mars(argument = !!value)

--- a/man/mlp.Rd
+++ b/man/mlp.Rd
@@ -63,8 +63,8 @@ The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} f
 with the data.
 
 Each of the arguments in this function other than \code{mode} and \code{engine} are
-captured as \link[rlang:`topic-quosure`]{quosures}. To pass values
-programmatically, use the \link[rlang:`!!`]{injection operator} like so:
+captured as \link[rlang:topic-quosure]{quosures}. To pass values
+programmatically, use the \link[rlang:injection-operator]{injection operator} like so:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
 mlp(argument = !!value)

--- a/man/multinom_reg.Rd
+++ b/man/multinom_reg.Rd
@@ -55,8 +55,8 @@ The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} f
 with the data.
 
 Each of the arguments in this function other than \code{mode} and \code{engine} are
-captured as \link[rlang:`topic-quosure`]{quosures}. To pass values
-programmatically, use the \link[rlang:`!!`]{injection operator} like so:
+captured as \link[rlang:topic-quosure]{quosures}. To pass values
+programmatically, use the \link[rlang:injection-operator]{injection operator} like so:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
 multinom_reg(argument = !!value)

--- a/man/naive_Bayes.Rd
+++ b/man/naive_Bayes.Rd
@@ -47,8 +47,8 @@ The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} f
 with the data.
 
 Each of the arguments in this function other than \code{mode} and \code{engine} are
-captured as \link[rlang:`topic-quosure`]{quosures}. To pass values
-programmatically, use the \link[rlang:`!!`]{injection operator} like so:
+captured as \link[rlang:topic-quosure]{quosures}. To pass values
+programmatically, use the \link[rlang:injection-operator]{injection operator} like so:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
 naive_Bayes(argument = !!value)

--- a/man/nearest_neighbor.Rd
+++ b/man/nearest_neighbor.Rd
@@ -52,8 +52,8 @@ The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} f
 with the data.
 
 Each of the arguments in this function other than \code{mode} and \code{engine} are
-captured as \link[rlang:`topic-quosure`]{quosures}. To pass values
-programmatically, use the \link[rlang:`!!`]{injection operator} like so:
+captured as \link[rlang:topic-quosure]{quosures}. To pass values
+programmatically, use the \link[rlang:injection-operator]{injection operator} like so:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
 nearest_neighbor(argument = !!value)

--- a/man/pls.Rd
+++ b/man/pls.Rd
@@ -45,8 +45,8 @@ The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} f
 with the data.
 
 Each of the arguments in this function other than \code{mode} and \code{engine} are
-captured as \link[rlang:`topic-quosure`]{quosures}. To pass values
-programmatically, use the \link[rlang:`!!`]{injection operator} like so:
+captured as \link[rlang:topic-quosure]{quosures}. To pass values
+programmatically, use the \link[rlang:injection-operator]{injection operator} like so:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
 pls(argument = !!value)

--- a/man/poisson_reg.Rd
+++ b/man/poisson_reg.Rd
@@ -50,8 +50,8 @@ The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} f
 with the data.
 
 Each of the arguments in this function other than \code{mode} and \code{engine} are
-captured as \link[rlang:`topic-quosure`]{quosures}. To pass values
-programmatically, use the \link[rlang:`!!`]{injection operator} like so:
+captured as \link[rlang:topic-quosure]{quosures}. To pass values
+programmatically, use the \link[rlang:injection-operator]{injection operator} like so:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
 poisson_reg(argument = !!value)

--- a/man/proportional_hazards.Rd
+++ b/man/proportional_hazards.Rd
@@ -51,8 +51,8 @@ The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} f
 with the data.
 
 Each of the arguments in this function other than \code{mode} and \code{engine} are
-captured as \link[rlang:`topic-quosure`]{quosures}. To pass values
-programmatically, use the \link[rlang:`!!`]{injection operator} like so:
+captured as \link[rlang:topic-quosure]{quosures}. To pass values
+programmatically, use the \link[rlang:injection-operator]{injection operator} like so:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
 proportional_hazards(argument = !!value)

--- a/man/rand_forest.Rd
+++ b/man/rand_forest.Rd
@@ -50,8 +50,8 @@ The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} f
 with the data.
 
 Each of the arguments in this function other than \code{mode} and \code{engine} are
-captured as \link[rlang:`topic-quosure`]{quosures}. To pass values
-programmatically, use the \link[rlang:`!!`]{injection operator} like so:
+captured as \link[rlang:topic-quosure]{quosures}. To pass values
+programmatically, use the \link[rlang:injection-operator]{injection operator} like so:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
 rand_forest(argument = !!value)

--- a/man/rule_fit.Rd
+++ b/man/rule_fit.Rd
@@ -81,8 +81,8 @@ The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} f
 with the data.
 
 Each of the arguments in this function other than \code{mode} and \code{engine} are
-captured as \link[rlang:`topic-quosure`]{quosures}. To pass values
-programmatically, use the \link[rlang:`!!`]{injection operator} like so:
+captured as \link[rlang:topic-quosure]{quosures}. To pass values
+programmatically, use the \link[rlang:injection-operator]{injection operator} like so:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
 rule_fit(argument = !!value)

--- a/man/surv_reg.Rd
+++ b/man/surv_reg.Rd
@@ -39,8 +39,8 @@ The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} f
 with the data.
 
 Each of the arguments in this function other than \code{mode} and \code{engine} are
-captured as \link[rlang:`topic-quosure`]{quosures}. To pass values
-programmatically, use the \link[rlang:`!!`]{injection operator} like so:
+captured as \link[rlang:topic-quosure]{quosures}. To pass values
+programmatically, use the \link[rlang:injection-operator]{injection operator} like so:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
 surv_reg(argument = !!value)

--- a/man/survival_reg.Rd
+++ b/man/survival_reg.Rd
@@ -35,8 +35,8 @@ The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} f
 with the data.
 
 Each of the arguments in this function other than \code{mode} and \code{engine} are
-captured as \link[rlang:`topic-quosure`]{quosures}. To pass values
-programmatically, use the \link[rlang:`!!`]{injection operator} like so:
+captured as \link[rlang:topic-quosure]{quosures}. To pass values
+programmatically, use the \link[rlang:injection-operator]{injection operator} like so:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
 survival_reg(argument = !!value)

--- a/man/svm_linear.Rd
+++ b/man/svm_linear.Rd
@@ -42,8 +42,8 @@ The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} f
 with the data.
 
 Each of the arguments in this function other than \code{mode} and \code{engine} are
-captured as \link[rlang:`topic-quosure`]{quosures}. To pass values
-programmatically, use the \link[rlang:`!!`]{injection operator} like so:
+captured as \link[rlang:topic-quosure]{quosures}. To pass values
+programmatically, use the \link[rlang:injection-operator]{injection operator} like so:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
 svm_linear(argument = !!value)

--- a/man/svm_poly.Rd
+++ b/man/svm_poly.Rd
@@ -54,8 +54,8 @@ The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} f
 with the data.
 
 Each of the arguments in this function other than \code{mode} and \code{engine} are
-captured as \link[rlang:`topic-quosure`]{quosures}. To pass values
-programmatically, use the \link[rlang:`!!`]{injection operator} like so:
+captured as \link[rlang:topic-quosure]{quosures}. To pass values
+programmatically, use the \link[rlang:injection-operator]{injection operator} like so:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
 svm_poly(argument = !!value)

--- a/man/svm_rbf.Rd
+++ b/man/svm_rbf.Rd
@@ -52,8 +52,8 @@ The model is not trained or fit until the \code{\link[=fit.model_spec]{fit()}} f
 with the data.
 
 Each of the arguments in this function other than \code{mode} and \code{engine} are
-captured as \link[rlang:`topic-quosure`]{quosures}. To pass values
-programmatically, use the \link[rlang:`!!`]{injection operator} like so:
+captured as \link[rlang:topic-quosure]{quosures}. To pass values
+programmatically, use the \link[rlang:injection-operator]{injection operator} like so:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{value <- 1
 svm_rbf(argument = !!value)


### PR DESCRIPTION
@hfrick pointed out we were seeing:

```
==> devtools::document(roclets = c('rd', 'collate', 'namespace'))

ℹ Updating parsnip documentation
ℹ Loading parsnip
Warning: [TEMPLATE:0] @details refers to unavailable topic rlang::`topic-quosure`
Warning: [TEMPLATE:0] @details refers to unavailable topic rlang::`!!`
Warning: [TEMPLATE:0] @details refers to unavailable topic rlang::`topic-quosure`
Warning: [TEMPLATE:0] @details refers to unavailable topic rlang::`!!`
Warning: [TEMPLATE:0] @details refers to unavailable topic rlang::`topic-quosure`
Warning: [TEMPLATE:0] @details refers to unavailable topic rlang::`!!`
```

following #918. Turns out we don't need to backtick here!

```
> roxygen2:::find_topic_in_package("rlang", "`!!`")
[1] NA
> roxygen2:::find_topic_in_package("rlang", "!!")
[1] "injection-operator"
```