### PR TITLE
Sync code/comment patterns across prediction types

### DIFF
--- a/R/predict_hazard.R
+++ b/R/predict_hazard.R
@@ -32,7 +32,7 @@ predict_hazard.model_fit <- function(object,
   if (!is.null(object$spec$method$pred$hazard$pre))
     new_data <- object$spec$method$pred$hazard$pre(new_data, object)
 
-  # Pass some extra arguments to be used in post-processor
+  # create prediction call
   pred_call <- make_pred_call(object$spec$method$pred$hazard)
 
   res <- eval_tidy(pred_call)

--- a/R/predict_linear_pred.R
+++ b/R/predict_linear_pred.R
@@ -23,8 +23,8 @@ predict_linear_pred.model_fit <- function(object, new_data, ...) {
   pred_call <- make_pred_call(object$spec$method$pred$linear_pred)
 
   res <- eval_tidy(pred_call)
-  # post-process the predictions
 
+  # post-process the predictions
   if (!is.null(object$spec$method$pred$linear_pred$post)) {
     res <- object$spec$method$pred$linear_pred$post(res, object)
   }

--- a/R/predict_numeric.R
+++ b/R/predict_numeric.R
@@ -27,8 +27,8 @@ predict_numeric.model_fit <- function(object, new_data, ...) {
   pred_call <- make_pred_call(object$spec$method$pred$numeric)
 
   res <- eval_tidy(pred_call)
+  
   # post-process the predictions
-
   if (!is.null(object$spec$method$pred$numeric$post)) {
     res <- object$spec$method$pred$numeric$post(res, object)
   }

--- a/R/predict_survival.R
+++ b/R/predict_survival.R
@@ -34,7 +34,7 @@ predict_survival.model_fit <- function(object,
   if (!is.null(object$spec$method$pred$survival$pre))
     new_data <- object$spec$method$pred$survival$pre(new_data, object)
 
-  # Pass some extra arguments to be used in post-processor
+  # create prediction call
   pred_call <- make_pred_call(object$spec$method$pred$survival)
 
   res <- eval_tidy(pred_call)

--- a/R/predict_time.R
+++ b/R/predict_time.R
@@ -27,8 +27,8 @@ predict_time.model_fit <- function(object, new_data, ...) {
   pred_call <- make_pred_call(object$spec$method$pred$time)
 
   res <- eval_tidy(pred_call)
+  
   # post-process the predictions
-
   if (!is.null(object$spec$method$pred$time$post)) {
     res <- object$spec$method$pred$time$post(res, object)
   }


### PR DESCRIPTION
#1066 removed the extra arguments we were adding to the prediction call so this PR updates the corresponding comment to the same one used across other prediction types. (Bonus: fixing some formatting while I was looking at those lines of code.)