### PR TITLE
Don't modify spark data in `form_form()`

### DIFF
--- a/R/fit_helpers.R
+++ b/R/fit_helpers.R
@@ -6,17 +6,17 @@
 form_form <-
   function(object, control, env, ...) {
 
-    encoding_info <-
-      get_encoding(class(object)[1]) %>%
-      dplyr::filter(mode == object$mode, engine == object$engine)
-
-    remove_intercept <- encoding_info %>% dplyr::pull(remove_intercept)
-    if (remove_intercept) {
-      env$data <- env$data[, colnames(env$data) != "(Intercept)", drop = FALSE]
-    }
-
     if (inherits(env$data, "data.frame")) {
       check_outcome(eval_tidy(rlang::f_lhs(env$formula), env$data), object)
+
+      encoding_info <-
+        get_encoding(class(object)[1]) %>%
+        dplyr::filter(mode == object$mode, engine == object$engine)
+
+      remove_intercept <- encoding_info %>% dplyr::pull(remove_intercept)
+      if (remove_intercept) {
+        env$data <- env$data[, colnames(env$data) != "(Intercept)", drop = FALSE]
+      }
     }
 
     # prob rewrite this as simple subset/levels


### PR DESCRIPTION
#1033 added an encodings-based removal of the intercept column to `form_form()`, which broke the spark case-weights tests in extratests.

So this PR moves that step so that we don't try this for spark data.