### PR TITLE
transition to `vec_slice()` in `get_pkgs()`

### DIFF
--- a/R/required_pkgs.R
+++ b/R/required_pkgs.R
@@ -37,9 +37,9 @@ required_pkgs.model_fit <- function(x, infra = TRUE, ...) {
 
 get_pkgs <- function(x, infra) {
   cls <- class(x)[1]
-  pkgs <-
-    get_from_env(paste0(cls, "_pkgs")) %>%
-    dplyr::filter(engine == x$engine)
+  pkgs <- get_from_env(paste0(cls, "_pkgs"))
+  pkgs <- vctrs::vec_slice(pkgs, pkgs$engine == x$engine)
+
   if (length(pkgs$pkg) == 0) {
     res <- character(0)
   } else {


### PR DESCRIPTION
With main dev:

``` r
library(tidymodels)
  
set.seed(1)

bench::mark(
  old = 
    fit_resamples(
      linear_reg(),
      mpg ~ .,
      bootstraps(mtcars)
    )
)
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 old           210ms    213ms      4.61    14.2MB     7.68
```

With this PR:

``` r
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 new           201ms    204ms      4.77    14.1MB     7.96
```

<sup>Created on 2023-05-01 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
