### PR TITLE
document censored regression as a possible mode

### DIFF
--- a/R/bag_tree.R
+++ b/R/bag_tree.R
@@ -10,6 +10,7 @@
 #' More information on how \pkg{parsnip} is used for modeling is at
 #' \url{https://www.tidymodels.org/}.
 #'
+#' @inheritParams boost_tree
 #' @inheritParams decision_tree
 #' @param class_cost A non-negative scalar for a class cost (where a cost of 1
 #' means no extra cost). This is useful for when the first level of the outcome

--- a/R/bart.R
+++ b/R/bart.R
@@ -11,6 +11,7 @@
 #' More information on how \pkg{parsnip} is used for modeling is at
 #' \url{https://www.tidymodels.org/}.
 #'
+#' @inheritParams nearest_neighbor
 #' @inheritParams boost_tree
 #' @param prior_terminal_node_coef A coefficient for the prior probability that
 #' a node is a terminal node. Values are usually between 0 and one with

--- a/R/boost_tree.R
+++ b/R/boost_tree.R
@@ -15,8 +15,8 @@
 #' \url{https://www.tidymodels.org/}.
 #'
 #' @param mode A single character string for the prediction outcome mode.
-#'  Possible values for this model are "unknown", "regression", or
-#'  "classification".
+#'  Possible values for this model are "unknown", "regression",
+#'  "classification", or "censored regression".
 #' @param engine A single character string specifying what computational engine
 #'  to use for fitting.
 #' @param mtry A number for the number (or proportion) of predictors that will

--- a/R/c5_rules.R
+++ b/R/c5_rules.R
@@ -13,7 +13,7 @@
 #' More information on how \pkg{parsnip} is used for modeling is at
 #' \url{https://www.tidymodels.org/}.
 #'
-#' @inheritParams boost_tree
+#' @inheritParams nearest_neighbor
 #' @param mode A single character string for the type of model.
 #'  The only possible value for this model is "classification".
 #' @param trees A non-negative integer (no greater than 100) for the number

--- a/R/cubist_rules.R
+++ b/R/cubist_rules.R
@@ -10,7 +10,7 @@
 #' More information on how \pkg{parsnip} is used for modeling is at
 #' \url{https://www.tidymodels.org/}.
 #'
-#' @inheritParams boost_tree
+#' @inheritParams nearest_neighbor
 #' @param mode A single character string for the type of model.
 #'  The only possible value for this model is "regression".
 #' @param committees A non-negative integer (no greater than 100) for the number

--- a/R/decision_tree.R
+++ b/R/decision_tree.R
@@ -12,7 +12,7 @@
 #' More information on how \pkg{parsnip} is used for modeling is at
 #' \url{https://www.tidymodels.org/}.
 #'
-#' @inheritParams nearest_neighbor
+#' @inheritParams boost_tree
 #' @param cost_complexity A positive number for the the cost/complexity
 #'   parameter (a.k.a. `Cp`) used by CART models (specific engines only).
 #' @param tree_depth An integer for maximum depth of the tree.

--- a/R/decision_tree.R
+++ b/R/decision_tree.R
@@ -12,7 +12,7 @@
 #' More information on how \pkg{parsnip} is used for modeling is at
 #' \url{https://www.tidymodels.org/}.
 #'
-#' @inheritParams boost_tree
+#' @inheritParams nearest_neighbor
 #' @param cost_complexity A positive number for the the cost/complexity
 #'   parameter (a.k.a. `Cp`) used by CART models (specific engines only).
 #' @param tree_depth An integer for maximum depth of the tree.

--- a/R/discrim_flexible.R
+++ b/R/discrim_flexible.R
@@ -11,7 +11,7 @@
 #' More information on how \pkg{parsnip} is used for modeling is at
 #' \url{https://www.tidymodels.org/}.
 #'
-#' @inheritParams boost_tree
+#' @inheritParams nearest_neighbor
 #' @inheritParams discrim_linear
 #' @param num_terms The number of features that will be retained in the
 #'    final model, including the intercept.

