### PR TITLE
bump minimum dplyr version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,7 @@ Depends:
     R (>= 3.5)
 Imports: 
     cli,
-    dplyr (>= 0.8.0.1),
+    dplyr (>= 1.1.0),
     generics (>= 0.1.2),
     ggplot2,
     globals,

--- a/R/glmnet-engines.R
+++ b/R/glmnet-engines.R
@@ -254,11 +254,7 @@ format_glmnet_multi_linear_reg <- function(pred, penalty) {
   pred$.row <- seq_len(nrow(pred))
   pred <- tidyr::pivot_longer(pred, -.row, names_to = "s", values_to = ".pred")
 
-  if (utils::packageVersion("dplyr") >= "1.0.99.9000") {
-    pred <- dplyr::full_join(penalty_key, pred, by = "s", multiple = "all")
-  } else {
-    pred <- dplyr::full_join(penalty_key, pred, by = "s")
-  }
+  pred <- dplyr::full_join(penalty_key, pred, by = "s", multiple = "all")
 
   pred <- pred %>%
     dplyr::select(-s) %>%
@@ -290,11 +286,7 @@ format_glmnet_multi_logistic_reg <- function(pred, penalty, type, lvl) {
       dplyr::select(c(".row", "s", paste0(".pred_", lvl)))
   }
 
-  if (utils::packageVersion("dplyr") >= "1.0.99.9000") {
-    pred <- dplyr::full_join(penalty_key, pred, by = "s", multiple = "all")
-  } else {
-    pred <- dplyr::full_join(penalty_key, pred, by = "s")
-  }
+  pred <- dplyr::full_join(penalty_key, pred, by = "s", multiple = "all")
 
   pred <- pred %>%
     dplyr::select(-s) %>%


### PR DESCRIPTION
Doing a quick speed audit on stacks right now to see if there's any low-hanging fruit, and this call to `packageVersion()` took up a pretty substantial amount of time. This PR proposes bumping the minimum dplyr version and writing out that conditional statement.

EDIT: Couldn't find it at first, but just confirmed we thumbs-upped a bump in minimum dplyr version in `#tidymodels-internal`.