### PR TITLE
Make `.check_censor_model()` error for non-censored-regression models

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: parsnip
 Title: A Common API to Modeling and Analysis Functions
-Version: 1.1.0.9002
+Version: 1.1.0.9003
 Authors@R: c(
     person("Max", "Kuhn", , "max@posit.co", role = c("aut", "cre")),
     person("Davis", "Vaughan", , "davis@posit.co", role = "aut"),


### PR DESCRIPTION
closes #971

Regression and classification models also have `$censor_probs` even though it's just an empty list, so this check function didn't error before.

Test is to be updated in extratests.

With this PR:
``` r
library(parsnip)
library(survival)

lung2 <- lung %>%
  dplyr::mutate(surv = Surv(time, status), .keep = "unused")

not_a_censor_model <- fit(linear_reg(), mpg ~ ., data = mtcars)

# this now errors
parsnip:::.check_censor_model(not_a_censor_model)
#> Error in `parsnip:::.check_censor_model()`:
#> ! The model needs to be for mode 'censored regression', not for mode
#>   'regression'.

# so also this errors now with the better message
.censoring_weights_graf(not_a_censor_model, lung2)
#> Error in `.check_censor_model()` at parsnip/R/survival-censoring-weights.R:226:2:
#> ! The model needs to be for mode 'censored regression', not for mode
#>   'regression'.
```

<sup>Created on 2023-05-18 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>