### PR TITLE
test parsnip "overhead"

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -56,7 +56,7 @@ jobs:
           needs: check
 
       - name: Install dev reticulate
-        run: pak::pkg_install('reticulate')
+        run: pak::pkg_install('rstudio/reticulate')
         shell: Rscript {0}
 
       - name: Install Miniconda

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,6 +40,7 @@ Imports:
     withr
 Suggests: 
     C50,
+    bench,
     covr,
     dials (>= 1.1.0),
     earth,

--- a/tests/testthat/test_fit_interfaces.R
+++ b/tests/testthat/test_fit_interfaces.R
@@ -156,6 +156,8 @@ test_that("fit() can handle attributes on a vector outcome", {
 })
 
 test_that("overhead of parsnip interface is minimal", {
+  skip_on_cran()
+
   timing <- function(expr) {
     expr <- substitute(expr)
     system.time(replicate(100, eval(expr)))[["elapsed"]]

--- a/tests/testthat/test_fit_interfaces.R
+++ b/tests/testthat/test_fit_interfaces.R
@@ -155,7 +155,7 @@ test_that("fit() can handle attributes on a vector outcome", {
   )
 })
 
-test_that("overhead of parsnip interface is minimal", {
+test_that("overhead of parsnip interface is minimal (#1071)", {
   skip_on_cran()
 
   timing <- function(expr) {

--- a/tests/testthat/test_fit_interfaces.R
+++ b/tests/testthat/test_fit_interfaces.R
@@ -154,3 +154,20 @@ test_that("fit() can handle attributes on a vector outcome", {
     ignore_attr = TRUE
   )
 })
+
+test_that("overhead of parsnip interface is minimal", {
+  timing <- function(expr) {
+    expr <- substitute(expr)
+    system.time(replicate(100, eval(expr)))[["elapsed"]]
+  }
+
+  time_engine <-
+    timing(lm(mpg ~ ., mtcars))
+  time_parsnip_form <-
+    timing(fit(parsnip::linear_reg(), mpg ~ ., mtcars))
+  time_parsnip_xy <-
+    timing(fit_xy(parsnip::linear_reg(), mtcars[2:11], mtcars[1]))
+
+  expect_true(time_parsnip_form / time_engine < 4.5)
+  expect_true(time_parsnip_xy / time_engine < 6)
+})

--- a/tests/testthat/test_fit_interfaces.R
+++ b/tests/testthat/test_fit_interfaces.R
@@ -158,19 +158,16 @@ test_that("fit() can handle attributes on a vector outcome", {
 test_that("overhead of parsnip interface is minimal (#1071)", {
   skip_on_cran()
   skip_on_covr()
+  skip_if_not_installed("bench")
 
-  timing <- function(expr) {
-    expr <- substitute(expr)
-    system.time(replicate(100, eval(expr)))[["elapsed"]]
-  }
+  bm <- bench::mark(
+    time_engine = lm(mpg ~ ., mtcars),
+    time_parsnip_form = fit(linear_reg(), mpg ~ ., mtcars),
+    time_parsnip_xy = fit_xy(linear_reg(), mtcars[2:11],  mtcars[1]),
+    relative = TRUE,
+    check = FALSE
+  )
 
-  time_engine <-
-    timing(lm(mpg ~ ., mtcars))
-  time_parsnip_form <-
-    timing(fit(linear_reg(), mpg ~ ., mtcars))
-  time_parsnip_xy <-
-    timing(fit_xy(linear_reg(), mtcars[2:11], mtcars[1]))
-
-  expect_true(time_parsnip_form / time_engine < 4.5)
-  expect_true(time_parsnip_xy / time_engine < 6)
+  expect_true(bm$median[2] < 3, label = "parsnip overhead is minimal (formula interface)")
+  expect_true(bm$median[3] < 3.5, , label = "parsnip overhead is minimal (xy interface)")
 })

--- a/tests/testthat/test_fit_interfaces.R
+++ b/tests/testthat/test_fit_interfaces.R
@@ -166,9 +166,9 @@ test_that("overhead of parsnip interface is minimal (#1071)", {
   time_engine <-
     timing(lm(mpg ~ ., mtcars))
   time_parsnip_form <-
-    timing(fit(parsnip::linear_reg(), mpg ~ ., mtcars))
+    timing(fit(linear_reg(), mpg ~ ., mtcars))
   time_parsnip_xy <-
-    timing(fit_xy(parsnip::linear_reg(), mtcars[2:11], mtcars[1]))
+    timing(fit_xy(linear_reg(), mtcars[2:11], mtcars[1]))
 
   expect_true(time_parsnip_form / time_engine < 4.5)
   expect_true(time_parsnip_xy / time_engine < 6)

--- a/tests/testthat/test_fit_interfaces.R
+++ b/tests/testthat/test_fit_interfaces.R
@@ -157,6 +157,7 @@ test_that("fit() can handle attributes on a vector outcome", {
 
 test_that("overhead of parsnip interface is minimal (#1071)", {
   skip_on_cran()
+  skip_on_covr()
 
   timing <- function(expr) {
     expr <- substitute(expr)


### PR DESCRIPTION
Some minimal testing to alert us when we've allowed additional "overhead" to creep in. A more true test of overhead would test differences rather than ratios, but those numbers are largely system-dependent.

My intent here is not that we'd automatically reject a PR that causes this test to fail, but to let us know when a PR changes these ratios and give us a chance to consider whether the slowdown is worth the benefit or ought to be addressed.