### PR TITLE
correct documented `mode`s for `null_model()`

### DIFF
--- a/R/nullmodel.R
+++ b/R/nullmodel.R
@@ -130,7 +130,7 @@ predict.nullmodel <- function (object, new_data = NULL, type  = NULL, ...) {
 #' `null_model()` defines a simple, non-informative model. It doesn't have any
 #'  main arguments. This function can fit classification and regression models.
 #'
-#' @inheritParams boost_tree
+#' @inheritParams set_new_model
 #' @details The model can be created using the `fit()` function using the
 #'  following _engines_:
 #' \itemize{

--- a/man/null_model.Rd
+++ b/man/null_model.Rd
@@ -7,9 +7,7 @@
 null_model(mode = "classification")
 }
 \arguments{
-\item{mode}{A single character string for the prediction outcome mode.
-Possible values for this model are "unknown", "regression", or
-"classification".}
+\item{mode}{A single character string for the model mode (e.g. "regression").}
 }
 \description{
 \code{null_model()} defines a simple, non-informative model. It doesn't have any


### PR DESCRIPTION
This PR aligns the `mode` argument documentation for `null_model()` with its registered modes:

https://github.com/tidymodels/parsnip/blob/a85e5083de0d1ec8087678cf21580690a37da81b/R/nullmodel_data.R#L8-L9

...and the help-file's model description:

https://github.com/tidymodels/parsnip/blob/a85e5083de0d1ec8087678cf21580690a37da81b/R/nullmodel.R#L130-L131


Closes #982.