### PR TITLE
Quantile predictions for linear regression models via lm()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -77,6 +77,6 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-Remotes:  
+Remotes: 
     tidymodels/hardhat
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 
 * New `extract_fit_time()` method has been added that returns the time it took to train the model (#853).
 
+* Adding `"quantile"` prediction methods for engines using `lm`, `stan`, and `dbarts`. 
 
 # parsnip 1.2.1
 

--- a/R/predict.R
+++ b/R/predict.R
@@ -86,9 +86,9 @@
 #' produces for class probabilities (or other non-scalar outputs),
 #' the columns are named `.pred_lower_classlevel` and so on.
 #'
-#' For `type = "quantile"`, the tibble has a `.pred` column, which is
+#' For `type = "quantile"`, the tibble has a `.pred_quantile` column, which is
 #'  a list-column. Each list element contains a tibble with columns
-#'  `.pred` and `.quantile` (and perhaps other columns).
+#'  `.pred_quantile` and `.quantile`.
 #'
 #' For `type = "time"`, the tibble has a `.pred_time` column.
 #'

--- a/R/predict_quantile.R
+++ b/R/predict_quantile.R
@@ -27,7 +27,7 @@ predict_quantile.model_fit <- function(object,
       new_data <- object$spec$method$pred$quantile$pre(new_data, object)
 
     # Pass some extra arguments to be used in post-processor
-    object$spec$method$pred$quantile$args$p <- quantile
+    object$spec$method$pred$quantile$args$quantile <- quantile
     pred_call <- make_pred_call(object$spec$method$pred$quantile)
 
     res <- eval_tidy(pred_call)

--- a/man/augment.Rd
+++ b/man/augment.Rd
@@ -4,7 +4,7 @@
 \alias{augment.model_fit}
 \title{Augment data with predictions}
 \usage{
-\method{augment}{model_fit}(x, new_data, eval_time = NULL, ...)
+\method{augment}{model_fit}(x, new_data, eval_time = NULL, quantile = NULL, ...)
 }
 \arguments{
 \item{x}{A \code{model_fit} object produced by \code{\link[=fit.model_spec]{fit.model_spec()}} or

--- a/man/predict.model_fit.Rd
+++ b/man/predict.model_fit.Rd
@@ -70,9 +70,9 @@ the confidence level. In the case where intervals can be
 produces for class probabilities (or other non-scalar outputs),
 the columns are named \code{.pred_lower_classlevel} and so on.
 
-For \code{type = "quantile"}, the tibble has a \code{.pred} column, which is
+For \code{type = "quantile"}, the tibble has a \code{.pred_quantile} column, which is
 a list-column. Each list element contains a tibble with columns
-\code{.pred} and \code{.quantile} (and perhaps other columns).
+\code{.pred_quantile} and \code{.quantile}.
 
 For \code{type = "time"}, the tibble has a \code{.pred_time} column.
 


### PR DESCRIPTION
Draft for review - unit tests to come.

@ryantibs @dajmcdon

Enable quantile predictions for linear regression models via `lm()`. This is the first PR to populate `type = “quantile”` predictions for existing models. The next few PRs will be for other existing models for existing engines (stan, BART, ranger, and (maybe) lightgbm models). After that, we can implement a few more engines (e.g., `quantreg`). 

Why not a different mode? 

First, we can possibly generate quantile intervals for classification models (e.g., quantiles of the event probability distributions). A good example is for stan logistic models. 

Second, the main difference for quantile predictions is the `type` option to `predict.model_fit()`. AFAIK we don’t need specialized metrics or other complications (as we had for survival analysis) but someone speak up if I'm being short-sighted.

Example: 

``` r
library(tidymodels)

lm_fit <- linear_reg() %>% fit(mpg ~ ., data = mtcars[, 1:4])

car_pred <- predict(lm_fit, mtcars[1:3, -1], type = "quantile", quantile = (1:3) / 4)
car_pred
#> # A tibble: 3 × 1
#>   .pred_quantile  
#>   <list>          
#> 1 <tibble [3 × 2]>
#> 2 <tibble [3 × 2]>
#> 3 <tibble [3 × 2]>
car_pred$.pred_quantile[[1]]
#> # A tibble: 3 × 2
#>   .quantile .pred_quantile
#>       <dbl>          <dbl>
#> 1      0.25           20.0
#> 2      0.5            22.2
#> 3      0.75           24.4

# Keep default behavior
augment(lm_fit, mtcars[1:3, 2:4])
#> # A tibble: 3 × 4
#>   .pred   cyl  disp    hp
#>   <dbl> <dbl> <dbl> <dbl>
#> 1  22.2     6   160   110
#> 2  22.2     6   160   110
#> 3  25.9     4   108    93
#>
# But get quantiles if you can
augment(lm_fit, mtcars[1:3, 2:4], quantile = (1:3) / 4)
#> # A tibble: 3 × 5
#>   .pred .pred_quantile     cyl  disp    hp
#>   <dbl> <list>           <dbl> <dbl> <dbl>
#> 1  22.2 <tibble [3 × 2]>     6   160   110
#> 2  22.2 <tibble [3 × 2]>     6   160   110
#> 3  25.9 <tibble [3 × 2]>     4   108    93
```

<sup>Created on 2024-07-18 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>