### PR TITLE
survival model fit augmentation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: parsnip
 Title: A Common API to Modeling and Analysis Functions
-Version: 1.1.0.9000
+Version: 1.1.0.9001
 Authors@R: c(
     person("Max", "Kuhn", , "max@posit.co", role = c("aut", "cre")),
     person("Davis", "Vaughan", , "davis@posit.co", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # parsnip (development version)
 
+* `augment()` now works for censored regression models. 
+
 # parsnip 1.1.0
 
 This release of parsnip contains a number of new features and bug fixes, accompanied by several optimizations that substantially decrease the time to `fit()` and `predict()` with the package.

--- a/R/augment.R
+++ b/R/augment.R
@@ -22,10 +22,14 @@
 #'
 #' ## Censored Regression
 #'
-#' For these models, predictions for the expected time, survival, probability,
-#' and linear predictor are created (if the model engine supports them). If the
-#' model supports survival prediction, the `eval_time` argument is required.
+#' For these models, predictions for the expected time and survival probability
+#' re created (if the model engine supports them). If the model supports
+#' survival prediction, the `eval_time` argument is required.
 #'
+#' If survival predictions are created and `new_data` contains a
+#' [survival::Surv()] object, additional columns are added for inverse
+#' probability of censoring weights (IPCW) are also created. This enables the
+#' user to compute performance metrics in the \pkg{yardstick} package.
 #'
 #' @param new_data A data frame or matrix.
 #' @param ... Not currently used.

--- a/R/augment.R
+++ b/R/augment.R
@@ -2,7 +2,6 @@
 #'
 #' `augment()` will add column(s) for predictions to the given data.
 #'
-
 #' @param x A `model_fit` object produced by [fit.model_spec()] or
 #' [fit_xy.model_spec()].
 #' @param eval_time For censored regression models, a vector of time points at

--- a/R/augment.R
+++ b/R/augment.R
@@ -71,6 +71,7 @@ augment.model_fit <- function(x, new_data, eval_time = NULL, ...) {
 }
 
 augment_regression <- function(x, new_data) {
+  ret <- new_data
   check_spec_pred_type(x, "numeric")
   ret <-
     ret %>%
@@ -87,6 +88,7 @@ augment_regression <- function(x, new_data) {
 }
 
 augment_classification <- function(x, new_data) {
+  ret <- new_data
   if (spec_has_pred_type(x, "class")) {
     ret <- dplyr::bind_cols(
       ret,
@@ -105,19 +107,19 @@ augment_classification <- function(x, new_data) {
 
 augment_censored <- function(x, new_data, eval_time = NULL) {
   ret <- new_data
-  if (parsnip:::spec_has_pred_type(x, "survival")) {
-    parsnip:::.filter_eval_time(eval_time)
+  if (spec_has_pred_type(x, "survival")) {
+    .filter_eval_time(eval_time)
     ret <- dplyr::bind_cols(
       ret,
       predict(x, new_data = new_data, type = "survival", eval_time = eval_time)
     )
     # Add inverse probability weights when the outcome is present in new_data
-    y_col <- parsnip:::.find_surv_col(new_data, fail = FALSE)
+    y_col <- .find_surv_col(new_data, fail = FALSE)
     if (length(y_col) != 0) {
       ret <- .censoring_weights_graf(x, ret)
     }
   }
-  if (parsnip:::spec_has_pred_type(x, "time")) {
+  if (spec_has_pred_type(x, "time")) {
     ret <- dplyr::bind_cols(
       ret,
       predict(x, new_data = new_data, type = "time")

--- a/R/augment.R
+++ b/R/augment.R
@@ -67,7 +67,7 @@ augment.model_fit <- function(x, new_data, eval_time = NULL, ...) {
   } else {
     rlang::abort(paste("Unknown mode:", x$spec$mode))
   }
-  as_tibble(res)
+  tibble::new_tibble(res)
 }
 
 augment_regression <- function(x, new_data) {
@@ -84,7 +84,7 @@ augment_regression <- function(x, new_data) {
       ret <- dplyr::mutate(ret, .resid = !!rlang::sym(y_nm) - .pred)
     }
   }
-  dplyr::relocate(ret, dplyr::starts_with(".pred"))
+  dplyr::relocate(ret, dplyr::starts_with(".pred"), dplyr::starts_with(".resid"))
 }
 
 augment_classification <- function(x, new_data) {

--- a/R/augment.R
+++ b/R/augment.R
@@ -109,8 +109,6 @@ augment_regression <- function(x, new_data) {
   dplyr::relocate(ret, dplyr::starts_with(".pred"), dplyr::starts_with(".resid"))
 }
 
-# nocov start
-# tested in tidymodels/extratests#
 augment_classification <- function(x, new_data) {
   ret <- new_data
   if (spec_has_pred_type(x, "class")) {
@@ -127,10 +125,9 @@ augment_classification <- function(x, new_data) {
   }
   dplyr::relocate(ret, dplyr::starts_with(".pred"))
 }
-# nocov end
 
-
-
+# nocov start
+# tested in tidymodels/extratests#
 augment_censored <- function(x, new_data, eval_time = NULL) {
   ret <- new_data
   if (spec_has_pred_type(x, "survival")) {
@@ -153,5 +150,4 @@ augment_censored <- function(x, new_data, eval_time = NULL) {
   }
   dplyr::relocate(ret, dplyr::starts_with(".pred"))
 }
-
-
+# nocov end

--- a/R/augment.R
+++ b/R/augment.R
@@ -63,7 +63,7 @@ augment.model_fit <- function(x, new_data, eval_time = NULL, ...) {
   } else if (x$spec$mode == "classification") {
     res <- augment_classification(x, new_data)
   } else if (x$spec$mode == "censored regression") {
-    res <- augment_classification(x, new_data)
+    res <- augment_censored(x, new_data, eval_time = eval_time)
   } else {
     rlang::abort(paste("Unknown mode:", x$spec$mode))
   }

--- a/R/augment.R
+++ b/R/augment.R
@@ -81,7 +81,7 @@ augment_regression <- function(x, new_data) {
       ret <- dplyr::mutate(ret, .resid = !!rlang::sym(y_nm) - .pred)
     }
   }
-  ret
+  dplyr::relocate(ret, dplyr::starts_with(".pred"))
 }
 
 augment_classification <- function(x, new_data) {
@@ -97,6 +97,6 @@ augment_classification <- function(x, new_data) {
       predict(x, new_data = new_data, type = "prob")
     )
   }
-  ret
+  dplyr::relocate(ret, dplyr::starts_with(".pred"))
 }
 

--- a/R/augment.R
+++ b/R/augment.R
@@ -22,7 +22,7 @@
 #' ## Censored Regression
 #'
 #' For these models, predictions for the expected time and survival probability
-#' re created (if the model engine supports them). If the model supports
+#' are created (if the model engine supports them). If the model supports
 #' survival prediction, the `eval_time` argument is required.
 #'
 #' If survival predictions are created and `new_data` contains a

--- a/R/survival-censoring-weights.R
+++ b/R/survival-censoring-weights.R
@@ -257,11 +257,11 @@ add_graf_weights_vec <- function(object, .pred, surv_obj, trunc = 0.05, eps = 10
   vctrs::vec_chop(y, sizes = num_times)
 }
 
-.find_surv_col <- function(x, call = rlang::env_parent()) {
+.find_surv_col <- function(x, call = rlang::env_parent(), fail = TRUE) {
   is_lst_col <- purrr::map_lgl(x, purrr::is_list)
   is_surv <- purrr::map_lgl(x[!is_lst_col], .is_surv, fail = FALSE)
   num_surv <- sum(is_surv)
-  if (num_surv != 1) {
+  if (fail && num_surv != 1) {
     rlang::abort("There should be a single column of class `Surv`", call = call)
   }
   names(is_surv)[is_surv]

--- a/man/augment.Rd
+++ b/man/augment.Rd
@@ -4,7 +4,7 @@
 \alias{augment.model_fit}
 \title{Augment data with predictions}
 \usage{
-\method{augment}{model_fit}(x, new_data, ...)
+\method{augment}{model_fit}(x, new_data, eval_time = NULL, ...)
 }
 \arguments{
 \item{x}{A \code{model_fit} object produced by \code{\link[=fit.model_spec]{fit.model_spec()}} or

--- a/man/augment.Rd
+++ b/man/augment.Rd
@@ -37,9 +37,14 @@ This depends on what type of prediction types are available for the model.
 
 \subsection{Censored Regression}{
 
-For these models, predictions for the expected time, survival, probability,
-and linear predictor are created (if the model engine supports them). If the
-model supports survival prediction, the \code{eval_time} argument is required.
+For these models, predictions for the expected time and survival probability
+re created (if the model engine supports them). If the model supports
+survival prediction, the \code{eval_time} argument is required.
+
+If survival predictions are created and \code{new_data} contains a
+\code{\link[survival:Surv]{survival::Surv()}} object, additional columns are added for inverse
+probability of censoring weights (IPCW) are also created. This enables the
+user to compute performance metrics in the \pkg{yardstick} package.
 }
 }
 \examples{

--- a/man/augment.Rd
+++ b/man/augment.Rd
@@ -8,9 +8,12 @@
 }
 \arguments{
 \item{x}{A \code{model_fit} object produced by \code{\link[=fit.model_spec]{fit.model_spec()}} or
-\code{\link[=fit_xy.model_spec]{fit_xy.model_spec()}} .}
+\code{\link[=fit_xy.model_spec]{fit_xy.model_spec()}}.}
 
 \item{new_data}{A data frame or matrix.}
+
+\item{eval_time}{For censored regression models, a vector of time points at
+which the survival probability is estimated.}
 
 \item{...}{Not currently used.}
 }
@@ -18,13 +21,26 @@
 \code{augment()} will add column(s) for predictions to the given data.
 }
 \details{
+\subsection{Regression}{
+
 For regression models, a \code{.pred} column is added. If \code{x} was created using
-\code{\link[=fit.model_spec]{fit.model_spec()}} and \code{new_data} contains the outcome column, a \code{.resid} column is
-also added.
+\code{\link[=fit.model_spec]{fit.model_spec()}} and \code{new_data} contains a regression outcome column, a
+\code{.resid} column is also added.
+}
+
+\subsection{Classification}{
 
 For classification models, the results can include a column called
 \code{.pred_class} as well as class probability columns named \verb{.pred_\{level\}}.
 This depends on what type of prediction types are available for the model.
+}
+
+\subsection{Censored Regression}{
+
+For these models, predictions for the expected time, survival, probability,
+and linear predictor are created (if the model engine supports them). If the
+model supports survival prediction, the \code{eval_time} argument is required.
+}
 }
 \examples{
 car_trn <- mtcars[11:32,]

--- a/man/augment.Rd
+++ b/man/augment.Rd
@@ -38,7 +38,7 @@ This depends on what type of prediction types are available for the model.
 \subsection{Censored Regression}{
 
 For these models, predictions for the expected time and survival probability
-re created (if the model engine supports them). If the model supports
+are created (if the model engine supports them). If the model supports
 survival prediction, the \code{eval_time} argument is required.
 
 If survival predictions are created and \code{new_data} contains a

--- a/tests/testthat/test_augment.R
+++ b/tests/testthat/test_augment.R
@@ -6,27 +6,31 @@ test_that('regression models', {
 
   expect_equal(
     colnames(augment(reg_form, head(mtcars))),
-    c("mpg", "cyl", "disp", "hp", "drat", "wt", "qsec", "vs", "am",
-      "gear", "carb", ".pred", ".resid")
+    c( ".pred", ".resid",
+       "mpg", "cyl", "disp", "hp", "drat", "wt", "qsec", "vs", "am",
+      "gear", "carb")
   )
   expect_equal(nrow(augment(reg_form, head(mtcars))), 6)
   expect_equal(
     colnames(augment(reg_form, head(mtcars[, -1]))),
-    c("cyl", "disp", "hp", "drat", "wt", "qsec", "vs", "am",
-      "gear", "carb", ".pred")
+    c(".pred",
+    "cyl", "disp", "hp", "drat", "wt", "qsec", "vs", "am",
+      "gear", "carb")
   )
   expect_equal(nrow(augment(reg_form, head(mtcars[, -1]))), 6)
 
   expect_equal(
     colnames(augment(reg_xy, head(mtcars))),
-    c("mpg", "cyl", "disp", "hp", "drat", "wt", "qsec", "vs", "am",
-      "gear", "carb", ".pred")
+    c(".pred",
+      "mpg", "cyl", "disp", "hp", "drat", "wt", "qsec", "vs", "am",
+      "gear", "carb")
   )
   expect_equal(nrow(augment(reg_xy, head(mtcars))), 6)
   expect_equal(
     colnames(augment(reg_xy, head(mtcars[, -1]))),
-    c("cyl", "disp", "hp", "drat", "wt", "qsec", "vs", "am",
-      "gear", "carb", ".pred")
+    c(".pred",
+      "cyl", "disp", "hp", "drat", "wt", "qsec", "vs", "am",
+      "gear", "carb")
   )
   expect_equal(nrow(augment(reg_xy, head(mtcars[, -1]))), 6)
 
@@ -49,23 +53,23 @@ test_that('classification models', {
 
   expect_equal(
     colnames(augment(cls_form, head(two_class_dat))),
-    c("A", "B", "Class", ".pred_class", ".pred_Class1", ".pred_Class2")
+    c(".pred_class", ".pred_Class1", ".pred_Class2", "A", "B", "Class")
   )
   expect_equal(nrow(augment(cls_form, head(two_class_dat))), 6)
   expect_equal(
     colnames(augment(cls_form, head(two_class_dat[, -3]))),
-    c("A", "B", ".pred_class", ".pred_Class1", ".pred_Class2")
+    c(".pred_class", ".pred_Class1", ".pred_Class2", "A", "B")
   )
   expect_equal(nrow(augment(cls_form, head(two_class_dat[, -3]))), 6)
 
   expect_equal(
     colnames(augment(cls_xy, head(two_class_dat))),
-    c("A", "B", "Class", ".pred_class", ".pred_Class1", ".pred_Class2")
+    c(".pred_class", ".pred_Class1", ".pred_Class2", "A", "B", "Class")
   )
   expect_equal(nrow(augment(cls_xy, head(two_class_dat))), 6)
   expect_equal(
     colnames(augment(cls_xy, head(two_class_dat[, -3]))),
-    c("A", "B", ".pred_class", ".pred_Class1", ".pred_Class2")
+    c(".pred_class", ".pred_Class1", ".pred_Class2", "A", "B")
   )
   expect_equal(nrow(augment(cls_xy, head(two_class_dat[, -3]))), 6)
 
@@ -81,7 +85,7 @@ test_that('augment for model without class probabilities', {
 
   expect_equal(
     colnames(augment(cls_form, head(two_class_dat))),
-    c("A", "B", "Class", ".pred_class")
+    c(".pred_class", "A", "B", "Class")
   )
   expect_equal(nrow(augment(cls_form, head(two_class_dat))), 6)
 


### PR DESCRIPTION
Enables `augment()` for models with mode `"censored regression"`. 

This also moves columns with `.pred*` and `.resid` to the left-most position.