### PR TITLE
make missing eval_time error in augment more informative

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: parsnip
 Title: A Common API to Modeling and Analysis Functions
-Version: 1.1.1.9007
+Version: 1.1.1.9008
 Authors@R: c(
     person("Max", "Kuhn", , "max@posit.co", role = c("aut", "cre")),
     person("Davis", "Vaughan", , "davis@posit.co", role = "aut"),

--- a/R/augment.R
+++ b/R/augment.R
@@ -128,8 +128,12 @@ augment_censored <- function(x, new_data, eval_time = NULL) {
 
   if (spec_has_pred_type(x, "survival")) {
     if (is.null(eval_time)) {
-      rlang::abort(
-        "The `eval_time` argument is missing, with no default.",
+      cli::cli_abort(
+        c(
+          x = "The {.arg eval_time} argument is missing, with no default.",
+          i = "{.arg eval_time} is required to be able to calculate \\
+              predictions of survival probability."
+        ),
         call = caller_env()
       )
     }


### PR DESCRIPTION
To close https://github.com/tidymodels/parsnip/issues/1049

``` r
library(censored)

proportional_hazards() %>%
  fit(Surv(time, status) ~ ., data = lung) %>% 
  augment(new_data = lung)
#> Error in `augment()`:
#> ✖ The `eval_time` argument is missing, with no default.
#> ℹ `eval_time` is required to be able to calculate predictions of survival
#>   probability.
```