--- a/R/discrim_linear.R
+++ b/R/discrim_linear.R
@@ -13,7 +13,7 @@
 #' More information on how \pkg{parsnip} is used for modeling is at
 #' \url{https://www.tidymodels.org/}.
 #'
-#' @inheritParams boost_tree
+#' @inheritParams nearest_neighbor
 #' @param mode A single character string for the type of model. The only
 #'  possible value for this model is "classification".
 #' @param penalty An non-negative number representing the amount of

--- a/R/discrim_quad.R
+++ b/R/discrim_quad.R
@@ -13,7 +13,7 @@
 #' More information on how \pkg{parsnip} is used for modeling is at
 #' \url{https://www.tidymodels.org/}.
 #'
-#' @inheritParams boost_tree
+#' @inheritParams nearest_neighbor
 #' @param mode A single character string for the type of model. The only
 #'  possible value for this model is "classification".
 #' @param regularization_method A character string for the type of regularized

--- a/R/discrim_regularized.R
+++ b/R/discrim_regularized.R
@@ -13,7 +13,7 @@
 #' More information on how \pkg{parsnip} is used for modeling is at
 #' \url{https://www.tidymodels.org/}.
 #'
-#' @inheritParams boost_tree
+#' @inheritParams nearest_neighbor
 #' @inheritParams discrim_linear
 #' @param frac_common_cov,frac_identity Numeric values between zero and one.
 #'

--- a/R/gen_additive_mod.R
+++ b/R/gen_additive_mod.R
@@ -10,7 +10,7 @@
 #' More information on how \pkg{parsnip} is used for modeling is at
 #' \url{https://www.tidymodels.org/}.
 #'
-#' @inheritParams boost_tree
+#' @inheritParams nearest_neighbor
 #' @param select_features `TRUE` or `FALSE.` If `TRUE`, the model has the
 #'  ability to eliminate a predictor (via penalization). Increasing
 #'  `adjust_deg_free` will increase the likelihood of removing predictors.

--- a/R/mars.R
+++ b/R/mars.R
@@ -12,7 +12,7 @@
 #' More information on how \pkg{parsnip} is used for modeling is at
 #' \url{https://www.tidymodels.org/}.
 #'
-#' @inheritParams boost_tree
+#' @inheritParams nearest_neighbor
 #' @param num_terms The number of features that will be retained in the
 #'    final model, including the intercept.
 #' @param prod_degree The highest possible interaction degree.

--- a/R/mlp.R
+++ b/R/mlp.R
@@ -10,6 +10,7 @@
 #' More information on how \pkg{parsnip} is used for modeling is at
 #' \url{https://www.tidymodels.org/}.
 #'
+#' @inheritParams nearest_neighbor
 #' @inheritParams boost_tree
 #' @param hidden_units An integer for the number of units in the hidden model.
 #' @param penalty A non-negative numeric value for the amount of weight

--- a/R/naive_Bayes.R
+++ b/R/naive_Bayes.R
@@ -11,7 +11,7 @@
 #' More information on how \pkg{parsnip} is used for modeling is at
 #' \url{https://www.tidymodels.org/}.
 #'
-#' @inheritParams boost_tree
+#' @inheritParams nearest_neighbor
 #' @inheritParams discrim_linear
 #' @param smoothness An non-negative number representing the the relative
 #'  smoothness of the class boundary. Smaller examples result in model flexible

--- a/R/nearest_neighbor.R
+++ b/R/nearest_neighbor.R
@@ -11,7 +11,11 @@
 #' More information on how \pkg{parsnip} is used for modeling is at
 #' \url{https://www.tidymodels.org/}.
 #'
-#' @inheritParams boost_tree
+#' @param mode A single character string for the prediction outcome mode.
+#'  Possible values for this model are "unknown", "regression", or
+#'  "classification".
+#' @param engine A single character string specifying what computational engine
+#'  to use for fitting.
 #' @param neighbors A single integer for the number of neighbors
 #' to consider (often called `k`). For \pkg{kknn}, a value of 5
 #' is used if `neighbors` is not specified.

