### PR TITLE
return early when possible in spec checking

### DIFF
--- a/R/aaa_models.R
+++ b/R/aaa_models.R
@@ -220,6 +220,16 @@ check_spec_mode_engine_val <- function(cls, eng, mode, call = caller_env()) {
 
   model_info <- rlang::env_get(get_model_env(), cls)
 
+  # Initially, check if the specification is well-defined in the current model
+  # parsnip model environment. If so, return early.
+  # If not, troubleshoot more precisely and raise a relevant error.
+  model_env_match <-
+    vctrs::vec_slice(model_info, model_info$engine == eng & model_info$mode == mode)
+
+  if (vctrs::vec_size(model_env_match) == 1) {
+    return(invisible(NULL))
+  }
+
   # Cases where the model definition is in parsnip but all of the engines
   # are contained in a different package
   model_info_parsnip_only <-


### PR DESCRIPTION
We've managed to cut down on calls to `check_spec_mode_engine_val()` in many places, though in most cases we're dropped into there we can still return early. It's hard to troubleshoot exactly what went wrong with misspecified specifications, but since the parsnip model environment is our ground truth for when a specification _is_ well-defined, we should first look to it to see if we can skip the remaining checks. For quick fits like `stats::lm()` on a small dataset, this makes parsnip about twice as fast!😮

With `main` dev:

``` r
library(parsnip)

bench::mark(
  total = fit(linear_reg(), mpg ~ ., mtcars),
  iterations = 25
)
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 total        7.65ms   8.04ms      120.    7.19MB     67.6
```

With this PR:

``` r
library(parsnip)

bench::mark(
  total = fit(linear_reg(), mpg ~ ., mtcars),
  iterations = 25
)
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 total         3.7ms   3.87ms      255.    7.12MB     48.5
```

<sup>Created on 2023-03-17 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

There are additional tests for this infrastructure [in extratests](https://github.com/tidymodels/extratests/blob/main/tests/testthat/test-parsnip-extension-messaging.R)—they are fine. :)