### PR TITLE
give .filter_eval_time() more informative warning

### DIFF
--- a/R/standalone-survival.R
+++ b/R/standalone-survival.R
@@ -162,7 +162,7 @@
     cli::cli_warn(
       c(
         "There {?was/were} {diffs} inappropriate evaluation time \\
-        point{?s} that {?was/were} removed. They were:",
+        point{?s} that {?was/were} removed. {?It was/They were}:",
         offenders
       ),
       call = NULL

--- a/R/standalone-survival.R
+++ b/R/standalone-survival.R
@@ -132,10 +132,38 @@
     )
   }
   if (!identical(eval_time, eval_time_0)) {
-    diffs <- setdiff(eval_time_0, eval_time)
-    cli::cli_warn("There {?was/were} {length(diffs)} inappropriate evaluation
-                  time point{?s} that {?was/were} removed.", call = NULL)
+    diffs <- length(eval_time_0) - length(eval_time)
 
+    offenders <- character()
+
+    n_na <- sum(is.na(eval_time_0))
+    if (n_na > 0) {
+      offenders <- c(offenders, "*" = "{n_na} missing value{?s}.")
+    }
+
+    n_inf <- sum(is.infinite(eval_time_0))
+    if (n_inf > 0) {
+      offenders <- c(offenders, "*" = "{n_inf} infinite value{?s}.")
+    }
+
+    n_neg <- sum(eval_time_0 < 0, na.rm = TRUE)
+    if (n_neg > 0) {
+      offenders <- c(offenders, "*" = "{n_neg} negative value{?s}.")
+    }
+
+    n_dup <- diffs - n_na - n_inf - n_neg
+    if (n_dup > 0) {
+      offenders <- c(offenders, "*" = "{n_dup} duplicate value{?s}.")
+    }
+
+    cli::cli_warn(
+      c(
+        "There {?was/were} {diffs} inappropriate evaluation time \\
+        point{?s} that {?was/were} removed. They were:",
+        offenders
+      ),
+      call = NULL
+    )
   }
   eval_time
 }

--- a/R/standalone-survival.R
+++ b/R/standalone-survival.R
@@ -1,7 +1,7 @@
 # ---
 # repo: tidymodels/parsnip
 # file: standalone-survival.R
-# last-updated: 2023-12-08
+# last-updated: 2024-01-10
 # license: https://unlicense.org
 # ---
 
@@ -9,8 +9,11 @@
 #
 
 # ## Changelog
+# 2024-01-10
+# * .filter_eval_time() gives more informative warning.
+#
 # 2023-12-08
-# * move .filter_eval_time to this file
+# * move .filter_eval_time() to this file
 #
 # 2023-11-09
 # * make sure survival vectors are unnamed.

--- a/tests/testthat/_snaps/standalone-survival.md
+++ b/tests/testthat/_snaps/standalone-survival.md
@@ -36,7 +36,7 @@
       parsnip:::.filter_eval_time(times_remove_singular)
     Condition
       Warning:
-      There was 1 inappropriate evaluation time point that was removed. They were:
+      There was 1 inappropriate evaluation time point that was removed. It was:
       * 1 negative value.
     Output
        [1]  0  1  2  3  4  5  6  7  8  9 10

--- a/tests/testthat/_snaps/standalone-survival.md
+++ b/tests/testthat/_snaps/standalone-survival.md
@@ -4,7 +4,8 @@
       parsnip:::.filter_eval_time(times_duplicated)
     Condition
       Warning:
-      There were 0 inappropriate evaluation time points that were removed.
+      There were 11 inappropriate evaluation time points that were removed. They were:
+      * 11 duplicate values.
     Output
        [1]  0  1  2  3  4  5  6  7  8  9 10
 
@@ -22,7 +23,10 @@
       parsnip:::.filter_eval_time(times_remove_plural)
     Condition
       Warning:
-      There were 3 inappropriate evaluation time points that were removed.
+      There were 3 inappropriate evaluation time points that were removed. They were:
+      * 1 missing value.
+      * 1 infinite value.
+      * 1 negative value.
     Output
        [1]  0  1  2  3  4  5  6  7  8  9 10
 
@@ -32,7 +36,8 @@
       parsnip:::.filter_eval_time(times_remove_singular)
     Condition
       Warning:
-      There was 1 inappropriate evaluation time point that was removed.
+      There was 1 inappropriate evaluation time point that was removed. They were:
+      * 1 negative value.
     Output
        [1]  0  1  2  3  4  5  6  7  8  9 10
 


### PR DESCRIPTION
To close #967 

I went all in! it is super fancy now

``` r
library(parsnip)

times_duplicated <- c(1:9, 1:4, NA, Inf, -4, -4, -3)
parsnip:::.filter_eval_time(times_duplicated)
#> Warning: There were 9 inappropriate evaluation time points that were removed. They were:
#> • 1 missing value.
#> • 1 infinite value.
#> • 3 negative values.
#> • 4 duplicate values.
#> [1] 1 2 3 4 5 6 7 8 9
```