### PR TITLE
dbarts: add standard error for interval predictions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,9 @@
 
 * `augment()` now works for censored regression models. 
 
+* For BART models with the `dbarts` engine, `predict()` can now also return the standard error for confidence and prediction intervals (#976).
+
+
 # parsnip 1.1.0
 
 This release of parsnip contains a number of new features and bug fixes, accompanied by several optimizations that substantially decrease the time to `fit()` and `predict()` with the package.

--- a/R/bart.R
+++ b/R/bart.R
@@ -232,6 +232,9 @@ dbart_predict_calc <- function(obj, new_data, type, level = 0.95, std_err = FALS
           )
         )
     }
+    if (std_err) {
+      res$.std_error <- apply(post_dist, 2, stats::sd, na.rm = TRUE)
+    }
   }
   res
 }

--- a/R/bart_data.R
+++ b/R/bart_data.R
@@ -140,7 +140,8 @@ set_pred(
         obj = expr(object),
         new_data = expr(new_data),
         type = "conf_int",
-        level = expr(level)
+        level = expr(level),
+        std_err = expr(std_error)
       )
   )
 )
@@ -158,7 +159,8 @@ set_pred(
         obj = expr(object),
         new_data = expr(new_data),
         type = "pred_int",
-        level = expr(level)
+        level = expr(level),
+        std_err = expr(std_error)
       )
   )
 )
@@ -215,7 +217,8 @@ set_pred(
         obj = expr(object),
         new_data = expr(new_data),
         type = "conf_int",
-        level = expr(level)
+        level = expr(level),
+        std_err = expr(std_error)
       )
   )
 )
@@ -233,7 +236,8 @@ set_pred(
         obj = expr(object),
         new_data = expr(new_data),
         type = "pred_int",
-        level = expr(level)
+        level = expr(level),
+        std_err = expr(std_error)
       )
   )
 )
@@ -248,7 +252,9 @@ set_pred(
     post = NULL,
     func = c(pkg = "parsnip", fun = "dbart_predict_calc"),
     args =
-      list(obj = quote(object),
-           new_data =  quote(new_data))
+      list(
+        obj = quote(object),
+        new_data =  quote(new_data)
+      )
   )
 )


### PR DESCRIPTION
closes  #976

``` r
library(parsnip)
library(dplyr)
#> 
#> Attaching package: 'dplyr'
#> The following objects are masked from 'package:stats':
#> 
#>     filter, lag
#> The following objects are masked from 'package:base':
#> 
#>     intersect, setdiff, setequal, union
data(two_class_dat, package = "modeldata")

set.seed(1)
bt_cls_fit <- 
  parsnip::bart() %>% 
  set_mode("classification") %>% 
  set_engine("dbarts") %>% 
  fit(Class ~ ., data = two_class_dat)

set.seed(2)
bind_cols(
  predict(bt_cls_fit, two_class_dat, type = "prob"),
  predict(bt_cls_fit, two_class_dat, type = "pred_int", std_error = TRUE)
) %>%
 select(-contains(c("lower", "upper")))
#> # A tibble: 791 × 3
#>    .pred_Class1 .pred_Class2 .std_error
#>           <dbl>        <dbl>      <dbl>
#>  1       0.351         0.649      0.478
#>  2       0.823         0.177      0.356
#>  3       0.54          0.46       0.498
#>  4       0.552         0.448      0.497
#>  5       0.454         0.546      0.495
#>  6       0.222         0.778      0.420
#>  7       0.6           0.4        0.486
#>  8       0.412         0.588      0.495
#>  9       0.979         0.021      0.133
#> 10       0.0790        0.921      0.276
#> # ℹ 781 more rows
```

<sup>Created on 2023-06-05 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>