### PR TITLE
 Fixed bug where `boost_tree()` models couldn't be fit with 1 predictor if `validation` argument was used.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 
 * Fixed bug where prediction on rank dificient `lm()` models produced `.pred_res` instead of `.pred`. (#985)
 
+* Fixed bug where `boost_tree()` models couldn't be fit with 1 predictor if `validation` argument was used. (#994)
+
 # parsnip 1.1.0
 
 This release of parsnip contains a number of new features and bug fixes, accompanied by several optimizations that substantially decrease the time to `fit()` and `predict()` with the package.

--- a/R/boost_tree.R
+++ b/R/boost_tree.R
@@ -435,15 +435,22 @@ as_xgb_data <- function(x, y, validation = 0, weights = NULL, event_level = "fir
       # Split data
       m <- floor(n * (1 - validation)) + 1
       trn_index <- sample(seq_len(n), size = max(m, 2))
-      val_data <- xgboost::xgb.DMatrix(x[-trn_index,], label = y[-trn_index], missing = NA)
+      val_data <- xgboost::xgb.DMatrix(
+        data = x[-trn_index, , drop = FALSE],
+        label = y[-trn_index],
+        missing = NA
+      )
       watch_list <- list(validation = val_data)
 
       info_list <- list(label = y[trn_index])
       if (!is.null(weights)) {
         info_list$weight <- weights[trn_index]
       }
-      dat <- xgboost::xgb.DMatrix(x[trn_index,], missing = NA, info = info_list)
-
+      dat <- xgboost::xgb.DMatrix(
+        data = x[trn_index, , drop = FALSE],
+        missing = NA,
+        info = info_list
+      )
 
     } else {
       info_list <- list(label = y)

--- a/tests/testthat/test_boost_tree.R
+++ b/tests/testthat/test_boost_tree.R
@@ -38,3 +38,12 @@ test_that('argument checks for data dimensions', {
   expect_equal(args$min_instances_per_node, expr(min_rows(1000, x)))
 })
 
+test_that('boost_tree can be fit with 1 predictor if validation is used', {
+  spec <- boost_tree(trees = 1) %>%
+    set_engine("xgboost", validation = 0.5) %>%
+    set_mode("regression")
+
+  expect_no_error(
+    fit(spec, mpg ~ disp, data = mtcars)
+  )
+})


### PR DESCRIPTION
What the title says. This bug was reported on StackOverflow here https://stackoverflow.com/questions/76782839/error-fitting-xgboost-classification-models-with-single-predictor

The fix was to [add drop = FALSE to matrix subsetting in as_xgb_data()](https://github.com/tidymodels/parsnip/commit/6fecfb83a6c83054b2e50f391fc732fa8992b9b7)