### PR TITLE
refine parsnip overhead test

### DIFF
--- a/tests/testthat/test-fit_interfaces.R
+++ b/tests/testthat/test-fit_interfaces.R
@@ -169,7 +169,7 @@ test_that("overhead of parsnip interface is minimal (#1071)", {
   )
 
   expect_true(
-    bm$median[2] < 3,
+    bm$median[2] < 3.5,
     label = paste0("parsnip overhead factor (formula interface): ", bm$median[2])
   )
   expect_true(

--- a/tests/testthat/test-fit_interfaces.R
+++ b/tests/testthat/test-fit_interfaces.R
@@ -168,6 +168,12 @@ test_that("overhead of parsnip interface is minimal (#1071)", {
     check = FALSE
   )
 
-  expect_true(bm$median[2] < 3, label = "parsnip overhead is minimal (formula interface)")
-  expect_true(bm$median[3] < 3.5, , label = "parsnip overhead is minimal (xy interface)")
+  expect_true(
+    bm$median[2] < 3,
+    label = paste0("parsnip overhead factor (formula interface): ", bm$median[2])
+  )
+  expect_true(
+    bm$median[3] < 3.5,
+    label = paste0("parsnip overhead factor (xy interface): ", bm$median[3])
+  )
 })

--- a/tests/testthat/test-fit_interfaces.R
+++ b/tests/testthat/test-fit_interfaces.R
@@ -173,7 +173,7 @@ test_that("overhead of parsnip interface is minimal (#1071)", {
     label = paste0("parsnip overhead factor (formula interface): ", bm$median[2])
   )
   expect_true(
-    bm$median[3] < 3.5,
+    bm$median[3] < 3.75,
     label = paste0("parsnip overhead factor (xy interface): ", bm$median[3])
   )
 })


### PR DESCRIPTION
Maybe every three or four times we run the parsnip overhead unit tests on the macOS-release and ubuntu-oldrel-4 runners, we see a failure. We should figure out how to make that happen much, much less often.

Starting out by making the error message more informative to see whether we're "close" to the limit.