### PR TITLE
address slowdown in `get_model_spec()`

### DIFF
--- a/R/translate.R
+++ b/R/translate.R
@@ -102,8 +102,6 @@ translate.default <- function(x, engine = x$engine, ...) {
 
 get_model_spec <- function(model, mode, engine) {
   m_env <- get_model_env()
-  env_obj <- rlang::env_names(m_env)
-  env_obj <- grep(model, env_obj, value = TRUE)
 
   res <- list()
 


### PR DESCRIPTION
This `env_obj` isn't used elsewhere in the function and accounts for a decent chunk of the overhead in this example.

With dev parsnip:

``` r
library(parsnip)

bench::mark(fit = fit(linear_reg(), mpg ~ ., mtcars))
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 fit          1.51ms   1.78ms      547.    3.76MB     32.5
```

With this PR:

``` r
library(parsnip)

bench::mark(fit = fit(linear_reg(), mpg ~ ., mtcars))
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 fit          1.41ms   1.51ms      642.    3.75MB     36.7
```

<sup>Created on 2024-02-26 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>