### PR TITLE
Add `call` arg to checking functions in standalone-survival

### DIFF
--- a/R/standalone-survival.R
+++ b/R/standalone-survival.R
@@ -30,6 +30,30 @@
 # nocov start
 # These are tested in the extratests repo since it would require a dependency
 # on the survival package. https://github.com/tidymodels/extratests/pull/78
+.is_surv <- function(surv, fail = TRUE) {
+  is_surv <- inherits(surv, "Surv")
+  if (!is_surv && fail) {
+    rlang::abort("The object does not have class `Surv`.", call = NULL)
+  }
+  is_surv
+}
+
+.extract_surv_type <- function(surv) {
+  attr(surv, "type")
+}
+
+.check_cens_type <- function(surv, type = "right", fail = TRUE) {
+  .is_surv(surv)
+  obj_type <- .extract_surv_type(surv)
+  good_type <- all(obj_type %in% type)
+  if (!good_type && fail) {
+    c_list <- paste0("'", type, "'")
+    msg <- cli::format_inline("For this usage, the allowed censoring type{?s} {?is/are}: {c_list}")
+    rlang::abort(msg, call = NULL)
+  }
+  good_type
+}
+
 .is_censored_right <- function(surv) {
   .check_cens_type(surv, fail = FALSE)
 }
@@ -59,30 +83,6 @@
     res <- res - 1
   }
   res
-}
-
-.is_surv <- function(surv, fail = TRUE) {
-  is_surv <- inherits(surv, "Surv")
-  if (!is_surv && fail) {
-    rlang::abort("The object does not have class `Surv`.", call = NULL)
-  }
-  is_surv
-}
-
-.extract_surv_type <- function(surv) {
-  attr(surv, "type")
-}
-
-.check_cens_type <- function(surv, type = "right", fail = TRUE) {
-  .is_surv(surv)
-  obj_type <- .extract_surv_type(surv)
-  good_type <- all(obj_type %in% type)
-  if (!good_type && fail) {
-    c_list <- paste0("'", type, "'")
-    msg <- cli::format_inline("For this usage, the allowed censoring type{?s} {?is/are}: {c_list}")
-    rlang::abort(msg, call = NULL)
-  }
-  good_type
 }
 
 # nocov end

--- a/R/standalone-survival.R
+++ b/R/standalone-survival.R
@@ -30,10 +30,10 @@
 # nocov start
 # These are tested in the extratests repo since it would require a dependency
 # on the survival package. https://github.com/tidymodels/extratests/pull/78
-.is_surv <- function(surv, fail = TRUE) {
+.is_surv <- function(surv, fail = TRUE, call = rlang::caller_env()) {
   is_surv <- inherits(surv, "Surv")
   if (!is_surv && fail) {
-    rlang::abort("The object does not have class `Surv`.", call = NULL)
+    rlang::abort("The object does not have class `Surv`.", call = call)
   }
   is_surv
 }
@@ -42,24 +42,24 @@
   attr(surv, "type")
 }
 
-.check_cens_type <- function(surv, type = "right", fail = TRUE) {
-  .is_surv(surv)
+.check_cens_type <- function(surv, type = "right", fail = TRUE, call = rlang::caller_env()) {
+  .is_surv(surv, call = call)
   obj_type <- .extract_surv_type(surv)
   good_type <- all(obj_type %in% type)
   if (!good_type && fail) {
     c_list <- paste0("'", type, "'")
     msg <- cli::format_inline("For this usage, the allowed censoring type{?s} {?is/are}: {c_list}")
-    rlang::abort(msg, call = NULL)
+    rlang::abort(msg, call = call)
   }
   good_type
 }
 
 .is_censored_right <- function(surv) {
-  .check_cens_type(surv, fail = FALSE)
+  .check_cens_type(surv, type = "right", fail = FALSE)
 }
 
-.check_censored_right <- function(surv) {
-  .check_cens_type(surv, fail = TRUE)
+.check_censored_right <- function(surv, call = rlang::caller_env()) {
+  .check_cens_type(surv, type = "right", fail = TRUE, call = call)
 } # will add more as we need them
 
 .extract_surv_time <- function(surv) {


### PR DESCRIPTION
This is possibly a smidge easier to read in commit-order instead of aggregated:

- the first commit just moves functions into an order in which they build on each other, for readability
- the second commit adds a call arg to functions that may call `rlang::abort()` so that we can pass the call through

The tests are in extratest and don't change because they either don't capture those error messages (yet) or because the call does not get passed on (yet).