### PR TITLE
use `rlang::f_lhs()` in favor of `formula[[2]]`

### DIFF
--- a/R/fit_helpers.R
+++ b/R/fit_helpers.R
@@ -7,7 +7,7 @@ form_form <-
   function(object, control, env, ...) {
 
     if (inherits(env$data, "data.frame")) {
-      check_outcome(eval_tidy(env$formula[[2]], env$data), object)
+      check_outcome(eval_tidy(rlang::f_lhs(env$formula), env$data), object)
     }
 
     # prob rewrite this as simple subset/levels
@@ -53,7 +53,7 @@ form_form <-
       )
       elapsed <- list(elapsed = NA_real_)
     }
-    res$preproc <- list(y_var = all.vars(env$formula[[2]]))
+    res$preproc <- list(y_var = all.vars(rlang::f_lhs(env$formula)))
     res$elapsed <- elapsed
     res
   }
@@ -149,7 +149,7 @@ form_xy <- function(object, control, env,
     control = control,
     target = target
   )
-  data_obj$y_var <- all.vars(env$formula[[2]])
+  data_obj$y_var <- all.vars(rlang::f_lhs(env$formula))
   data_obj$x <- NULL
   data_obj$y <- NULL
   data_obj$weights <- NULL

--- a/R/grouped_binomial.R
+++ b/R/grouped_binomial.R
@@ -103,7 +103,7 @@ glm_grouped <- function(formula, data, weights, ...) {
   data <- data[, all_cols, drop = FALSE]
   data$..weights <- weights
   # Reconstruct the new data format (made below) to the grouped formula format
-  formula[[2]] <- rlang::call2("cbind", !!!rlang::syms(rev(lvls)))
+  rlang::f_lhs(formula) <- rlang::call2("cbind", !!!rlang::syms(rev(lvls)))
 
   data <-
     data %>%

--- a/R/misc.R
+++ b/R/misc.R
@@ -260,7 +260,7 @@ levels_from_formula <- function(f, dat) {
   if (inherits(dat, "tbl_spark")) {
     res <- NULL
   } else {
-    res <- levels(eval_tidy(f[[2]], dat))
+    res <- levels(eval_tidy(rlang::f_lhs(f), dat))
   }
   res
 }


### PR DESCRIPTION
This is the first step to address https://github.com/tidymodels/parsnip/issues/1003.

``` r
form_a <- mpg ~ .
form_b <- ~ .

# [[2]] does not necessarily give LHS
form_a[[2]]
#> mpg
form_b[[2]]
#> .

# resulting in:
rlang::eval_tidy(form_a[[2]], mtcars)
#>  [1] 21.0 21.0 22.8 21.4 18.7 18.1 14.3 24.4 22.8 19.2 17.8 16.4 17.3 15.2 10.4
#> [16] 10.4 14.7 32.4 30.4 33.9 21.5 15.5 15.2 13.3 19.2 27.3 26.0 30.4 15.8 19.7
#> [31] 15.0 21.4
rlang::eval_tidy(form_b[[2]], mtcars)
#> Error: object '.' not found

# but:
rlang::f_lhs(form_a)
#> mpg
rlang::f_lhs(form_b)
#> NULL

# gives:
rlang::eval_tidy(rlang::f_lhs(form_a), mtcars)
#>  [1] 21.0 21.0 22.8 21.4 18.7 18.1 14.3 24.4 22.8 19.2 17.8 16.4 17.3 15.2 10.4
#> [16] 10.4 14.7 32.4 30.4 33.9 21.5 15.5 15.2 13.3 19.2 27.3 26.0 30.4 15.8 19.7
#> [31] 15.0 21.4
rlang::eval_tidy(rlang::f_lhs(form_b), mtcars)
#> NULL
```

<sup>Created on 2023-11-02 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

This will give us some better information to work with in `check_outcome()`.