### PR TITLE
speed up `format_classprobs()` helper

### DIFF
--- a/R/predict.R
+++ b/R/predict.R
@@ -258,8 +258,14 @@ format_classprobs <- function(x) {
   if (!any(grepl("^\\.pred_", names(x)))) {
     names(x) <- paste0(".pred_", names(x))
   }
-  x <- as_tibble(x)
-  x <- purrr::map_dfr(x, rlang::set_names, NULL)
+  if (!tibble::is_tibble(x)) {
+    x <- as_tibble(x)
+  }
+
+  for (i in seq_along(x)) {
+    names(x[[i]]) <- NULL
+  }
+
   x
 }
 


### PR DESCRIPTION
We're now good to go on the worst-case overhead of `fit()`, though this step in `predict()` introduces the last big slowdown causing the overhead in evaluation time in the causal estimate bootstrapping example. `as_tibble()` takes a bit of time, but the deprecation warning in `map_dfr()` especially slows us down.

With `main` dev:

``` r
library(tidymodels)

lr <- fit(logistic_reg(), Class ~ ., two_class_dat)

bench::mark(
  old = predict(lr, two_class_dat, type = "prob")
)
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 old          3.01ms   3.12ms      305.    3.62MB     6.27
```

With this PR:

``` r
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 new          1.32ms   1.35ms      729.   92.92KB     8.26
```

<sup>Created on 2023-03-20 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>