--- a/R/pls.R
+++ b/R/pls.R
@@ -10,7 +10,7 @@
 #' More information on how \pkg{parsnip} is used for modeling is at
 #' \url{https://www.tidymodels.org/}.
 #'
-#' @inheritParams boost_tree
+#' @inheritParams nearest_neighbor
 #' @param predictor_prop The maximum proportion of original predictors that can
 #'  have _non-zero_ coefficients for each PLS component (via regularization).
 #'  This value is used for all PLS components for X.

--- a/R/poisson_reg.R
+++ b/R/poisson_reg.R
@@ -10,7 +10,7 @@
 #' More information on how \pkg{parsnip} is used for modeling is at
 #' \url{https://www.tidymodels.org/}.
 #'
-#' @inheritParams boost_tree
+#' @inheritParams nearest_neighbor
 #' @param mode A single character string for the type of model.
 #'  The only possible value for this model is "regression".
 #' @param penalty A non-negative number representing the total

--- a/R/proportional_hazards.R
+++ b/R/proportional_hazards.R
@@ -10,7 +10,7 @@
 #' More information on how \pkg{parsnip} is used for modeling is at
 #' \url{https://www.tidymodels.org/}.
 #'
-#' @inheritParams boost_tree
+#' @inheritParams nearest_neighbor
 #' @inheritParams linear_reg
 #' @param mode A single character string for the prediction outcome mode.
 #'  The only possible value for this model is "censored regression".

--- a/R/rand_forest.R
+++ b/R/rand_forest.R
@@ -12,7 +12,7 @@
 #' More information on how \pkg{parsnip} is used for modeling is at
 #' \url{https://www.tidymodels.org/}.
 #'
-#' @inheritParams nearest_neighbor
+#' @inheritParams boost_tree
 #' @param mtry An integer for the number of predictors that will
 #'  be randomly sampled at each split when creating the tree models.
 #' @param trees An integer for the number of trees contained in

--- a/R/rand_forest.R
+++ b/R/rand_forest.R
@@ -12,7 +12,7 @@
 #' More information on how \pkg{parsnip} is used for modeling is at
 #' \url{https://www.tidymodels.org/}.
 #'
-#' @inheritParams boost_tree
+#' @inheritParams nearest_neighbor
 #' @param mtry An integer for the number of predictors that will
 #'  be randomly sampled at each split when creating the tree models.
 #' @param trees An integer for the number of trees contained in

--- a/R/rule_fit.R
+++ b/R/rule_fit.R
@@ -10,6 +10,7 @@
 #' More information on how \pkg{parsnip} is used for modeling is at
 #' \url{https://www.tidymodels.org/}.
 #'
+#' @inheritParams nearest_neighbor
 #' @inheritParams boost_tree
 #' @param penalty L1 regularization parameter.
 #' @details

--- a/R/surv_reg.R
+++ b/R/surv_reg.R
@@ -11,7 +11,7 @@
 #' More information on how \pkg{parsnip} is used for modeling is at
 #' \url{https://www.tidymodels.org/}.
 #'
-#' @inheritParams boost_tree
+#' @inheritParams nearest_neighbor
 #' @param mode A single character string for the prediction outcome mode.
 #'  The only possible value for this model is "regression".
 #' @param dist A character string for the probability distribution of the

--- a/R/survival_reg.R
+++ b/R/survival_reg.R
@@ -9,7 +9,7 @@
 #' More information on how \pkg{parsnip} is used for modeling is at
 #' \url{https://www.tidymodels.org/}.
 #'
-#' @inheritParams boost_tree
+#' @inheritParams nearest_neighbor
 #' @param mode A single character string for the prediction outcome mode.
 #'  The only possible value for this model is "censored regression".
 #' @param dist A character string for the probability distribution of the

