### PR TITLE
Move .censoring weights graf.workflow

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: parsnip
 Title: A Common API to Modeling and Analysis Functions
-Version: 1.1.1.9005
+Version: 1.1.1.9007
 Authors@R: c(
     person("Max", "Kuhn", , "max@posit.co", role = c("aut", "cre")),
     person("Davis", "Vaughan", , "davis@posit.co", role = "aut"),

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,7 +2,6 @@
 
 S3method(.censoring_weights_graf,default)
 S3method(.censoring_weights_graf,model_fit)
-S3method(.censoring_weights_graf,workflow)
 S3method(augment,model_fit)
 S3method(autoplot,glmnet)
 S3method(autoplot,model_fit)

--- a/R/survival-censoring-weights.R
+++ b/R/survival-censoring-weights.R
@@ -178,19 +178,6 @@ graf_weight_time_vec <- function(surv_obj, eval_time, eps = 10^-10) {
   rlang::abort(msg)
 }
 
-
-#' @export
-#' @rdname censoring_weights
-.censoring_weights_graf.workflow <- function(object,
-                                             predictions,
-                                             cens_predictors = NULL,
-                                             trunc = 0.05, eps = 10^-10, ...) {
-  if (is.null(object$fit$fit)) {
-    rlang::abort("The workflow does not have a model fit object.")
-  }
-  .censoring_weights_graf(object$fit$fit, predictions, cens_predictors, trunc, eps)
-}
-
 #' @export
 #' @rdname censoring_weights
 .censoring_weights_graf.model_fit <- function(object,

--- a/man/censoring_weights.Rd
+++ b/man/censoring_weights.Rd
@@ -4,22 +4,12 @@
 \alias{censoring_weights}
 \alias{.censoring_weights_graf}
 \alias{.censoring_weights_graf.default}
-\alias{.censoring_weights_graf.workflow}
 \alias{.censoring_weights_graf.model_fit}
 \title{Calculations for inverse probability of censoring weights (IPCW)}
 \usage{
 .censoring_weights_graf(object, ...)
 
 \method{.censoring_weights_graf}{default}(object, ...)
-
-\method{.censoring_weights_graf}{workflow}(
-  object,
-  predictions,
-  cens_predictors = NULL,
-  trunc = 0.05,
-  eps = 10^-10,
-  ...
-)
 
 \method{.censoring_weights_graf}{model_fit}(
   object,


### PR DESCRIPTION
to close https://github.com/tidymodels/parsnip/issues/968

Paired {workflows} PR: https://github.com/tidymodels/workflows/pull/213

There are 4 possible scenarios:

## `.censoring_weights_graf.workflow()` is exported from only {parsnip}

This is fine!

Happens if `parsnip < 1.1.1.9007` and `workflows < 1.1.3.9001`, which is another way of saying that both packages are installed before Dec 12.

## `.censoring_weights_graf.workflow()` is exported from only {workflows}

This is fine!

Happens if `parsnip >= 1.1.1.9007` and `workflows >= 1.1.3.9001`, which is another way of saying that both packages are installed after Dec 12 (or whenever the PRs are merged in.

## `.censoring_weights_graf.workflow()` is exported from both {parsnip} and {workflows}

This is not good.

Would need `parsnip < 1.1.1.9007` and `workflows >= 1.1.3.9001`. Which can't happen as workflows `1.1.3.9001` requires `parsnip >= 1.1.1.9007`. So we are good here.

##`.censoring_weights_graf.workflow()` isn't exported

Would happen if `parsnip >= 1.1.1.9007` and `workflow < 1.1.3.9001`. Which could happen. I can't recall if there is a way for us to deal with this last point