### PR TITLE
Touch-up NEWS

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@
 
 * Fixed documentation for `mlp(engine = "brulee")`: the default values for `learn_rate` and `epochs` were swapped (#1018).
 
-* The `new_data` argument for the `predict()` method of `censoring_model_reverse_km()` has been deprecated (#965).
+* The `new_data` argument for the `predict()` method for `censoring_model_reverse_km` objects has been deprecated (#965).
 
 * When computing censoring weights, the resulting vectors are no longer named (#1023).
 


### PR DESCRIPTION
`censoring_model_reverse_km` is the class of the objects returned by `reverse_km()`. Not sure if this means we should change the name of either but for now this is a very light touch-up on the NEWS so that it's correct.