### PR TITLE
error if `eval_time` is needed and missing when calling augment()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: parsnip
 Title: A Common API to Modeling and Analysis Functions
-Version: 1.1.0.9003
+Version: 1.1.0.9004
 Authors@R: c(
     person("Max", "Kuhn", , "max@posit.co", role = c("aut", "cre")),
     person("Davis", "Vaughan", , "davis@posit.co", role = "aut"),

--- a/R/augment.R
+++ b/R/augment.R
@@ -124,6 +124,12 @@ augment_censored <- function(x, new_data, eval_time = NULL) {
   }
 
   if (spec_has_pred_type(x, "survival")) {
+    if (is.null(eval_time)) {
+      rlang::abort(
+        "The `eval_time` argument is missing, with no default.",
+        call = caller_env()
+      )
+    }
     .filter_eval_time(eval_time)
     ret <- dplyr::bind_cols(
       predict(x, new_data = new_data, type = "survival", eval_time = eval_time),


### PR DESCRIPTION
What the title says. to close https://github.com/tidymodels/parsnip/issues/988.

I didn't add anything to `NEWS` since it already has a bullet that says `augment() now works for censored regression models.`