### PR TITLE
Doc Fix: `mlp_brulee()`

### DIFF
--- a/man/rmd/mlp_brulee.Rmd
+++ b/man/rmd/mlp_brulee.Rmd
@@ -8,7 +8,7 @@
 ```{r brulee-param-info, echo = FALSE}
 defaults <- 
   tibble::tibble(parsnip = c("hidden_units", "penalty", "dropout", "epochs", "learn_rate", "activation", "mixture"),
-                 default = c("3L", "0.0", "0.0", "100L", "0.01", "'relu'", "0.0"))
+                 default = c("3L", "0.001", "0.0", "100L", "0.01", "'relu'", "0.0"))
 
 param <-
   mlp() %>% 

--- a/man/rmd/mlp_brulee.md
+++ b/man/rmd/mlp_brulee.md
@@ -11,7 +11,7 @@ This model has 6 tuning parameters:
 
 - `hidden_units`: # Hidden Units (type: integer, default: 3L)
 
-- `penalty`: Amount of Regularization (type: double, default: 0.0)
+- `penalty`: Amount of Regularization (type: double, default: 0.001)
 
 - `epochs`: # Epochs (type: integer, default: 100L)
 


### PR DESCRIPTION
The default parameter for `penalty` in the docs is incorrect. This is a comically small PR, but it did trip me up this week thinking the default was 0 when it wasn't.

Here is some quick reprex proof via `parsnip::` and via `brulee::` itself (see 'weight decay' value):

``` r
data <- modeldata::two_class_dat
# - recipe
rec <-
    data |>
        recipes::recipe(Class ~ .)
# - default param brulee_mlp via parsnip
mod <-
    parsnip::mlp() |>
        parsnip::set_engine("brulee") |>
        parsnip::set_mode("classification")
# - workflow
wf <-
    workflows::workflow() |>
        workflows::add_recipe(rec) |>
        workflows::add_model(mod)
# - fit
wf |>
    parsnip::fit(data = data)
#> ══ Workflow [trained] ══════════════════════════════════════════════════════════
#> Preprocessor: Recipe
#> Model: mlp()
#> 
#> ── Preprocessor ────────────────────────────────────────────────────────────────
#> 0 Recipe Steps
#> 
#> ── Model ───────────────────────────────────────────────────────────────────────
#> Multilayer perceptron
#> 
#> relu activation
#> 3 hidden units,  17 model parameters
#> 791 samples, 2 features, 2 classes 
#> class weights Class1=1, Class2=1 
#> weight decay: 0.001 
#> dropout proportion: 0 
#> batch size: 712 
#> learn rate: 0.01 
#> validation loss after 4 epochs: 0.5
```

``` r

brulee::brulee_mlp(
    x = rec,
    data = data
)
#> Multilayer perceptron
#> 
#> relu activation
#> 3 hidden units,  17 model parameters
#> 791 samples, 2 features, 2 classes 
#> class weights Class1=1, Class2=1 
#> weight decay: 0.001 
#> dropout proportion: 0 
#> batch size: 712 
#> learn rate: 0.01 
#> validation loss after 30 epochs: 0.379
```