### PR TITLE
Remove redundant test on `trunc_probs()`

### DIFF
--- a/tests/testthat/test-survival-censoring-weights.R
+++ b/tests/testthat/test-survival-censoring-weights.R
@@ -22,21 +22,6 @@ test_that("probability truncation via trunc_probs()", {
   )
 })
 
-test_that("trunc_probs()", {
-  probs_1 <- (0:10) / 20
-  probs_2 <- probs_1
-  probs_2[3] <- NA_real_
-
-  expect_equal(parsnip:::trunc_probs(probs_1, 0), probs_1)
-  expect_equal(parsnip:::trunc_probs(probs_2, 0), probs_2)
-  expect_equal(
-    parsnip:::trunc_probs(probs_1, 0.1),
-    ifelse(probs_1 < 0.05 / 2, 0.05 / 2, probs_1)
-  )
-  expect_equal(min(parsnip:::trunc_probs(probs_2, 0.1), na.rm = TRUE), 0.05 / 2)
-  expect_equal(is.na(parsnip:::trunc_probs(probs_2, 0.1)),is.na(probs_2))
-})
-
 test_that(".filter_eval_time()", {
   times_basic <- 0:10
   expect_equal(


### PR DESCRIPTION
I think the test removed in this PR is mainly to test aspects which are already covered by the other test on `trunc_probs()`. I'll comment with links :)