### PR TITLE
enable setting `stop_iter` with brulee `mlp()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # parsnip (development version)
 
+* Fixed issue in `mlp()` metadata where the `stop_iter` engine argument had been mistakenly protected for the `"brulee"` engine. (#1050)
+
 * `.filter_eval_time()` was moved to the survival standalone file. 
 
 * Improved errors and documentation related to special terms in formulas. See `?model_formula` to learn more. (#770, #1014)

--- a/R/mlp_data.R
+++ b/R/mlp_data.R
@@ -433,16 +433,6 @@ set_model_arg(
   has_submodel = FALSE
 )
 
-
-set_model_arg(
-  model = "mlp",
-  eng = "brulee",
-  parsnip = "stop_iter",
-  original = "stop_iter",
-  func = list(pkg = "dials", fun = "stop_iter"),
-  has_submodel = FALSE
-)
-
 set_model_arg(
   model = "mlp",
   eng = "brulee",


### PR DESCRIPTION
Closes #1050.🏄

`stop_iter` had been mistakenly registered as a model argument for `mlp()`.

``` r
library(tidymodels)

set.seed(1)
mlp(hidden_units = 5, epochs = 100) %>% 
  set_engine("brulee", stop_iter = 5)  %>% 
  set_mode("regression") %>%
  fit(price ~ latitude + longitude, data = Sacramento)
#> parsnip model object
#> 
#> Multilayer perceptron
#> 
#> relu activation
#> 5 hidden units,  21 model parameters
#> 932 samples, 2 features, numeric outcome 
#> weight decay: 0.001 
#> dropout proportion: 0 
#> batch size: 839 
#> learn rate: 0.01 
#> scaled validation loss after 100 epochs: 1.29


# tunable information is still preserved:
set.seed(1)
res <- 
  tune_grid(
    mlp(hidden_units = 3, epochs = 50) %>% 
      set_engine("brulee", stop_iter = tune())  %>% 
      set_mode("regression"),
    price ~ latitude + longitude,
    vfold_cv(Sacramento, v = 5),
    grid = 3
  )
#> → A | warning: A correlation computation is required, but `estimate` is constant and has 0
#>                standard deviation, resulting in a divide by 0 error. `NA` will be returned.
#> There were issues with some computations   A: x1
#> There were issues with some computations   A: x4
#> There were issues with some computations   A: x5
#> 

collect_metrics(res)
#> # A tibble: 6 × 7
#>   stop_iter .metric .estimator    mean     n  std_err .config             
#>       <int> <chr>   <chr>        <dbl> <int>    <dbl> <chr>               
#> 1        19 rmse    standard   1.46e+5     5  1.17e+4 Preprocessor1_Model1
#> 2        19 rsq     standard   2.61e-2     1 NA       Preprocessor1_Model1
#> 3        13 rmse    standard   2.74e+9     5  2.74e+9 Preprocessor1_Model2
#> 4        13 rsq     standard   8.45e-2     1 NA       Preprocessor1_Model2
#> 5         5 rmse    standard   2.99e+9     5  1.88e+9 Preprocessor1_Model3
#> 6         5 rsq     standard   1.14e-1     2  2.74e-2 Preprocessor1_Model3
```

<sup>Created on 2024-01-16 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

Probably worth writing up a quick check to see if we've done this anywhere else. :)