### PR TITLE
Remove intercept coming from workflows based on engine encodings

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: parsnip
 Title: A Common API to Modeling and Analysis Functions
-Version: 1.1.1.9003
+Version: 1.1.1.9004
 Authors@R: c(
     person("Max", "Kuhn", , "max@posit.co", role = c("aut", "cre")),
     person("Davis", "Vaughan", , "davis@posit.co", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,9 @@
 
 * When computing censoring weights, the resulting vectors are no longer named (#1023).
 
+* Fixed a bug in the integration with workflows where using a model formula with a formula preprocessor could result in a double intercept (#1033).
+
+
 # parsnip 1.1.1
 
 * Fixed bug where prediction on rank deficient `lm()` models produced `.pred_res` instead of `.pred`. (#985)

--- a/R/convert_data.R
+++ b/R/convert_data.R
@@ -45,6 +45,10 @@
     rlang::abort("`composition` should be either 'data.frame' or 'matrix'.")
   }
 
+  if (remove_intercept) {
+    data <- data[, colnames(data) != "(Intercept)", drop = FALSE]
+  }
+
   ## Assemble model.frame call from call arguments
   mf_call <- quote(model.frame(formula, data))
   mf_call$na.action <- match.call()$na.action # TODO this should work better

--- a/R/fit_helpers.R
+++ b/R/fit_helpers.R
@@ -6,6 +6,15 @@
 form_form <-
   function(object, control, env, ...) {
 
+    encoding_info <-
+      get_encoding(class(object)[1]) %>%
+      dplyr::filter(mode == object$mode, engine == object$engine)
+
+    remove_intercept <- encoding_info %>% dplyr::pull(remove_intercept)
+    if (remove_intercept) {
+      env$data <- env$data[, colnames(env$data) != "(Intercept)", drop = FALSE]
+    }
+
     if (inherits(env$data, "data.frame")) {
       check_outcome(eval_tidy(rlang::f_lhs(env$formula), env$data), object)
     }


### PR DESCRIPTION
closes  #1032

parsnip captures in its encodings ([example](https://github.com/tidymodels/parsnip/blob/d65dde2185c02f30325b080faf5163bb0c0ede93/R/linear_reg_data.R#L28-L29)) what to do about the intercept for a specific engine. In a "pure parsnip use case" this only matters when parsnip has to convert data between its own formula interface and the engine's matrix interface, covered in `.convert_form_to_xy()`. (The reason why we might have both `include_intercept` and `remove_intercept` as `TRUE` is because the indicators for factor variables are affected by the absence/presence of the intercept.)

When a parsnip model is used inside of a workflow together with a formula as the preprocessor, the encodings matter again (they do not matter for other kinds of preprocessors):

In workflow's pre stage:
- `finalize_blueprint()` encodes `include_intercept` in the blueprint (if not supplied by the user, which is the default)
- `fit.action_formula()` uses the (preprocessing) formula and that blueprint to make the mold (containing the outcomes and the predictors) - this may now contain an intercept based on the encodings.

In workflow's fit stage:
- workflows sends the data (with the potential intercept) off to parsnip: 
  - to `fit()` if the workflow contains a model formula
  - to `fix_xy()` otherwise

In parsnip:
- one of four fit helpers will bridge between the parsnip interface and the engine interface (and actually get the fitted model):
  - `xy_xy()`
  - `xy_form()`
  - `form_form()`
  - `form_xy()`

That was all for fitting a model - they matter again when predicting with a model.
For "pure parsnip" and the formula-to-matrix conversion case, `.convert_form_to_xy_new()` deals with the intercept based on the encodings.
In workflows, predictors are `forge()`ed based on the blueprint generated during the fit process, containing the information on whether to include the intercept.

We've reckoned with that intercept coming in from workflows previously:
- For `xy_form()`: https://github.com/tidymodels/parsnip/pull/332, among many other things, adds a step inside of `.convert_xy_to_form_fit()` to remove the intercept from the predictor matrix (as always, based on the encodings) before putting it together with the outcome into a data frame and sending it off with a `y ~ .` formula. That `dot` will mean the engine may add its own intercept as appropriate.
- For `xy_xy()`, https://github.com/tidymodels/parsnip/pull/352 adds that encoding-based removal step.

And then we touched it once more, in the follow-up PR https://github.com/tidymodels/parsnip/pull/353/ where we added that step to `prepare_data()` which is used in parsnip's predict call stack, to remove the intercept added by workflow's predict method.

Leaves us with the `form_xy()` and `form_form()` cases. We've now found that one-too-many intercept for `form_xy()` in [this comment](https://github.com/tidymodels/censored/issues/272#issuecomment-1825871789) and for `form_form()` in https://github.com/tidymodels/workflows/issues/210.

So, after a lot of sleuthing and diagramming, this PR adds that encoding-based removal step to both those cases! 

As for prediction: we don't need to touch `prepare_data()` because for
- xy-to-form (aka the `xy_form()` case for fitting): `.convert_xy_to_form_new()` subsets on `x_var` from `$preproc` which was generated _after_ the intercept was removed.
- form-to-xy: `.convert_form_to_xy_new()` makes the model frame with the `terms` from `$preproce` which were (with this PR) now also generated _after_ the intercept from workflows was removed.
- xy-to-xy and form-to-form are both seeing the workflows intercept being removed by the step added in #353.

Tests are in https://github.com/tidymodels/extratests/pull/151


![workflows-parsnip-intercept](https://github.com/tidymodels/parsnip/assets/12950918/af2a4865-a9ac-4fc3-9a1a-c2463a699737)
