### PR TITLE
Document default ranges for tunable parameters

### DIFF
--- a/man/rmd/bart_dbarts.Rmd
+++ b/man/rmd/bart_dbarts.Rmd
@@ -25,6 +25,8 @@ This model has `r nrow(param)` tuning parameters:
 param$item
 ```
 
+Parsnip changes the default range for `trees` to `c(50, 500)`.
+
 ## Important engine-specific options
 
 Some relevant arguments that can be passed to `set_engine()`: 

--- a/man/rmd/mars_earth.Rmd
+++ b/man/rmd/mars_earth.Rmd
@@ -22,7 +22,7 @@ This model has `r nrow(param)` tuning parameters:
 param$item
 ```
 
-The default value of `num_terms` depends on the number of predictor columns. For a data frame `x`, the default is `min(200, max(20, 2 * ncol(x))) + 1` (see [earth::earth()] and the reference below). 
+Parsnip changes the default range for `num_terms` to `c(50, 500)`.
 
 ## Translation from parsnip to the original package (regression)
 

--- a/man/rmd/mlp_brulee.Rmd
+++ b/man/rmd/mlp_brulee.Rmd
@@ -33,6 +33,7 @@ Other engine arguments of interest:
  - `class_weights()`: Numeric class weights. See [brulee::brulee_mlp()].
  - `stop_iter()`: A non-negative integer for how many iterations with no improvement before stopping. (default: 5L).
 
+Parsnip changes the default range for `learn_rate` to `c(-2.5, -0.5)`.
 
 ## Translation from parsnip to the original package (regression)
 

--- a/man/rmd/nearest_neighbor_kknn.Rmd
+++ b/man/rmd/nearest_neighbor_kknn.Rmd
@@ -22,6 +22,9 @@ This model has `r nrow(param)` tuning parameters:
 param$item
 ```
 
+Parsnip changes the default range for `neighbors` to `c(1, 15)` and `dist_power` to `c(1/10, 2)`.
+
+
 ## Translation from parsnip to the original package (regression)
 
 ```{r kknn-reg}

--- a/man/rmd/svm_linear_LiblineaR.Rmd
+++ b/man/rmd/svm_linear_LiblineaR.Rmd
@@ -24,6 +24,8 @@ param$item
 
 This engine fits models that are L2-regularized for L2-loss. In the [LiblineaR::LiblineaR()] documentation, these are types 1 (classification) and 11 (regression).
 
+Parsnip changes the default range for `cost` to `c(-10, 5)`.
+
 ## Translation from parsnip to the original package (regression)
 
 ```{r LiblineaR-reg}

--- a/man/rmd/svm_linear_kernlab.Rmd
+++ b/man/rmd/svm_linear_kernlab.Rmd
@@ -22,6 +22,8 @@ This model has `r nrow(param)` tuning parameters:
 param$item
 ```
 
+Parsnip changes the default range for `cost` to `c(-10, 5)`.
+
 ## Translation from parsnip to the original package (regression)
 
 ```{r kernlab-reg}

--- a/man/rmd/svm_poly_kernlab.Rmd
+++ b/man/rmd/svm_poly_kernlab.Rmd
@@ -22,6 +22,8 @@ This model has `r nrow(param)` tuning parameters:
 param$item
 ```
 
+Parsnip changes the default range for `cost` to `c(-10, 5)`.
+
 ## Translation from parsnip to the original package (regression)
 
 ```{r kernlab-reg}

--- a/man/rmd/svm_rbf_kernlab.Rmd
+++ b/man/rmd/svm_rbf_kernlab.Rmd
@@ -24,6 +24,8 @@ param$item
 
 There is no default for the radial basis function kernel parameter. kernlab estimates it from the data using a heuristic method. See [kernlab::sigest()]. This method uses random numbers so, without setting the seed before fitting, the model will not be reproducible. 
 
+Parsnip changes the default range for `cost` to `c(-10, 5)`.
+
 ## Translation from parsnip to the original package (regression)
 
 ```{r kernlab-reg}


### PR DESCRIPTION
Documents {parsnip}'s default ranges for tunable parameter via `set_model_arg()`. Also removes documentation for mars model earth engine that described non-implemented functionality for `num_terms`.

Fixes #954 

Note that this does not include tunable parameters where this is set by another means.