### PR TITLE
`time` to `eval_time`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: parsnip
 Title: A Common API to Modeling and Analysis Functions
-Version: 1.0.4.9004
+Version: 1.0.4.9005
 Authors@R: c(
     person("Max", "Kuhn", , "max@posit.co", role = c("aut", "cre")),
     person("Davis", "Vaughan", , "davis@posit.co", role = "aut"),

--- a/R/predict.R
+++ b/R/predict.R
@@ -31,7 +31,7 @@
 #'            linear predictors). Default value is `FALSE`.
 #'     \item `quantile`: for `type` equal to `quantile`, the quantiles of the
 #'            distribution. Default is `(1:9)/10`.
-#'     \item `time`: for `type` equal to `"survival"` or `"hazard"`, the
+#'     \item `eval_time`: for `type` equal to `"survival"` or `"hazard"`, the
 #'            time points at which the survival probability or hazard is estimated.
 #'  }
 #' @details For `type = NULL`, `predict()` uses
@@ -48,7 +48,7 @@
 #'
 #'  ## Censored regression predictions
 #'
-#' For censored regression, a numeric vector for `time` is required when
+#' For censored regression, a numeric vector for `eval_time` is required when
 #' survival or hazard probabilities are requested. Also, when
 #' `type = "linear_pred"`, censored regression models will by default be
 #' formatted such that the linear predictor _increases_ with time. This may
@@ -83,11 +83,11 @@
 #'
 #' For `type = "survival"`, the tibble has a `.pred` column, which is
 #'  a list-column. Each list element contains a tibble with columns
-#'  `.time` and `.pred_survival` (and perhaps other columns).
+#'  `.eval_time` and `.pred_survival` (and perhaps other columns).
 #'
 #' For `type = "hazard"`, the tibble has a `.pred` column, which is
 #'  a list-column. Each list element contains a tibble with columns
-#'  `.time` and `.pred_hazard` (and perhaps other columns).
+#'  `.eval_time` and `.pred_hazard` (and perhaps other columns).
 #'
 #' Using `type = "raw"` with `predict.model_fit()` will return
 #'  the unadulterated results of the prediction function.
@@ -328,7 +328,8 @@ check_pred_type_dots <- function(object, type, ..., call = rlang::caller_env()) 
 
   # ----------------------------------------------------------------------------
 
-  other_args <- c("interval", "level", "std_error", "quantile", "time", "increasing")
+  other_args <- c("interval", "level", "std_error", "quantile",
+                  "time", "eval_time", "increasing")
   is_pred_arg <- names(the_dots) %in% other_args
   if (any(!is_pred_arg)) {
     bad_args <- names(the_dots)[!is_pred_arg]
@@ -342,7 +343,15 @@ check_pred_type_dots <- function(object, type, ..., call = rlang::caller_env()) 
   }
 
   # ----------------------------------------------------------------------------
-  # places where time should not be given
+  # places where eval_time should not be given
+  if (any(nms == "eval_time") & !type %in% c("survival", "hazard")) {
+    rlang::abort(
+      paste(
+        "`eval_time` should only be passed to `predict()` when `type` is one of:",
+        paste0("'", c("survival", "hazard"), "'", collapse = ", ")
+      )
+    )
+  }
   if (any(nms == "time") & !type %in% c("survival", "hazard")) {
     rlang::abort(
       paste(
@@ -351,12 +360,12 @@ check_pred_type_dots <- function(object, type, ..., call = rlang::caller_env()) 
       )
     )
   }
-  # when time should be passed
-  if (!any(nms == "time") & type %in% c("survival", "hazard")) {
+  # when eval_time should be passed
+  if (!any(nms %in% c("eval_time", "time")) & type %in% c("survival", "hazard")) {
     rlang::abort(
       paste(
-        "When using 'type' values of 'survival' or 'hazard' are given,",
-        "a numeric vector 'time' should also be given."
+        "When using `type` values of 'survival' or 'hazard',",
+        "a numeric vector `eval_time` should also be given."
       )
     )
   }

--- a/R/predict_hazard.R
+++ b/R/predict_hazard.R
@@ -4,35 +4,37 @@
 #' @method predict_hazard model_fit
 #' @export predict_hazard.model_fit
 #' @export
-predict_hazard.model_fit <-
-  function(object, new_data, time, ...) {
+predict_hazard.model_fit <- function(object,
+                                     new_data,
+                                     time,
+                                     ...) {
 
-    check_spec_pred_type(object, "hazard")
+  check_spec_pred_type(object, "hazard")
 
-    if (inherits(object$fit, "try-error")) {
-      rlang::warn("Model fit failed; cannot make predictions.")
-      return(NULL)
-    }
-
-    new_data <- prepare_data(object, new_data)
-
-    # preprocess data
-    if (!is.null(object$spec$method$pred$hazard$pre))
-      new_data <- object$spec$method$pred$hazard$pre(new_data, object)
-
-    # Pass some extra arguments to be used in post-processor
-    object$spec$method$pred$hazard$args$time <- time
-    pred_call <- make_pred_call(object$spec$method$pred$hazard)
-
-    res <- eval_tidy(pred_call)
-
-    # post-process the predictions
-    if(!is.null(object$spec$method$pred$hazard$post)) {
-      res <- object$spec$method$pred$hazard$post(res, object)
-    }
-
-    res
+  if (inherits(object$fit, "try-error")) {
+    rlang::warn("Model fit failed; cannot make predictions.")
+    return(NULL)
   }
+
+  new_data <- prepare_data(object, new_data)
+
+  # preprocess data
+  if (!is.null(object$spec$method$pred$hazard$pre))
+    new_data <- object$spec$method$pred$hazard$pre(new_data, object)
+
+  # Pass some extra arguments to be used in post-processor
+  object$spec$method$pred$hazard$args$time <- time
+  pred_call <- make_pred_call(object$spec$method$pred$hazard)
+
+  res <- eval_tidy(pred_call)
+
+  # post-process the predictions
+  if(!is.null(object$spec$method$pred$hazard$post)) {
+    res <- object$spec$method$pred$hazard$post(res, object)
+  }
+
+  res
+}
 
 # @export
 # @keywords internal

--- a/R/predict_hazard.R
+++ b/R/predict_hazard.R
@@ -6,8 +6,17 @@
 #' @export
 predict_hazard.model_fit <- function(object,
                                      new_data,
-                                     time,
+                                     eval_time,
+                                     time = deprecated(),
                                      ...) {
+  if (lifecycle::is_present(time)) {
+    lifecycle::deprecate_warn(
+      "1.0.4.9005",
+      "predict_hazard(time)",
+      "predict_hazard(eval_time)"
+    )
+    eval_time <- time
+  }
 
   check_spec_pred_type(object, "hazard")
 
@@ -23,7 +32,7 @@ predict_hazard.model_fit <- function(object,
     new_data <- object$spec$method$pred$hazard$pre(new_data, object)
 
   # Pass some extra arguments to be used in post-processor
-  object$spec$method$pred$hazard$args$time <- time
+  object$spec$method$pred$hazard$args$eval_time <- eval_time
   pred_call <- make_pred_call(object$spec$method$pred$hazard)
 
   res <- eval_tidy(pred_call)

--- a/R/predict_survival.R
+++ b/R/predict_survival.R
@@ -6,10 +6,19 @@
 #' @export
 predict_survival.model_fit <- function(object,
                                        new_data,
-                                       time,
+                                       eval_time,
+                                       time = deprecated(),
                                        interval = "none",
                                        level = 0.95,
                                        ...) {
+  if (lifecycle::is_present(time)) {
+    lifecycle::deprecate_warn(
+      "1.0.4.9005",
+      "predict_survival(time)",
+      "predict_survival(eval_time)"
+    )
+    eval_time <- time
+  }
 
   check_spec_pred_type(object, "survival")
 
@@ -25,7 +34,7 @@ predict_survival.model_fit <- function(object,
     new_data <- object$spec$method$pred$survival$pre(new_data, object)
 
   # Pass some extra arguments to be used in post-processor
-  object$spec$method$pred$survival$args$time <- time
+  object$spec$method$pred$survival$args$eval_time <- eval_time
   pred_call <- make_pred_call(object$spec$method$pred$survival)
 
   res <- eval_tidy(pred_call)

--- a/R/predict_survival.R
+++ b/R/predict_survival.R
@@ -4,35 +4,39 @@
 #' @method predict_survival model_fit
 #' @export predict_survival.model_fit
 #' @export
-predict_survival.model_fit <-
-  function(object, new_data, time, interval = "none", level = 0.95, ...) {
+predict_survival.model_fit <- function(object,
+                                       new_data,
+                                       time,
+                                       interval = "none",
+                                       level = 0.95,
+                                       ...) {
 
-    check_spec_pred_type(object, "survival")
+  check_spec_pred_type(object, "survival")
 
-    if (inherits(object$fit, "try-error")) {
-      rlang::warn("Model fit failed; cannot make predictions.")
-      return(NULL)
-    }
-
-    new_data <- prepare_data(object, new_data)
-
-    # preprocess data
-    if (!is.null(object$spec$method$pred$survival$pre))
-      new_data <- object$spec$method$pred$survival$pre(new_data, object)
-
-    # Pass some extra arguments to be used in post-processor
-    object$spec$method$pred$survival$args$time <- time
-    pred_call <- make_pred_call(object$spec$method$pred$survival)
-
-    res <- eval_tidy(pred_call)
-
-    # post-process the predictions
-    if(!is.null(object$spec$method$pred$survival$post)) {
-      res <- object$spec$method$pred$survival$post(res, object)
-    }
-
-    res
+  if (inherits(object$fit, "try-error")) {
+    rlang::warn("Model fit failed; cannot make predictions.")
+    return(NULL)
   }
+
+  new_data <- prepare_data(object, new_data)
+
+  # preprocess data
+  if (!is.null(object$spec$method$pred$survival$pre))
+    new_data <- object$spec$method$pred$survival$pre(new_data, object)
+
+  # Pass some extra arguments to be used in post-processor
+  object$spec$method$pred$survival$args$time <- time
+  pred_call <- make_pred_call(object$spec$method$pred$survival)
+
+  res <- eval_tidy(pred_call)
+
+  # post-process the predictions
+  if(!is.null(object$spec$method$pred$survival$post)) {
+    res <- object$spec$method$pred$survival$post(res, object)
+  }
+
+  res
+}
 
 #' @export
 #' @keywords internal

--- a/man/other_predict.Rd
+++ b/man/other_predict.Rd
@@ -23,7 +23,7 @@
 
 \method{predict_classprob}{model_fit}(object, new_data, ...)
 
-\method{predict_hazard}{model_fit}(object, new_data, time, ...)
+\method{predict_hazard}{model_fit}(object, new_data, eval_time, time = deprecated(), ...)
 
 \method{predict_confint}{model_fit}(object, new_data, level = 0.95, std_error = FALSE, ...)
 
@@ -44,7 +44,15 @@ predict_numeric(object, ...)
   ...
 )
 
-\method{predict_survival}{model_fit}(object, new_data, time, interval = "none", level = 0.95, ...)
+\method{predict_survival}{model_fit}(
+  object,
+  new_data,
+  eval_time,
+  time = deprecated(),
+  interval = "none",
+  level = 0.95,
+  ...
+)
 
 predict_survival(object, ...)
 
@@ -74,7 +82,7 @@ the standard error of fit or prediction (on the scale of the
 linear predictors). Default value is \code{FALSE}.
 \item \code{quantile}: for \code{type} equal to \code{quantile}, the quantiles of the
 distribution. Default is \code{(1:9)/10}.
-\item \code{time}: for \code{type} equal to \code{"survival"} or \code{"hazard"}, the
+\item \code{eval_time}: for \code{type} equal to \code{"survival"} or \code{"hazard"}, the
 time points at which the survival probability or hazard is estimated.
 }}
 

--- a/man/predict.model_fit.Rd
+++ b/man/predict.model_fit.Rd
@@ -44,7 +44,7 @@ the standard error of fit or prediction (on the scale of the
 linear predictors). Default value is \code{FALSE}.
 \item \code{quantile}: for \code{type} equal to \code{quantile}, the quantiles of the
 distribution. Default is \code{(1:9)/10}.
-\item \code{time}: for \code{type} equal to \code{"survival"} or \code{"hazard"}, the
+\item \code{eval_time}: for \code{type} equal to \code{"survival"} or \code{"hazard"}, the
 time points at which the survival probability or hazard is estimated.
 }}
 }
@@ -78,11 +78,11 @@ For \code{type = "time"}, the tibble has a \code{.pred_time} column.
 
 For \code{type = "survival"}, the tibble has a \code{.pred} column, which is
 a list-column. Each list element contains a tibble with columns
-\code{.time} and \code{.pred_survival} (and perhaps other columns).
+\code{.eval_time} and \code{.pred_survival} (and perhaps other columns).
 
 For \code{type = "hazard"}, the tibble has a \code{.pred} column, which is
 a list-column. Each list element contains a tibble with columns
-\code{.time} and \code{.pred_hazard} (and perhaps other columns).
+\code{.eval_time} and \code{.pred_hazard} (and perhaps other columns).
 
 Using \code{type = "raw"} with \code{predict.model_fit()} will return
 the unadulterated results of the prediction function.
@@ -118,7 +118,7 @@ extra column of standard error values (if available).
 
 \subsection{Censored regression predictions}{
 
-For censored regression, a numeric vector for \code{time} is required when
+For censored regression, a numeric vector for \code{eval_time} is required when
 survival or hazard probabilities are requested. Also, when
 \code{type = "linear_pred"}, censored regression models will by default be
 formatted such that the linear predictor \emph{increases} with time. This may


### PR DESCRIPTION
Closes #892

This PR deprecates the `time` argument to the prediction functions in favor of the `eval_time` argument name.

- `predict()` only takes this argument in the ellipsis, so I updated only the documentation. I replaced `time` with `eval_time`, i.e. there is no mention of any deprecation but instead a direct swap. Should this talk about deprecation as well? I was trying not to overload that help page since it contains so much already.
- `predict_survival()` and `predict_hazard()` both had a `time` argument. Now they have both `time` and `eval_time` as arguments, and `time` is deprecated, including updates to the documentation.

This PR starts the deprecation at `deprecate_warn()` rather than a soft-deprecation. Does that sound good?

Tests on this deprecation are going to have to sit in censored since we need an engine for those prediction types. parsnip does contain `surv_reg()`, but that uses the mode `"regression"` for which we don't predict survival or hazard probabilities.
