### PR TITLE
speed up `prepare_data()` helper

### DIFF
--- a/R/predict.R
+++ b/R/predict.R
@@ -394,12 +394,12 @@ prepare_data <- function(object, new_data) {
     new_data <- .convert_xy_to_form_new(object$preproc, new_data)
   }
 
-  remove_intercept <- get_encoding(class(object$spec)[1])
+  encodings <- get_encoding(class(object$spec)[1])
   remove_intercept <-
     vctrs::vec_slice(
-      remove_intercept$remove_intercept,
-      remove_intercept$mode == object$spec$mode &
-        remove_intercept$engine == object$spec$engine
+      encodings$remove_intercept,
+      encodings$mode == object$spec$mode &
+        encodings$engine == object$spec$engine
     )
 
   if (remove_intercept & any(grepl("Intercept", names(new_data)))) {

--- a/R/predict.R
+++ b/R/predict.R
@@ -394,12 +394,16 @@ prepare_data <- function(object, new_data) {
     new_data <- .convert_xy_to_form_new(object$preproc, new_data)
   }
 
+  remove_intercept <- get_encoding(class(object$spec)[1])
   remove_intercept <-
-    get_encoding(class(object$spec)[1]) %>%
-    dplyr::filter(mode == object$spec$mode, engine == object$spec$engine) %>%
-    dplyr::pull(remove_intercept)
+    vctrs::vec_slice(
+      remove_intercept$remove_intercept,
+      remove_intercept$mode == object$spec$mode &
+        remove_intercept$engine == object$spec$engine
+    )
+
   if (remove_intercept & any(grepl("Intercept", names(new_data)))) {
-    new_data <- new_data %>% dplyr::select(-dplyr::one_of("(Intercept)"))
+    new_data <- new_data[, colnames(new_data) != "(Intercept)", drop = FALSE]
   }
 
   fit_interface <- object$spec$method$fit$interface


### PR DESCRIPTION
Together with #934, puts us under 100% overhead in the causal estimate bootstrapping example. :)

With `main` dev:

``` r
library(tidymodels)

lr <- fit(logistic_reg(), Class ~ ., two_class_dat)

bench::mark(
  old = predict(lr, two_class_dat, type = "prob")
)
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 old          3.01ms   3.12ms      305.    3.62MB     6.27
```

With this PR:

``` r
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 new          2.14ms   2.44ms      398.   84.78KB     6.19
```

<sup>Created on 2023-03-20 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>