### PR TITLE
Make testing more quiet

### DIFF
--- a/R/engines.R
+++ b/R/engines.R
@@ -41,7 +41,7 @@ load_libs <- function(x, quiet, attach = FALSE) {
     if (!attach) {
       suppressPackageStartupMessages(requireNamespace(pkg, quietly = quiet))
     } else {
-      library(pkg, character.only = TRUE)
+      library(pkg, character.only = TRUE, quietly = quiet)
     }
   }
   invisible(x)

--- a/tests/testthat/test_grouped_glm.R
+++ b/tests/testthat/test_grouped_glm.R
@@ -1,10 +1,8 @@
-library(tidyr)
-
 test_that('correct results for glm_grouped()', {
   ucb_weighted <- as.data.frame(UCBAdmissions)
   ucb_weighted$Freq <- as.integer(ucb_weighted$Freq)
 
-  ucb_long <- uncount(ucb_weighted, Freq)
+  ucb_long <- tidyr::uncount(ucb_weighted, Freq)
 
   ungrouped <- glm(Admit ~ Gender + Dept, data = ucb_long, family = binomial)
 
@@ -12,6 +10,6 @@ test_that('correct results for glm_grouped()', {
     grouped <- glm_grouped(Admit ~ Gender + Dept, data = ucb_weighted, weights = ucb_weighted$Freq),
     regexp = NA
   )
-  expect_equal(grouped$df.null, 11)
 
+  expect_equal(grouped$df.null, 11)
 })


### PR DESCRIPTION
This isn't the biggest deal in the world. But the tests can sometimes be a little noisy. This PR fixes what I found.

For example this is what I'm trying to avoid:

![Screenshot 2023-08-08 at 10 30 50 AM](https://github.com/tidymodels/parsnip/assets/14034784/c1cc83fb-75e8-4016-9f2d-cd698bf9f578)
