### PR TITLE
Keep IPCW results in the list column format predicted by the predict() methods

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: parsnip
 Title: A Common API to Modeling and Analysis Functions
-Version: 1.0.4.9005
+Version: 1.0.4.9006
 Authors@R: c(
     person("Max", "Kuhn", , "max@posit.co", role = c("aut", "cre")),
     person("Davis", "Vaughan", , "davis@posit.co", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,7 +36,7 @@ Imports:
     tibble (>= 2.1.1),
     tidyr (>= 1.3.0),
     utils,
-    vctrs (>= 0.4.1),
+    vctrs (>= 0.6.0),
     withr
 Suggests: 
     C50,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: parsnip
 Title: A Common API to Modeling and Analysis Functions
-Version: 1.0.4.9004
+Version: 1.0.4.9005
 Authors@R: c(
     person("Max", "Kuhn", , "max@posit.co", role = c("aut", "cre")),
     person("Davis", "Vaughan", , "davis@posit.co", role = "aut"),

--- a/R/ipcw.R
+++ b/R/ipcw.R
@@ -239,9 +239,8 @@ add_graf_weights_vec <- function(object, .pred, surv_obj, trunc = 0.05, eps = 10
   y$.weight_censored = 1 / y$.pred_censored
   # Convert back the list column format
   y$surv_obj <- NULL
-  inds <- purrr::map(1:n, ~ which(y$.row == .x))
   y$.row <- NULL
-  vctrs::vec_chop(y, inds)
+  vctrs::vec_chop(y, sizes = num_times)
 }
 
 .find_surv_col <- function(x, call = rlang::env_parent()) {

--- a/R/ipcw.R
+++ b/R/ipcw.R
@@ -250,7 +250,7 @@ add_graf_weights_vec <- function(object, .pred, surv_obj, trunc = 0.05, eps = 10
   # Compute the corresponding probability of being censored
   y$.pred_censored <- predict(object$censor_probs, time = y$.weight_time, as_vector = TRUE)
   y$.pred_censored <- trunc_probs(y$.pred_censored, trunc = trunc)
-  # Invert the probabilties to create weights
+  # Invert the probabilities to create weights
   y$.weight_censored = 1 / y$.pred_censored
   # Convert back the list column format
   y$surv_obj <- NULL

--- a/R/ipcw.R
+++ b/R/ipcw.R
@@ -228,7 +228,6 @@ add_graf_weights_vec <- function(object, .pred, surv_obj, trunc = 0.05, eps = 10
   num_times <- vctrs::list_sizes(.pred)
   y <- vctrs::list_unchop(.pred)
   y$surv_obj <- vctrs::vec_rep_each(surv_obj, times = num_times)
-  y$.row <- vctrs::vec_rep_each(1:n, times = num_times)
   names(y)[names(y) == ".time"] <- ".eval_time"   # Temporary
   # Compute the actual time of evaluation
   y$.weight_time <- graf_weight_time_vec(y$surv_obj, y$.eval_time, eps = eps)
@@ -239,7 +238,6 @@ add_graf_weights_vec <- function(object, .pred, surv_obj, trunc = 0.05, eps = 10
   y$.weight_censored = 1 / y$.pred_censored
   # Convert back the list column format
   y$surv_obj <- NULL
-  y$.row <- NULL
   vctrs::vec_chop(y, sizes = num_times)
 }
 

--- a/R/ipcw.R
+++ b/R/ipcw.R
@@ -189,7 +189,7 @@ graf_weight_time_vec <- function(surv_obj, eval_time, eps = 10^-10) {
                                              cens_predictors = NULL,
                                              trunc = 0.05, eps = 10^-10, ...) {
   if (is.null(object$fit$fit)) {
-    rlang::abort("The workflow does not have a model fit object.", call = FALSE)
+    rlang::abort("The workflow does not have a model fit object.")
   }
   .censoring_weights_graf(object$fit$fit, predictions, cens_predictors, trunc, eps)
 }

--- a/R/ipcw.R
+++ b/R/ipcw.R
@@ -24,9 +24,8 @@ trunc_probs <- function(probs, trunc = 0.01) {
   }
   # will still propagate nulls:
   eval_time <- eval_time[!is.na(eval_time)]
-  eval_time <- unique(eval_time)
-  eval_time <- sort(eval_time)
   eval_time <- eval_time[eval_time >= 0 & is.finite(eval_time)]
+  eval_time <- unique(eval_time)
   if (fail && identical(eval_time, numeric(0))) {
     rlang::abort(
       "There were no usable evaluation times (finite, non-missing, and >= 0).",
@@ -34,16 +33,6 @@ trunc_probs <- function(probs, trunc = 0.01) {
     )
   }
   eval_time
-}
-
-.find_surv_col <- function(x, call = rlang::env_parent()) {
-  is_lst_col <- purrr::map_lgl(x, purrr::is_list)
-  is_surv <- purrr::map_lgl(x[!is_lst_col], .is_surv, fail = FALSE)
-  num_surv <- sum(is_surv)
-  if (num_surv != 1) {
-    rlang::abort("There should be a single column of class `Surv`", call = call)
-  }
-  names(is_surv)[is_surv]
 }
 
 .check_pred_col <- function(x, call = rlang::env_parent()) {
@@ -253,6 +242,16 @@ add_graf_weights_vec <- function(object, .pred, surv_obj, trunc = 0.05, eps = 10
   inds <- purrr::map(1:n, ~ which(y$.row == .x))
   y$.row <- NULL
   vctrs::vec_chop(y, inds)
+}
+
+.find_surv_col <- function(x, call = rlang::env_parent()) {
+  is_lst_col <- purrr::map_lgl(x, purrr::is_list)
+  is_surv <- purrr::map_lgl(x[!is_lst_col], .is_surv, fail = FALSE)
+  num_surv <- sum(is_surv)
+  if (num_surv != 1) {
+    rlang::abort("There should be a single column of class `Surv`", call = call)
+  }
+  names(is_surv)[is_surv]
 }
 
 # nocov end

--- a/R/predict.R
+++ b/R/predict.R
@@ -49,9 +49,13 @@
 #'  ## Censored regression predictions
 #'
 #' For censored regression, a numeric vector for `eval_time` is required when
-#' survival or hazard probabilities are requested. Also, when
-#' `type = "linear_pred"`, censored regression models will by default be
-#' formatted such that the linear predictor _increases_ with time. This may
+#' survival or hazard probabilities are requested. The time values are required
+#' to be unique, finite, non-missing, and non-negative. The `predict()`
+#' functions will adjust the values to fit this specification by removing
+#' offending points (with a warning).
+#'
+#' Also, when `type = "linear_pred"`, censored regression models will by default
+#' be formatted such that the linear predictor _increases_ with time. This may
 #' have the opposite sign as what the underlying model's `predict()` method
 #' produces. Set `increasing = FALSE` to suppress this behavior.
 #'

--- a/R/predict_hazard.R
+++ b/R/predict_hazard.R
@@ -17,6 +17,7 @@ predict_hazard.model_fit <- function(object,
     )
     eval_time <- time
   }
+  eval_time <- .filter_eval_time(eval_time)
 
   check_spec_pred_type(object, "hazard")
 

--- a/R/predict_survival.R
+++ b/R/predict_survival.R
@@ -19,6 +19,7 @@ predict_survival.model_fit <- function(object,
     )
     eval_time <- time
   }
+  eval_time <- .filter_eval_time(eval_time)
 
   check_spec_pred_type(object, "survival")
 

--- a/man/censoring_weights.Rd
+++ b/man/censoring_weights.Rd
@@ -101,6 +101,14 @@ survival probability predictions at \code{eval_time = 3.0}, we would \emph{not} 
 about the probability of being censored at that exact time (since it has not
 occurred yet).
 
+When creating weights by inverting probabilities, there is the risk that a few
+cases will have severe outliers due to probabilities close to zero. To
+mitigate this, the \code{trunc} argument can be used to put a cap on the weights.
+If the smallest probability is greater than \code{trunc}, the probabilities with
+values less than \code{trunc} are given that value. Otherwise,  \code{trunc} is
+adjusted to be half of the smallest probability and that value is used as the
+lower bound..
+
 Note that if there are \code{n} rows in \code{data} and \code{t} time points, the resulting
 data, once unnested, has \code{n * t} rows. Computations will not easily scale
 well as \code{t} becomes very large.

--- a/man/censoring_weights.Rd
+++ b/man/censoring_weights.Rd
@@ -97,7 +97,7 @@ computed by inverting the censoring probability.
 The \code{eps} argument is used to avoid information leakage when computing the
 censoring probability. Subtracting a small number avoids using data that
 would not be known at the time of prediction. For example, if we are making
-survival probability predictions at \code{eval_time = 3.0}, we would not know the
+survival probability predictions at \code{eval_time = 3.0}, we would \emph{not} know the
 about the probability of being censored at that exact time (since it has not
 occurred yet).
 

--- a/man/censoring_weights.Rd
+++ b/man/censoring_weights.Rd
@@ -14,9 +14,7 @@
 
 \method{.censoring_weights_graf}{workflow}(
   object,
-  data,
-  eval_time,
-  rows = NULL,
+  predictions,
   predictors = NULL,
   trunc = 0.05,
   eps = 10^-10,
@@ -25,9 +23,7 @@
 
 \method{.censoring_weights_graf}{model_fit}(
   object,
-  data,
-  eval_time,
-  rows = NULL,
+  predictions,
   predictors = NULL,
   trunc = 0.05,
   eps = 10^-10,
@@ -38,17 +34,12 @@
 \item{object}{A fitted parsnip model object or fitted workflow with a mode
 of "censored regression".}
 
-\item{data}{A data frame with a column containing a \code{\link[survival:Surv]{survival::Surv()}} object.}
-
-\item{eval_time}{A vector of finite, non-negative times at which to
-compute the probability of censoring and the corresponding weights.}
-
-\item{rows}{An optional integer vector with length equal to the number of
-rows in \code{data} that is used to index the original data. The default is to
-use a fresh index on data (i.e. \code{1:nrow(data)}).}
+\item{predictions}{A data frame with a column containing a \code{\link[survival:Surv]{survival::Surv()}}
+object as well as a list column called \code{.pred} that contains the data
+structure produced by \code{\link[=predict.model_fit]{predict.model_fit()}}.}
 
 \item{predictors}{Not currently used. A potential future slot for models with
-informative censoring based on columns in \code{data}.}
+informative censoring based on columns in \code{predictions}.}
 
 \item{trunc}{A potential lower bound for the probability of censoring to avoid
 very large weight values.}
@@ -57,15 +48,21 @@ very large weight values.}
 computing the censoring probabilities. See Details below.}
 }
 \value{
-A tibble with columns \code{.row}, \code{eval_time}, \code{.prob_cens} (the
-probability of being censored just prior to the evaluation time), and
-\code{.weight_cens} (the inverse probability of censoring weight).
+The same data are returned with the \code{pred} tibbles containing
+several new columns:
+\itemize{
+\item \code{.weight_time}: the time at which the inverse censoring probability weights
+are computed. This is a function of the observed time and the time of
+analysis (i.e., \code{eval_time}). See Details for more information.
+\item \code{.pred_censored}: the probability of being censored at \code{.weight_time}.
+\item \code{.weight_censored}: The inverse of the censoring probability.
+}
 }
 \description{
 The method of Graf \emph{et al} (1999) is used to compute weights at specific
 evaluation times that can be used to help measure a model's time-dependent
 performance (e.g. the time-dependent Brier score or the area under the ROC
-curve).
+curve). This is an internal function.
 }
 \details{
 A probability that the data are censored immediately prior to a specific
@@ -105,8 +102,8 @@ about the probability of being censored at that exact time (since it has not
 occurred yet).
 
 Note that if there are \code{n} rows in \code{data} and \code{t} time points, the resulting
-data has \code{n * t} rows. Computations will not easily scale well as \code{t} becomes
-large.
+data, once unnested, has \code{n * t} rows. Computations will not easily scale
+well as \code{t} becomes very large.
 }
 \references{
 Graf, E., Schmoor, C., Sauerbrei, W. and Schumacher, M. (1999),

--- a/man/censoring_weights.Rd
+++ b/man/censoring_weights.Rd
@@ -15,7 +15,7 @@
 \method{.censoring_weights_graf}{workflow}(
   object,
   predictions,
-  predictors = NULL,
+  cens_predictors = NULL,
   trunc = 0.05,
   eps = 10^-10,
   ...
@@ -24,7 +24,7 @@
 \method{.censoring_weights_graf}{model_fit}(
   object,
   predictions,
-  predictors = NULL,
+  cens_predictors = NULL,
   trunc = 0.05,
   eps = 10^-10,
   ...
@@ -38,7 +38,7 @@ of "censored regression".}
 object as well as a list column called \code{.pred} that contains the data
 structure produced by \code{\link[=predict.model_fit]{predict.model_fit()}}.}
 
-\item{predictors}{Not currently used. A potential future slot for models with
+\item{cens_predictors}{Not currently used. A potential future slot for models with
 informative censoring based on columns in \code{predictions}.}
 
 \item{trunc}{A potential lower bound for the probability of censoring to avoid

--- a/man/predict.model_fit.Rd
+++ b/man/predict.model_fit.Rd
@@ -119,9 +119,13 @@ extra column of standard error values (if available).
 \subsection{Censored regression predictions}{
 
 For censored regression, a numeric vector for \code{eval_time} is required when
-survival or hazard probabilities are requested. Also, when
-\code{type = "linear_pred"}, censored regression models will by default be
-formatted such that the linear predictor \emph{increases} with time. This may
+survival or hazard probabilities are requested. The time values are required
+to be unique, finite, non-missing, and non-negative. The \code{predict()}
+functions will adjust the values to fit this specification by removing
+offending points (with a warning).
+
+Also, when \code{type = "linear_pred"}, censored regression models will by default
+be formatted such that the linear predictor \emph{increases} with time. This may
 have the opposite sign as what the underlying model's \code{predict()} method
 produces. Set \code{increasing = FALSE} to suppress this behavior.
 }

--- a/tests/testthat/_snaps/ipcw.md
+++ b/tests/testthat/_snaps/ipcw.md
@@ -1,5 +1,13 @@
 # time filtering
 
+    There were 3 inappropriate evaluation time points that were removed.
+
+---
+
+    There was 1 inappropriate evaluation time point that was removed.
+
+---
+
     Code
       parsnip:::.filter_eval_time(-1)
     Condition

--- a/tests/testthat/_snaps/translate.md
+++ b/tests/testthat/_snaps/translate.md
@@ -2142,7 +2142,7 @@
       .model_param_name_key(linear_reg())
     Output
       # A tibble: 0 x 3
-      # ... with 3 variables: user <chr>, parsnip <chr>, engine <chr>
+      # i 3 variables: user <chr>, parsnip <chr>, engine <chr>
 
 ---
 

--- a/tests/testthat/test-ipcw.R
+++ b/tests/testthat/test-ipcw.R
@@ -49,6 +49,8 @@ test_that('time filtering', {
     parsnip:::.filter_eval_time(times_3),
     times_3
   )
+  expect_snapshot_warning(parsnip:::.filter_eval_time(times_2))
+  expect_snapshot_warning(parsnip:::.filter_eval_time(times_2[3:4]))
   expect_snapshot(error = TRUE, parsnip:::.filter_eval_time(-1))
   expect_null(parsnip:::.filter_eval_time(NULL))
 })

--- a/tests/testthat/test-ipcw.R
+++ b/tests/testthat/test-ipcw.R
@@ -35,6 +35,7 @@ test_that('probability truncation', {
 test_that('time filtering', {
   times_1 <- 0:10
   times_2 <- c(Inf, NA, -3, times_1, times_1)
+  times_3 <- c(10, 1:9)
 
   expect_equal(
     parsnip:::.filter_eval_time(times_1),
@@ -43,6 +44,10 @@ test_that('time filtering', {
   expect_equal(
     parsnip:::.filter_eval_time(times_1),
     times_1
+  )
+  expect_equal(
+    parsnip:::.filter_eval_time(times_3),
+    times_3
   )
   expect_snapshot(error = TRUE, parsnip:::.filter_eval_time(-1))
   expect_null(parsnip:::.filter_eval_time(NULL))


### PR DESCRIPTION
The current code unnests the data. This is a problem if we also are using static predictions (like the predicted event time). 

This PR keeps the list format and adds the required columns to each tibble within the list. 