--- a/R/svm_linear.R
+++ b/R/svm_linear.R
@@ -13,7 +13,7 @@
 #' More information on how \pkg{parsnip} is used for modeling is at
 #' \url{https://www.tidymodels.org/}.
 #'
-#' @inheritParams boost_tree
+#' @inheritParams nearest_neighbor
 #' @param cost A positive number for the cost of predicting a sample within
 #'  or on the wrong side of the margin
 #' @param margin A positive number for the epsilon in the SVM insensitive

--- a/R/svm_poly.R
+++ b/R/svm_poly.R
@@ -14,7 +14,7 @@
 #' More information on how \pkg{parsnip} is used for modeling is at
 #' \url{https://www.tidymodels.org/}.
 #'
-#' @inheritParams boost_tree
+#' @inheritParams nearest_neighbor
 #' @param cost A positive number for the cost of predicting a sample within
 #'  or on the wrong side of the margin
 #' @param degree A positive number for polynomial degree.

--- a/R/svm_rbf.R
+++ b/R/svm_rbf.R
@@ -14,7 +14,7 @@
 #' More information on how \pkg{parsnip} is used for modeling is at
 #' \url{https://www.tidymodels.org/}.
 #'
-#' @inheritParams boost_tree
+#' @inheritParams nearest_neighbor
 #' @param engine A single character string specifying what computational engine
 #'  to use for fitting. Possible engines are listed below. The default for this
 #'  model is `"kernlab"`.

--- a/man/bag_tree.Rd
+++ b/man/bag_tree.Rd
@@ -15,16 +15,17 @@ bag_tree(
 }
 \arguments{
 \item{mode}{A single character string for the prediction outcome mode.
-Possible values for this model are "unknown", "regression", or
-"classification".}
+Possible values for this model are "unknown", "regression",
+"classification", or "censored regression".}
 
 \item{cost_complexity}{A positive number for the the cost/complexity
 parameter (a.k.a. \code{Cp}) used by CART models (specific engines only).}
 
-\item{tree_depth}{An integer for maximum depth of the tree.}
+\item{tree_depth}{An integer for the maximum depth of the tree (i.e. number
+of splits) (specific engines only).}
 
 \item{min_n}{An integer for the minimum number of data points
-in a node that are required for the node to be split further.}
+in a node that is required for the node to be split further.}
 
 \item{class_cost}{A non-negative scalar for a class cost (where a cost of 1
 means no extra cost). This is useful for when the first level of the outcome

--- a/man/boost_tree.Rd
+++ b/man/boost_tree.Rd
@@ -19,8 +19,8 @@ boost_tree(
 }
 \arguments{
 \item{mode}{A single character string for the prediction outcome mode.
-Possible values for this model are "unknown", "regression", or
-"classification".}
+Possible values for this model are "unknown", "regression",
+"classification", or "censored regression".}
 
 \item{engine}{A single character string specifying what computational engine
 to use for fitting.}

--- a/man/decision_tree.Rd
+++ b/man/decision_tree.Rd
@@ -14,8 +14,8 @@ decision_tree(
 }
 \arguments{
 \item{mode}{A single character string for the prediction outcome mode.
-Possible values for this model are "unknown", "regression", or
-"classification".}
+Possible values for this model are "unknown", "regression",
+"classification", or "censored regression".}
 
 \item{engine}{A single character string specifying what computational engine
 to use for fitting.}

--- a/man/rand_forest.Rd
+++ b/man/rand_forest.Rd
@@ -14,8 +14,8 @@ rand_forest(
 }
 \arguments{
 \item{mode}{A single character string for the prediction outcome mode.
-Possible values for this model are "unknown", "regression", or
-"classification".}
+Possible values for this model are "unknown", "regression",
+"classification", or "censored regression".}
 
 \item{engine}{A single character string specifying what computational engine
 to use for fitting.}


### PR DESCRIPTION
To close https://github.com/tidymodels/parsnip/issues/661.

I switched the default to nearest neighbor for classification/regression