### PR TITLE
add to `predict()` docs how to get the IPCW

### DIFF
--- a/R/augment.R
+++ b/R/augment.R
@@ -27,12 +27,15 @@
 #'
 #' If survival predictions are created and `new_data` contains a
 #' [survival::Surv()] object, additional columns are added for inverse
-#' probability of censoring weights (IPCW) are also created. This enables the
-#' user to compute performance metrics in the \pkg{yardstick} package.
+#' probability of censoring weights (IPCW) are also created (see `tidymodels.org`
+#' page in the references below). This enables the user to compute performance
+#' metrics in the \pkg{yardstick} package.
 #'
 #' @param new_data A data frame or matrix.
 #' @param ... Not currently used.
 #' @rdname augment
+#' @references
+#' \url{https://www.tidymodels.org/learn/statistics/survival-metrics/}
 #' @export
 #' @examples
 #' car_trn <- mtcars[11:32,]

--- a/R/predict.R
+++ b/R/predict.R
@@ -56,9 +56,10 @@
 #'
 #' `predict.model_fit()` does not require the outcome to be present. For
 #' performance metrics on the predicted survival probability, inverse probability
-#' of censoring weights (IPCW) are required. Those require the outcome and are
-#' thus not returned by `predict()`. They can be added via [augment.model_fit()] if
-#' `new_data` contains a column with the outcome as a `Surv` object.
+#' of censoring weights (IPCW) are required (see the `tidymodels.org` reference
+#' below). Those require the outcome and are thus not returned by `predict()`.
+#' They can be added via [augment.model_fit()] if `new_data` contains a column
+#' with the outcome as a `Surv` object.
 #'
 #' Also, when `type = "linear_pred"`, censored regression models will by default
 #' be formatted such that the linear predictor _increases_ with time. This may
@@ -111,7 +112,8 @@
 #'  `predict()` function will return the same structure as above but
 #'  filled with missing values. This does not currently work for
 #'  multivariate models.
-#'
+#' @references
+#' \url{https://www.tidymodels.org/learn/statistics/survival-metrics/}
 #' @examples
 #' library(dplyr)
 #'

--- a/R/predict.R
+++ b/R/predict.R
@@ -54,6 +54,12 @@
 #' functions will adjust the values to fit this specification by removing
 #' offending points (with a warning).
 #'
+#' `predict.model_fit()` does not require the outcome to be present. For
+#' performance metrics on the predicted survival probability, inverse probability
+#' of censoring weights (IPCW) are required. Those require the outcome and are
+#' thus not returned by `predict()`. They can be added via [augment.model_fit()] if
+#' `new_data` contains a column with the outcome as a `Surv` object.
+#'
 #' Also, when `type = "linear_pred"`, censored regression models will by default
 #' be formatted such that the linear predictor _increases_ with time. This may
 #' have the opposite sign as what the underlying model's `predict()` method

--- a/man/augment.Rd
+++ b/man/augment.Rd
@@ -43,8 +43,9 @@ survival prediction, the \code{eval_time} argument is required.
 
 If survival predictions are created and \code{new_data} contains a
 \code{\link[survival:Surv]{survival::Surv()}} object, additional columns are added for inverse
-probability of censoring weights (IPCW) are also created. This enables the
-user to compute performance metrics in the \pkg{yardstick} package.
+probability of censoring weights (IPCW) are also created (see \code{tidymodels.org}
+page in the references below). This enables the user to compute performance
+metrics in the \pkg{yardstick} package.
 }
 }
 \examples{
@@ -88,4 +89,7 @@ augment(cls_form, cls_tst[, -3])
 augment(cls_xy, cls_tst)
 augment(cls_xy, cls_tst[, -3])
 
+}
+\references{
+\url{https://www.tidymodels.org/learn/statistics/survival-metrics/}
 }

--- a/man/predict.model_fit.Rd
+++ b/man/predict.model_fit.Rd
@@ -126,9 +126,10 @@ offending points (with a warning).
 
 \code{predict.model_fit()} does not require the outcome to be present. For
 performance metrics on the predicted survival probability, inverse probability
-of censoring weights (IPCW) are required. Those require the outcome and are
-thus not returned by \code{predict()}. They can be added via \code{\link[=augment.model_fit]{augment.model_fit()}} if
-\code{new_data} contains a column with the outcome as a \code{Surv} object.
+of censoring weights (IPCW) are required (see the \code{tidymodels.org} reference
+below). Those require the outcome and are thus not returned by \code{predict()}.
+They can be added via \code{\link[=augment.model_fit]{augment.model_fit()}} if \code{new_data} contains a column
+with the outcome as a \code{Surv} object.
 
 Also, when \code{type = "linear_pred"}, censored regression models will by default
 be formatted such that the linear predictor \emph{increases} with time. This may
@@ -164,5 +165,8 @@ predict(
   type = "raw",
   opts = list(type = "terms")
 )
+}
+\references{
+\url{https://www.tidymodels.org/learn/statistics/survival-metrics/}
 }
 \keyword{internal}

--- a/man/predict.model_fit.Rd
+++ b/man/predict.model_fit.Rd
@@ -124,6 +124,12 @@ to be unique, finite, non-missing, and non-negative. The \code{predict()}
 functions will adjust the values to fit this specification by removing
 offending points (with a warning).
 
+\code{predict.model_fit()} does not require the outcome to be present. For
+performance metrics on the predicted survival probability, inverse probability
+of censoring weights (IPCW) are required. Those require the outcome and are
+thus not returned by \code{predict()}. They can be added via \code{\link[=augment.model_fit]{augment.model_fit()}} if
+\code{new_data} contains a column with the outcome as a \code{Surv} object.
+
 Also, when \code{type = "linear_pred"}, censored regression models will by default
 be formatted such that the linear predictor \emph{increases} with time. This may
 have the opposite sign as what the underlying model's \code{predict()} method


### PR DESCRIPTION
closes #979

I've not included links to `.censoring_weights_graf()` like in the issue description because that function is `@keyword internal` and I think it would be too much detail on the predict help page. If we think it's super important to talk about that internal function in the docs then I would add it to the help page for `augment()` (and consider making the function not internal) - but I tend to think that `augment()` is the right place to point a user to.