### PR TITLE
address slowdown in `form_form()`

### DIFF
--- a/R/fit_helpers.R
+++ b/R/fit_helpers.R
@@ -9,9 +9,12 @@ form_form <-
     if (inherits(env$data, "data.frame")) {
       check_outcome(eval_tidy(rlang::f_lhs(env$formula), env$data), object)
 
+      encoding_info <- get_encoding(class(object)[1])
       encoding_info <-
-        get_encoding(class(object)[1]) %>%
-        dplyr::filter(mode == object$mode, engine == object$engine)
+        vctrs::vec_slice(
+          encoding_info,
+          encoding_info$mode == object$mode & encoding_info$engine == object$engine
+        )
 
       remove_intercept <- encoding_info %>% dplyr::pull(remove_intercept)
       if (remove_intercept) {


### PR DESCRIPTION
A `dplyr::filter()` crept into the `fit()` path. :)

With dev parsnip:

``` r
library(parsnip)

bench::mark(fit = fit(linear_reg(), mpg ~ ., mtcars))
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 fit          1.51ms   1.78ms      547.    3.76MB     32.5
```

With this PR:

``` r
library(parsnip)

bench::mark(fit = fit(linear_reg(), mpg ~ ., mtcars))
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 fit           1.1ms   1.25ms      778.    2.55MB     33.8
```

<sup>Created on 2024-02-26 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>
