### PR TITLE
Fix bug for 4.3 where rank deficient prediction from `lm` model gave different column names

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 
 * A few censored regression helper functions were exported: `.extract_surv_status()`, `.extract_surv_time()`, and `.time_as_binary_event()` (#973).
 
+* Fixed bug where prediction on rank dificient `lm()` models produced `.pred_res` instead of `.pred`. (#985)
 
 # parsnip 1.1.0
 

--- a/R/linear_reg_data.R
+++ b/R/linear_reg_data.R
@@ -44,7 +44,8 @@ set_pred(
       list(
         object = expr(object$fit),
         newdata = expr(new_data),
-        type = "response"
+        type = "response",
+        rankdeficient = "simple"
       )
   )
 )

--- a/tests/testthat/test_linear_reg.R
+++ b/tests/testthat/test_linear_reg.R
@@ -318,3 +318,27 @@ test_that('show engine', {
   expect_error(show_engines("linear_re"), "No results found for model function")
 })
 
+test_that('lm can handle rankdeficient predictions', {
+  data <- data.frame(
+    y = c(1,2,3,4),
+    x1 = c(1,1,2,3),
+    x2 = c(3,4,5,2),
+    x3 = c(4,2,6,0),
+    x4 = c(2,1,3,0)
+  )
+  data2 <- data.frame(
+    x1 = c(3,2,1,3),
+    x2 = c(3,2,1,4),
+    x3 = c(3,4,5,1),
+    x4 = c(0,0,2,3)
+  )
+
+  expect_warning(
+    preds <- linear_reg() %>%
+      fit(y ~ ., data = data) %>%
+      predict(new_data = data2)
+  )
+
+  expect_identical(names(preds), ".pred")
+})
+


### PR DESCRIPTION
This PR aims to close https://github.com/tidymodels/parsnip/issues/985.

This bug only appears on 4.3 and newer as that is when `predict.lm()` got the new `rankdeficient` argument.

<img width="805" alt="Screenshot 2023-07-17 at 4 55 24 PM" src="https://github.com/tidymodels/parsnip/assets/14034784/425b9735-f142-4e8f-b4cb-d0da4f5b77c4">

I picked this solution as it would create backwards compatibility.
