### PR TITLE
make .extract_surv_time() work correctly for 1-row output

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: parsnip
 Title: A Common API to Modeling and Analysis Functions
-Version: 1.1.1.9002
+Version: 1.1.1.9003
 Authors@R: c(
     person("Max", "Kuhn", , "max@posit.co", role = c("aut", "cre")),
     person("Davis", "Vaughan", , "davis@posit.co", role = "aut"),

--- a/R/standalone-survival.R
+++ b/R/standalone-survival.R
@@ -74,11 +74,12 @@
 .extract_surv_time <- function(surv) {
   .is_surv(surv)
   keepers <- c("time", "start", "stop", "time1", "time2")
-  res <- surv[, colnames(surv) %in% keepers]
-  if (NCOL(res) > 1) {
+  cols <- colnames(surv)[colnames(surv) %in% keepers]
+  res <- surv[, cols, drop = FALSE]
+  if (length(cols) > 1) {
     res <- tibble::tibble(as.data.frame(res))
   } else {
-    res <- unname(res)
+    res <- as.numeric(res)
   }
   res
 }


### PR DESCRIPTION
to close https://github.com/tidymodels/parsnip/issues/1025

``` r
times <- seq(1, 100, length.out = 5)
times2 <- seq(100, 200, length.out = 5)
events <- c(1, 0, 1, 0, 1)

intv_c <- survival::Surv(times, times2, events, type = "interval")
count_c <- survival::Surv(times, times2, events)

parsnip:::.extract_surv_time(intv_c[1])
#> # A tibble: 2 × 1
#>     res
#>   <dbl>
#> 1     1
#> 2     1

parsnip:::.extract_surv_time(count_c[1])
#> # A tibble: 2 × 1
#>     res
#>   <dbl>
#> 1     1
#> 2   100
```

<sup>Created on 2023-11-17 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>