### PR TITLE
don't use colon programatically

### DIFF
--- a/R/adds.R
+++ b/R/adds.R
@@ -9,11 +9,7 @@ add_rowindex <- function(x) {
   if (!is.data.frame(x)) {
     rlang::abort("`x` should be a data frame.")
   }
-  if (nrow(x) > 0) {
-    x <- dplyr::mutate(x, .row = 1:nrow(x))
-  } else {
-    x$.row <- integer(0)
-  }
+  x <- dplyr::mutate(x, .row = seq_len(nrow(x)))
   x
 }
 

--- a/R/autoplot.R
+++ b/R/autoplot.R
@@ -81,7 +81,7 @@ top_coefs <- function(x, top_n = 5) {
     dplyr::slice(1) %>%
     dplyr::ungroup() %>%
     dplyr::arrange(dplyr::desc(abs(estimate))) %>%
-    dplyr::slice(1:top_n)
+    dplyr::slice(seq_len(top_n))
 }
 
 autoplot_glmnet <- function(x, min_penalty = 0, best_penalty = NULL, top_n = 3L, ...) {

--- a/R/boost_tree.R
+++ b/R/boost_tree.R
@@ -434,7 +434,7 @@ as_xgb_data <- function(x, y, validation = 0, weights = NULL, event_level = "fir
     if (validation > 0) {
       # Split data
       m <- floor(n * (1 - validation)) + 1
-      trn_index <- sample(1:n, size = max(m, 2))
+      trn_index <- sample(seq_len(n), size = max(m, 2))
       val_data <- xgboost::xgb.DMatrix(x[-trn_index,], label = y[-trn_index], missing = NA)
       watch_list <- list(validation = val_data)
 
@@ -526,7 +526,7 @@ xgb_by_tree <- function(tree, object, new_data, type, ...) {
     nms <- names(pred)
   }
   pred[["trees"]] <- tree
-  pred[[".row"]] <- 1:nrow(new_data)
+  pred[[".row"]] <- seq_len(nrow(new_data))
   pred[, c(".row", "trees", nms)]
 }
 
@@ -635,7 +635,7 @@ C50_by_tree <- function(tree, object, new_data, type, ...) {
   }
   nms <- names(pred)
   pred[["trees"]] <- tree
-  pred[[".row"]] <- 1:nrow(new_data)
+  pred[[".row"]] <- seq_len(nrow(new_data))
   pred[, c(".row", "trees", nms)]
 }
 

--- a/R/mars.R
+++ b/R/mars.R
@@ -199,6 +199,6 @@ earth_by_terms <- function(num_terms, object, new_data, type, ...) {
   pred <- predict(object, new_data = new_data, type = type)
   nms <- names(pred)
   pred[["num_terms"]] <- num_terms
-  pred[[".row"]] <- 1:nrow(new_data)
+  pred[[".row"]] <- seq_len(nrow(new_data))
   pred[, c(".row", "num_terms", nms)]
 }

--- a/R/misc.R
+++ b/R/misc.R
@@ -292,7 +292,7 @@ names0 <- function(num, prefix = "x") {
   if (num < 1) {
     rlang::abort("`num` should be > 0.")
   }
-  ind <- format(1:num)
+  ind <- format(seq_len(num))
   ind <- gsub(" ", "0", ind)
   paste0(prefix, ind)
 }

--- a/R/mlp.R
+++ b/R/mlp.R
@@ -384,7 +384,7 @@ multi_predict._torch_mlp <-
       purrr::map(epochs,
                  ~ predict(object, new_data, type, epochs = .x) %>%
                    dplyr::mutate(epochs = .x)) %>%
-      purrr::map(~ .x %>% dplyr::mutate(.row = 1:nrow(new_data))) %>%
+      purrr::map(~ .x %>% dplyr::mutate(.row = seq_len(nrow(new_data)))) %>%
       purrr::list_rbind() %>%
       dplyr::arrange(.row, epochs)
     res <- split(dplyr::select(res, -.row), res$.row)

--- a/R/surv_reg.R
+++ b/R/surv_reg.R
@@ -115,7 +115,7 @@ survreg_quant <- function(results, object) {
   results <-
     results %>%
     as_tibble() %>%
-    mutate(.row = 1:n) %>%
+    mutate(.row = seq_len(n)) %>%
     gather(.label, .pred, -.row) %>%
     arrange(.row, .label) %>%
     mutate(.quantile = rep(pctl, n)) %>%


### PR DESCRIPTION
I noticed there are a couple of places where we use `:` that could be replaced with `seq_*()` to make the code a little more robust