### PR TITLE
address slowdown in `fit_xy()`

### DIFF
--- a/R/fit_helpers.R
+++ b/R/fit_helpers.R
@@ -175,11 +175,14 @@ xy_form <- function(object, env, control, ...) {
 
   check_outcome(env$y, object)
 
-  encoding_info <-
-    get_encoding(class(object)[1]) %>%
-    dplyr::filter(mode == object$mode, engine == object$engine)
+  encoding_info <- get_encoding(class(object)[1])
+  encoding_info <- 
+    vctrs::vec_slice(
+      encoding_info, 
+      encoding_info$mode == object$mode & encoding_info$engine == object$engine
+    )
 
-  remove_intercept <- encoding_info %>% dplyr::pull(remove_intercept)
+  remove_intercept <- encoding_info$remove_intercept
 
   data_obj <-
     .convert_xy_to_form_fit(


### PR DESCRIPTION
On `main` dev:

```r
library(parsnip)
bench::mark(
  fit = fit_xy(linear_reg(), mtcars[2:11], mtcars[1])
)
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 fit          1.76ms   2.07ms      473.    3.95MB     32.3
```

With this PR:

``` r
library(parsnip)
bench::mark(
  fit = fit_xy(linear_reg(), mtcars[2:11], mtcars[1])
)
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 fit          1.27ms   1.48ms      656.    2.79MB     31.7
```

<sup>Created on 2024-02-27 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>
