### PR TITLE
remove new_data argument from predict.censoring_model_reverse_km()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 * Fixed documentation for `mlp(engine = "brulee")`: the default values for `learn_rate` and `epochs` were swapped (#1018).
 
+* The `new_data` argument for the `predict()` method of `censoring_model_reverse_km()` has been deprecated (#965).
+
 # parsnip 1.1.1
 
 * Fixed bug where prediction on rank deficient `lm()` models produced `.pred_res` instead of `.pred`. (#985)

--- a/R/survival-censoring-model.R
+++ b/R/survival-censoring-model.R
@@ -65,6 +65,13 @@ predict.censoring_model_reverse_km <- function(object, time, as_vector = FALSE, 
   rlang::check_installed("prodlim", version = "2022.10.13")
   rlang::check_installed("censored", version = "0.1.1.9002")
 
+  if ("new_data" %in% names(list(...))) {
+    cli::cli_warn(
+      "{.arg new_data} is ignored when predicting on \\
+      {.fn censoring_model_reverse_km} models as it doesn't affect the result."
+    )
+  }
+
   res <- rep(NA_real_, length(time))
   if (length(time) == 0) {
     return(res)

--- a/R/survival-censoring-model.R
+++ b/R/survival-censoring-model.R
@@ -61,7 +61,7 @@ predict.censoring_model <- function(object, ...) {
 }
 
 #' @export
-predict.censoring_model_reverse_km <- function(object, new_data = NULL, time, as_vector = FALSE, ...) {
+predict.censoring_model_reverse_km <- function(object, time, as_vector = FALSE, ...) {
   rlang::check_installed("prodlim", version = "2022.10.13")
   rlang::check_installed("censored", version = "0.1.1.9002")
 
@@ -76,13 +76,7 @@ predict.censoring_model_reverse_km <- function(object, new_data = NULL, time, as
     time <- time[-is_na]
   }
 
-  if (is.null(new_data)) {
-    tmp <-
-      purrr::map_dbl(time, ~ predict(object$fit, times = .x, type = "surv"))
-  } else {
-    tmp <-
-      purrr::map_dbl(time, ~ predict(object$fit, newdata = new_data, times = .x, type = "surv"))
-  }
+  tmp <- purrr::map_dbl(time, ~ predict(object$fit, times = .x, type = "surv"))
 
   zero_prob <- purrr::map_lgl(tmp, ~ !is.na(.x) && .x == 0)
   if (any(zero_prob)) {

--- a/R/survival-censoring-model.R
+++ b/R/survival-censoring-model.R
@@ -61,14 +61,14 @@ predict.censoring_model <- function(object, ...) {
 }
 
 #' @export
-predict.censoring_model_reverse_km <- function(object, time, as_vector = FALSE, ...) {
+predict.censoring_model_reverse_km <- function(object, new_data, time, as_vector = FALSE, ...) {
   rlang::check_installed("prodlim", version = "2022.10.13")
   rlang::check_installed("censored", version = "0.1.1.9002")
 
-  if ("new_data" %in% names(list(...))) {
-    cli::cli_warn(
-      "{.arg new_data} is ignored when predicting on \\
-      {.fn censoring_model_reverse_km} models as it doesn't affect the result."
+  if (lifecycle::is_present(new_data)) {
+    lifecycle::deprecate_stop(
+      "1.2.0",
+      "predict.censoring_model_reverse_km(new_data)"
     )
   }
 


### PR DESCRIPTION
To close #965

I removed `new_data` from the function signature since it is swalloed up by `...` anyways. I also added a little warning, since using `new_data` for predict methods are quite a common action

``` r
library(censored)

mod_fit <-
  survival_reg() %>%
  fit(Surv(time, status) ~ age + sex, data = lung)

# can use different data (because reverse_km model uses ~ 1)
pred_newdata <- predict(mod_fit$censor_probs, time = (7:10) * 100,
                        new_data = mtcars)
#> Warning: `new_data` is ignored when predicting on `censoring_model_reverse_km()` models
#> as it doesn't affect the result.
```

<sup>Created on 2023-11-17 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>