### PR TITLE
mass replace of rlang::abort with cli::cli_abort

### DIFF
--- a/R/nearest_neighbor_data.R
+++ b/R/nearest_neighbor_data.R
@@ -93,7 +93,7 @@ set_pred(
     # model mode
     pre = function(x, object) {
       if (object$fit$response != "continuous") {
-        rlang::abort(
+        cli::cli_abort(
           glue::glue("`kknn` model does not appear to use numeric predictions.",
                      " Was the model fit with a continuous response variable?")
         )
@@ -136,7 +136,7 @@ set_pred(
   value = list(
     pre = function(x, object) {
       if (!(object$fit$response %in% c("ordinal", "nominal"))) {
-        rlang::abort(
+        cli::cli_abort(
           glue::glue("`kknn` model does not appear to use class predictions.",
                      " Was the model fit with a factor response variable?")
         )
@@ -162,7 +162,7 @@ set_pred(
   value = list(
     pre = function(x, object) {
       if (!(object$fit$response %in% c("ordinal", "nominal"))) {
-        rlang::abort(
+        cli::cli_abort(
           glue::glue("`kknn` model does not appear to use class predictions.",
                      " Was the model fit with a factor response variable?")
         )

--- a/R/rand_forest.R
+++ b/R/rand_forest.R
@@ -99,7 +99,7 @@ translate.rand_forest <- function(x, engine = x$engine, ...) {
 
   if (x$engine == "spark") {
     if (x$mode == "unknown") {
-      rlang::abort(
+      cli::cli_abort(
         glue::glue("For spark random forests models, the mode cannot ",
                    "be 'unknown' if the specification is to be translated.")
       )
@@ -121,7 +121,7 @@ translate.rand_forest <- function(x, engine = x$engine, ...) {
 
     if (any(names(arg_vals) == "importance")) {
       if (isTRUE(is.logical(quo_get_expr(arg_vals$importance)))) {
-        rlang::abort("`importance` should be a character value. See ?ranger::ranger.")
+        cli::cli_abort("`importance` should be a character value. See ?ranger::ranger.")
       }
     }
     # unless otherwise specified, classification models are probability forests

--- a/R/rand_forest_data.R
+++ b/R/rand_forest_data.R
@@ -64,7 +64,7 @@ ranger_confint <- function(object, new_data, ...) {
     if (object$fit$forest$treetype == "Probability estimation") {
       res <- ranger_class_confint(object, new_data, ...)
     } else {
-      rlang::abort(
+      cli::cli_abort(
         glue::glue(
           "Cannot compute confidence intervals for a ranger forest ",
           "of type {object$fit$forest$treetype}."
@@ -204,7 +204,7 @@ set_pred(
   value = list(
     pre = function(x, object) {
       if (object$fit$forest$treetype != "Probability estimation")
-        rlang::abort(
+        cli::cli_abort(
           glue::glue(
             "`ranger` model does not appear to use class probabilities. Was ",
             "the model fit with `probability = TRUE`?"

--- a/R/svm_linear.R
+++ b/R/svm_linear.R
@@ -105,7 +105,7 @@ translate.svm_linear <- function(x, engine = x$engine, ...) {
         arg_vals$svr_eps <- 0.1
       if (!is_null(liblinear_type))
         if(!liblinear_type %in% 11:13)
-          rlang::abort(
+          cli::cli_abort(
             paste0("The LiblineaR engine argument of `type` = ",
                    liblinear_type,
                    " does not correspond to an SVM regression model.")
@@ -113,7 +113,7 @@ translate.svm_linear <- function(x, engine = x$engine, ...) {
     } else if (x$mode == "classification") {
       if (!is_null(liblinear_type))
         if(!liblinear_type %in% 1:5)
-          rlang::abort(
+          cli::cli_abort(
             paste0("The LiblineaR engine argument of `type` = ",
                    liblinear_type,
                    " does not correspond to an SVM classification model.")

--- a/R/svm_rbf_data.R
+++ b/R/svm_rbf_data.R
@@ -296,7 +296,7 @@ set_pred(
   value = list(
     pre = function(x, object) {
       if (!object$fit$predict.prob) {
-        rlang::abort(
+        cli::cli_abort(
           paste0("`svm` model does not appear to use class probabilities. Was ",
                  "the model fit with `predict.prob = TRUE`?")
         )


### PR DESCRIPTION
mass replace of rlang::abort with cli::cli_abort, no user input or special glue::glue brackets were used, so a mass replace was made #1142