### PR TITLE
address uninformative error with r-release

### DIFF
--- a/R/glmnet-engines.R
+++ b/R/glmnet-engines.R
@@ -388,7 +388,7 @@ format_glmnet_multinom_class <- function(pred, penalty, lvl, n_obs) {
       rlang::abort(
         glue::glue(
           "`penalty` should be a single numeric value. `multi_predict()` ",
-          "can be used to get multiple predictions per row of data.",
+          "can be used to get multiple predictions per row of data."
         )
       )
     }


### PR DESCRIPTION
Closes tidymodels/extratests#209, related to tidyverse/glue#320.