### PR TITLE
store `y_var` in fit output from xy interface when available

### DIFF
--- a/R/fit.R
+++ b/R/fit.R
@@ -265,19 +265,21 @@ fit_xy.model_spec <-
         rlang::warn(glue::glue("Engine set to `{object$engine}`."))
       }
     }
+    y_var <- names(y)
 
     if (object$engine != "spark" & NCOL(y) == 1 & !(is.vector(y) | is.factor(y))) {
       if (is.matrix(y)) {
         y <- y[, 1]
-      } else {
-        y <- y[[1]]
       }
+
+      y <- y[[1]]
     }
 
     cl <- match.call(expand.dots = TRUE)
     eval_env <- rlang::env()
     eval_env$x <- x
     eval_env$y <- y
+    eval_env$y_var <- y_var
     eval_env$weights <- weights_to_numeric(case_weights, object)
 
     # TODO case weights: pass in eval_env not individual elements

--- a/R/fit_helpers.R
+++ b/R/fit_helpers.R
@@ -187,11 +187,16 @@ xy_form <- function(object, env, control, ...) {
     control = control,
     ...
   )
-  if (is.vector(env$y)) {
-    data_obj$y_var <- character(0)
+  if (!is.null(env$y_var)) {
+    data_obj$y_var <- env$y_var
   } else {
+    if (is.vector(env$y)) {
+      data_obj$y_var <- character(0)
+    }
+
     data_obj$y_var <- colnames(env$y)
   }
+
   res$preproc <- data_obj[c("x_var", "y_var")]
   res
 }


### PR DESCRIPTION
Related to https://github.com/tidymodels/workflows/issues/131. That issue notes that `augment.workflow()` doesn't return `.resid` as does the equivalent model fit from `augment.model_fit()`, even though it calls the `model_fit` methods in its internals. This is because workflows always(?) transitions to the xy interface before handing data off to parsnip. I came across this while putting together the companion PR to https://github.com/tidymodels/parsnip/pull/960. 

While the xy machinery makes use of the `..y` placeholder in its internals, we can append the actual names attached to `y`—that are, at least in the workflows case, still intact—as `y_var` to the resulting `model_fit` so that we can reference that column later.

In combination with a workflows PR that will follow up on this one, `augment.workflow()` will return residuals in the situations that `augment.model_fit()` does!
