### PR TITLE
speed up `get_args()` helper

### DIFF
--- a/R/translate.R
+++ b/R/translate.R
@@ -127,9 +127,12 @@ get_model_spec <- function(model, mode, engine) {
 
 get_args <- function(model, engine) {
   m_env <- get_model_env()
-  rlang::env_get(m_env, paste0(model, "_args")) %>%
-    dplyr::filter(engine == !!engine) %>%
-    dplyr::select(-engine)
+
+  args <- rlang::env_get(m_env, paste0(model, "_args"))
+  args <- vctrs::vec_slice(args, args$engine == engine)
+  args$engine <- NULL
+
+  args
 }
 
 # to replace harmonize


### PR DESCRIPTION
With `main` dev:

``` r
library(parsnip)

bench::mark(
  total = fit(linear_reg(), mpg ~ ., mtcars),
  iterations = 25
)
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 total        7.65ms   8.04ms      120.    7.19MB     67.6
```

With this PR:

``` r
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 total        6.62ms   6.78ms      145.    7.19MB     56.5
```

Taken together with the other PRs this morning, `fit(linear_reg(), mpg ~ ., mtcars)` is now free of any calls to `select()`, `filter()`, or `mutate()`!😮

<sup>Created on 2023-03-17 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
