### PR TITLE
fix default vaulues for `mlp(engine = "brulee")`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * Improved errors in cases where the outcome column is mis-specified. (#1003)
 
+* Documentation fixed for `mlp(engine = "brulee")`: the default values for `learn_rate` and `epochs` were swapped (#1018).
+
 # parsnip 1.1.1
 
 * Fixed bug where prediction on rank deficient `lm()` models produced `.pred_res` instead of `.pred`. (#985)

--- a/man/rmd/mlp_brulee.Rmd
+++ b/man/rmd/mlp_brulee.Rmd
@@ -8,7 +8,7 @@
 ```{r brulee-param-info, echo = FALSE}
 defaults <- 
   tibble::tibble(parsnip = c("hidden_units", "penalty", "dropout", "epochs", "learn_rate", "activation", "mixture"),
-                 default = c("3L", "0.0", "0.0", "0.01", "100L", "'relu'", "0.0"))
+                 default = c("3L", "0.0", "0.0", "100L", "0.01", "'relu'", "0.0"))
 
 param <-
   mlp() %>% 

--- a/man/rmd/mlp_brulee.md
+++ b/man/rmd/mlp_brulee.md
@@ -15,11 +15,11 @@ This model has 7 tuning parameters:
 
 - `mixture`: Proportion of Lasso Penalty (type: double, default: 0.0)
 
-- `epochs`: # Epochs (type: integer, default: 0.01)
+- `epochs`: # Epochs (type: integer, default: 100L)
 
 - `dropout`: Dropout Rate (type: double, default: 0.0)
 
-- `learn_rate`: Learning Rate (type: double, default: 100L)
+- `learn_rate`: Learning Rate (type: double, default: 0.01)
 
 - `activation`: Activation Function (type: character, default: 'relu')
 


### PR DESCRIPTION
closes  #1018

Looks like the values for `learn_rate` and `epochs` got swapped. The new values are the default values in {brulee}.