### PR TITLE
transition v0.1.6 and v0.1.8 `soft`-deprecations to `warn`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,8 @@
 
 * The minimum version for R is now 3.5 (#926).
 
+* Transitioned all soft-deprecations that were at least a year old to warn-deprecations. These changes apply to `fit_control()`, `surv_reg()`, `varying()`, `varying_args()`, and the `"liquidSVM"` engine.
+
 * The `time` argument to `predict_survival()` and `predict_hazard()` is deprecated in favor of the new `eval_time` argument (#936).
 
 

--- a/R/engines.R
+++ b/R/engines.R
@@ -126,7 +126,7 @@ set_engine.model_spec <- function(object, engine, ...) {
   }
 
   if (object$engine == "liquidSVM") {
-    lifecycle::deprecate_soft(
+    lifecycle::deprecate_warn(
       "0.1.6",
       "set_engine(engine = 'cannot be liquidSVM')",
       details = "The liquidSVM package is no longer available on CRAN.")

--- a/R/fit_control.R
+++ b/R/fit_control.R
@@ -27,6 +27,6 @@
 #' @export
 #' @keywords internal
 fit_control <- function(verbosity = 1L, catch = FALSE) {
-  lifecycle::deprecate_soft("0.1.8", "fit_control()", "control_parsnip()")
+  lifecycle::deprecate_warn("0.1.8", "fit_control()", "control_parsnip()")
   control_parsnip(verbosity = verbosity, catch = catch)
 }

--- a/R/surv_reg.R
+++ b/R/surv_reg.R
@@ -37,7 +37,7 @@
 #' @export
 surv_reg <- function(mode = "regression", engine = "survival", dist = NULL) {
 
-  lifecycle::deprecate_soft("0.1.6", "surv_reg()", "survival_reg()")
+  lifecycle::deprecate_warn("0.1.6", "surv_reg()", "survival_reg()")
 
     args <- list(
       dist = enquo(dist)

--- a/R/surv_reg.R
+++ b/R/surv_reg.R
@@ -3,11 +3,10 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' This function is soft-deprecated in favor of `survival_reg()` which uses the
+#' This function is deprecated in favor of `survival_reg()` which uses the
 #' `"censored regression"` mode.
 #'
 #' `surv_reg()` defines a parametric survival model.
-
 #'
 #' More information on how \pkg{parsnip} is used for modeling is at
 #' \url{https://www.tidymodels.org/}.

--- a/R/surv_reg.R
+++ b/R/surv_reg.R
@@ -9,8 +9,6 @@
 #' `surv_reg()` defines a parametric survival model.
 
 #'
-#' \Sexpr[stage=render,results=rd]{parsnip:::make_engine_list("surv_reg")}
-#'
 #' More information on how \pkg{parsnip} is used for modeling is at
 #' \url{https://www.tidymodels.org/}.
 #'
@@ -27,12 +25,6 @@
 #'
 #' @template spec-references
 #'
-#' @seealso \Sexpr[stage=render,results=rd]{parsnip:::make_seealso_list("surv_reg")}
-#'
-#' @examples
-#' show_engines("surv_reg")
-#'
-#' surv_reg(mode = "regression", dist = "weibull")
 #' @keywords internal
 #' @export
 surv_reg <- function(mode = "regression", engine = "survival", dist = NULL) {

--- a/R/varying.R
+++ b/R/varying.R
@@ -7,7 +7,7 @@
 #' @export
 #' @keywords internal
 varying <- function() {
-  lifecycle::deprecate_soft("0.1.8", "varying()", "hardhat::tune()")
+  lifecycle::deprecate_warn("0.1.8", "varying()", "hardhat::tune()")
   quote(varying())
 }
 
@@ -68,7 +68,7 @@ generics::varying_args
 #' @keywords internal
 #' @export
 varying_args.model_spec <- function(object, full = TRUE, ...) {
-  lifecycle::deprecate_soft("0.1.8", "varying_args()", "tune_args()")
+  lifecycle::deprecate_warn("0.1.8", "varying_args()", "tune_args()")
 
   # use the model_spec top level class as the id
   id <- class(object)[1]
@@ -104,7 +104,7 @@ varying_args.model_spec <- function(object, full = TRUE, ...) {
 #' @export
 #' @rdname varying_args
 varying_args.recipe <- function(object, full = TRUE, ...) {
-  lifecycle::deprecate_soft("0.1.8", "varying_args()", "tune_args()")
+  lifecycle::deprecate_warn("0.1.8", "varying_args()", "tune_args()")
 
   steps <- object$steps
 
@@ -118,7 +118,7 @@ varying_args.recipe <- function(object, full = TRUE, ...) {
 #' @export
 #' @rdname varying_args
 varying_args.step <- function(object, full = TRUE, ...) {
-  lifecycle::deprecate_soft("0.1.8", "varying_args()", "tune_args()")
+  lifecycle::deprecate_warn("0.1.8", "varying_args()", "tune_args()")
 
   # Unique step id
   id <- object$id

--- a/man/surv_reg.Rd
+++ b/man/surv_reg.Rd
@@ -19,7 +19,7 @@ outcome. The default is "weibull".}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-This function is soft-deprecated in favor of \code{survival_reg()} which uses the
+This function is deprecated in favor of \code{survival_reg()} which uses the
 \code{"censored regression"} mode.
 
 \code{surv_reg()} defines a parametric survival model.

--- a/man/surv_reg.Rd
+++ b/man/surv_reg.Rd
@@ -24,8 +24,6 @@ This function is soft-deprecated in favor of \code{survival_reg()} which uses th
 
 \code{surv_reg()} defines a parametric survival model.
 
-\Sexpr[stage=render,results=rd]{parsnip:::make_engine_list("surv_reg")}
-
 More information on how \pkg{parsnip} is used for modeling is at
 \url{https://www.tidymodels.org/}.
 }
@@ -50,15 +48,7 @@ Since survival models typically involve censoring (and require the use of
 \code{\link[survival:Surv]{survival::Surv()}} objects), the \code{\link[=fit.model_spec]{fit.model_spec()}} function will require that the
 survival model be specified via the formula interface.
 }
-\examples{
-show_engines("surv_reg")
-
-surv_reg(mode = "regression", dist = "weibull")
-}
 \references{
 \url{https://www.tidymodels.org}, \href{https://www.tmwr.org/}{\emph{Tidy Modeling with R}}, \href{https://www.tidymodels.org/find/parsnip/}{searchable table of parsnip models}
-}
-\seealso{
-\Sexpr[stage=render,results=rd]{parsnip:::make_seealso_list("surv_reg")}
 }
 \keyword{internal}


### PR DESCRIPTION
It has now been at least a year since each of these were soft-deprecated. :)