### PR TITLE
Refactor formatting functions for glmnet methods for `multi_predict()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ Imports:
     magrittr,
     pillar,
     prettyunits,
-    purrr,
+    purrr (>= 1.0.0),
     rlang (>= 0.3.1),
     stats,
     tibble (>= 2.1.1),

--- a/R/glmnet-engines.R
+++ b/R/glmnet-engines.R
@@ -329,7 +329,7 @@ format_glmnet_multinom_prob <- function(pred, penalty, lvl, n_obs) {
   # dim 3 = penalty values
   apply(pred, 3, as_tibble) %>%
     purrr::list_rbind() %>%
-    rlang::set_names(paste0("pred_", lvl)) %>%
+    rlang::set_names(paste0(".pred_", lvl)) %>%
     dplyr::mutate(
       .row = rep(seq_len(n_obs), times = length(penalty)),
       penalty = rep(penalty, each = n_obs)


### PR DESCRIPTION
This refactoring doesn't change how the functions work but aims to increase readability. The function for logistic regression models already uses this style.

Extratests includes tests on the exact format of predictions (and those run fine).