### PR TITLE
speed up `ensure_parsnip_format()`

### DIFF
--- a/R/predict.R
+++ b/R/predict.R
@@ -302,7 +302,7 @@ format_hazard <- function(x) {
 
 ensure_parsnip_format <- function(x, col_name, overwrite = TRUE) {
   if (isTRUE(ncol(x) > 1) | is.data.frame(x)) {
-    x <- as_tibble(x, .name_repair = "minimal")
+    x <- tibble::new_tibble(x)
     if (!any(grepl(paste0("^\\", col_name), names(x)))) {
       if (overwrite) {
         names(x) <- col_name
@@ -311,7 +311,8 @@ ensure_parsnip_format <- function(x, col_name, overwrite = TRUE) {
       }
     }
   } else {
-    x <- tibble(unname(x))
+    x <- tibble::new_tibble(vctrs::df_list(unname(x), .name_repair = "minimal"),
+                            nrow = length(x))
     names(x) <- col_name
     x
   }


### PR DESCRIPTION
A helper that gets a good bit of traffic at `predict()`.

With `main` dev:

``` r
library(parsnip)

lm_fit <- fit(linear_reg(), mpg ~ ., mtcars)

bench::mark(old = predict(lm_fit, mtcars))
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 old           619µs    654µs     1476.    1.08MB     35.9
```

With this PR:

``` r
bench::mark(new = predict(lm_fit, mtcars))
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 new           389µs    404µs     2419.     599KB     40.3
```

<sup>Created on 2023-04-02 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>