### PR TITLE
speed up `tune_tbl()` helper

### DIFF
--- a/R/tune_args.R
+++ b/R/tune_args.R
@@ -18,13 +18,15 @@ tune_args.model_spec <- function(object, full = FALSE, ...) {
   res <- c(arg_id, eng_arg_id)
   res <- ifelse(res == "", names(res), res)
 
+  len_res <- length(res)
+
   tune_tbl(
     name = names(res),
     tunable = unname(!is.na(res)),
     id = res,
-    source = "model_spec",
-    component = model_type,
-    component_id = NA_character_,
+    source = rep("model_spec", len_res),
+    component = rep(model_type, len_res),
+    component_id = rep(NA_character_, len_res),
     full = full
   )
 }
@@ -65,13 +67,16 @@ tune_tbl <- function(name = character(),
          ".", sep = "", call. = FALSE)
   }
 
-  vry_tbl <- tibble::tibble(
-    name = as.character(name),
-    tunable = as.logical(tunable),
-    id = as.character(id),
-    source = as.character(source),
-    component = as.character(component),
-    component_id = as.character(component_id)
+  vry_tbl <- tibble::new_tibble(
+    list(
+      name = as.character(name),
+      tunable = as.logical(tunable),
+      id = as.character(id),
+      source = as.character(source),
+      component = as.character(component),
+      component_id = as.character(component_id)
+    ),
+    nrow = length(as.character(name))
   )
 
   if (!full) {


### PR DESCRIPTION
`tune_tbl()` is called each resample fit, and is a light wrapper around `tibble::tibble()`. The function is only called inside of `tune_args()`, so we know what kinds of inputs the helper will receive:

<https://github.com/tidymodels/parsnip/blob/d8f273cd3eeac3cb2c130109a785fb291bc9e58c/R/tune_args.R#L21-L29>

``` r
bm <- 
  bench::mark(
    total = fit_resamples(linear_reg(), mpg ~ ., bootstraps(mtcars, 100)),
    tune_tbl = replicate(100, parsnip:::tune_tbl()),
    check = FALSE
  )

bm
#> # A tibble: 2 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 total         3.25s    3.25s     0.308    47.7MB     8.92
#> 2 tune_tbl    43.77ms  47.91ms    22.6        77KB    11.3
```

As a percentage of total time, the helper takes:

``` r
100 * as.numeric(bm$median[2]) / as.numeric(bm$median[1])
#> [1] 1.474154
```

Since we can recycle vectors as needed before inputting to the helper, we can use `new_tibble(list())` instead of `tibble()`, which will drastically cut down on the time this helper takes. 