### PR TITLE
Document what `mtry = NULL` means for xgboost

### DIFF
--- a/R/boost_tree.R
+++ b/R/boost_tree.R
@@ -21,7 +21,7 @@
 #'  to use for fitting.
 #' @param mtry A number for the number (or proportion) of predictors that will
 #'  be randomly sampled at each split when creating the tree models
-#' (specific engines only)
+#' (specific engines only).
 #' @param trees An integer for the number of trees contained in
 #'  the ensemble.
 #' @param min_n An integer for the minimum number of data points

--- a/man/boost_tree.Rd
+++ b/man/boost_tree.Rd
@@ -27,7 +27,7 @@ to use for fitting.}
 
 \item{mtry}{A number for the number (or proportion) of predictors that will
 be randomly sampled at each split when creating the tree models
-(specific engines only)}
+(specific engines only).}
 
 \item{trees}{An integer for the number of trees contained in
 the ensemble.}

--- a/man/parsnip_update.Rd
+++ b/man/parsnip_update.Rd
@@ -370,7 +370,7 @@ on the logit scale). The default value is 2.}
 
 \item{mtry}{A number for the number (or proportion) of predictors that will
 be randomly sampled at each split when creating the tree models
-(specific engines only)}
+(specific engines only).}
 
 \item{learn_rate}{A number for the rate at which the boosting algorithm adapts
 from iteration-to-iteration (specific engines only). This is sometimes referred to

--- a/man/rmd/boost_tree_xgboost.Rmd
+++ b/man/rmd/boost_tree_xgboost.Rmd
@@ -24,6 +24,8 @@ This model has `r nrow(param)` tuning parameters:
 param$item
 ```
 
+For `mtry`, the default value of `NULL` translates to using all available columns.
+
 ## Translation from parsnip to the original package (regression)
 
 ```{r xgboost-reg}

--- a/man/rmd/boost_tree_xgboost.md
+++ b/man/rmd/boost_tree_xgboost.md
@@ -25,6 +25,8 @@ This model has 8 tuning parameters:
 
 - `stop_iter`: # Iterations Before Stopping (type: integer, default: Inf)
 
+For `mtry`, the default value of `NULL` translates to using all available columns.
+
 ## Translation from parsnip to the original package (regression)
 
 

--- a/man/rule_fit.Rd
+++ b/man/rule_fit.Rd
@@ -25,7 +25,7 @@ Possible values for this model are "unknown", "regression", or
 
 \item{mtry}{A number for the number (or proportion) of predictors that will
 be randomly sampled at each split when creating the tree models
-(specific engines only)}
+(specific engines only).}
 
 \item{trees}{An integer for the number of trees contained in
 the ensemble.}


### PR DESCRIPTION
closes  #1017