### PR TITLE
ensure survival vectors are unnamed for #1023

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: parsnip
 Title: A Common API to Modeling and Analysis Functions
-Version: 1.1.1.9001
+Version: 1.1.1.9002
 Authors@R: c(
     person("Max", "Kuhn", , "max@posit.co", role = c("aut", "cre")),
     person("Davis", "Vaughan", , "davis@posit.co", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,8 @@
 
 * Fixed bug where `boost_tree()` models couldn't be fit with 1 predictor if `validation` argument was used. (#994)
 
+* When computing censoring weights, the resulting vectors are no longer named (#1023).
+
 # parsnip 1.1.0
 
 This release of parsnip contains a number of new features and bug fixes, accompanied by several optimizations that substantially decrease the time to `fit()` and `predict()` with the package.

--- a/R/standalone-survival.R
+++ b/R/standalone-survival.R
@@ -17,6 +17,9 @@
 #
 # 2023-06-14
 # * removed time to factor conversion
+#
+# 2023-11-09
+# * make sure survival vectors are unnamed.
 
 # @param surv A [survival::Surv()] object
 # @details
@@ -74,6 +77,8 @@
   res <- surv[, colnames(surv) %in% keepers]
   if (NCOL(res) > 1) {
     res <- tibble::tibble(as.data.frame(res))
+  } else {
+    res <- unname(res)
   }
   res
 }
@@ -88,6 +93,6 @@
     (identical(un_vals, 1:2) | identical(un_vals, c(1.0, 2.0))) ) {
     res <- res - 1
   }
-  res
+  unname(res)
 }
 # nocov end

--- a/tests/testthat/test-survival-censoring-weights.R
+++ b/tests/testthat/test-survival-censoring-weights.R
@@ -50,21 +50,3 @@ test_that(".filter_eval_time()", {
   times_remove_singular <- c(-3, times_basic)
   expect_snapshot(parsnip:::.filter_eval_time(times_remove_singular))
 })
-
-test_that("no names in weight values", {
-  # See #1023
-
-  surv_obj <-
-    structure(
-      c(9, 13, 13, 18, 23, 28, 1, 1, 0, 1, 1, 0),
-      dim = c(6L, 2L),
-      dimnames = list(NULL, c("time", "status")),
-      type = "right",
-      class = "Surv"
-    )
-
-  row_1 <- parsnip:::graf_weight_time_vec(surv_obj[1,,drop = FALSE], 1.0)
-  row_5 <- parsnip:::graf_weight_time_vec(surv_obj, 1.0)
-  expect_null(names(row_1))
-  expect_null(names(row_5))
-})

--- a/tests/testthat/test-survival-censoring-weights.R
+++ b/tests/testthat/test-survival-censoring-weights.R
@@ -50,3 +50,21 @@ test_that(".filter_eval_time()", {
   times_remove_singular <- c(-3, times_basic)
   expect_snapshot(parsnip:::.filter_eval_time(times_remove_singular))
 })
+
+test_that("no names in weight values", {
+  # See #1023
+
+  surv_obj <-
+    structure(
+      c(9, 13, 13, 18, 23, 28, 1, 1, 0, 1, 1, 0),
+      dim = c(6L, 2L),
+      dimnames = list(NULL, c("time", "status")),
+      type = "right",
+      class = "Surv"
+    )
+
+  row_1 <- parsnip:::graf_weight_time_vec(surv_obj[1,,drop = FALSE], 1.0)
+  row_5 <- parsnip:::graf_weight_time_vec(surv_obj, 1.0)
+  expect_null(names(row_1))
+  expect_null(names(row_5))
+})


### PR DESCRIPTION
Closes #1023

See https://github.com/tidymodels/workflows/pull/200 and https://github.com/tidymodels/extratests/issues/110