### PR TITLE
save x column names from fit_xy()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@
 
 * Ensure that `knit_engine_docs()` has the required packages installed (#1156).
 
+* Fixed bug where some models fit using `fit_xy()` couldn't predict (#1166).
 
 # parsnip 1.2.1
 

--- a/R/fit_helpers.R
+++ b/R/fit_helpers.R
@@ -115,7 +115,7 @@ xy_xy <- function(object,
   } else {
     y_name <- colnames(env$y)
   }
-  res$preproc <- list(y_var = y_name)
+  res$preproc <- list(y_var = y_name, x_names = colnames(env$x))
   res$elapsed <- list(elapsed = elapsed, print = control$verbosity > 1L)
   res
 }

--- a/R/predict.R
+++ b/R/predict.R
@@ -440,6 +440,8 @@ prepare_data <- function(object, new_data) {
   preproc_names <- names(object$preproc)
   translate_from_formula_to_xy <- any(preproc_names == "terms", na.rm = TRUE)
   translate_from_xy_to_formula <- any(preproc_names == "x_var", na.rm = TRUE)
+  # For backwards compatibility, only do this if `y_var` is missing and
+  # `x_names` is present
   translate_from_xy_to_xy <- any(preproc_names == "x_names", na.rm = TRUE) &&
     identical(object$preproc$y_var, character(0))
 

--- a/R/predict.R
+++ b/R/predict.R
@@ -440,11 +440,15 @@ prepare_data <- function(object, new_data) {
   preproc_names <- names(object$preproc)
   translate_from_formula_to_xy <- any(preproc_names == "terms", na.rm = TRUE)
   translate_from_xy_to_formula <- any(preproc_names == "x_var", na.rm = TRUE)
+  translate_from_xy_to_xy <- any(preproc_names == "x_names", na.rm = TRUE) &&
+    identical(object$preproc$y_var, character(0))
 
   if (translate_from_formula_to_xy) {
     new_data <- .convert_form_to_xy_new(object$preproc, new_data)$x
   } else if (translate_from_xy_to_formula) {
     new_data <- .convert_xy_to_form_new(object$preproc, new_data)
+  } else if (translate_from_xy_to_xy) {
+    new_data <- new_data[, object$preproc$x_names]
   }
 
   encodings <- get_encoding(class(object$spec)[1])

--- a/tests/testthat/test-predict_formats.R
+++ b/tests/testthat/test-predict_formats.R
@@ -106,4 +106,20 @@ test_that('non-factor classification', {
   )
 })
 
+test_that("predict() works for model fit with fit_xy() (#1166)", {
+  skip_if_not_installed("xgboost")
 
+  spec <- boost_tree() %>%
+    set_mode("regression") %>%
+    set_engine("xgboost")
+
+  tree_fit <- fit(spec, mpg ~ ., data = mtcars)
+
+  exp <- predict(tree_fit, mtcars)
+
+  tree_fit <- fit_xy(spec, x = mtcars[, -1], y = mtcars[, 1])
+
+  res <- predict(tree_fit, mtcars)
+  
+  expect_identical(exp, res)
+})


### PR DESCRIPTION
to close #1166.

This bug happened because we don't know the name of the outcome(s) `y` when using `fit_xy()` because it is often a nameless vector. So instead, what I tried to do was to save the names of the `x` and subset with those when appropriate. 

This is NOT a xgboost issue. it is just that xgboost complains more loudly than other engines. 

``` r
library(parsnip)

spec <- boost_tree() %>%
  set_mode("regression") %>%
  set_engine("xgboost")

lm_fit <- fit(spec, mpg ~ ., data = mtcars)

predict(lm_fit, mtcars)
#> # A tibble: 32 × 1
#>    .pred
#>    <dbl>
#>  1  20.9
#>  2  20.9
#>  3  22.6
#>  4  21.0
#>  5  18.4
#>  6  18.1
#>  7  14.2
#>  8  23.7
#>  9  22.4
#> 10  18.9
#> # ℹ 22 more rows

lm_fit <- fit_xy(spec, x = mtcars[, -1], y = mtcars[, 1])

predict(lm_fit, mtcars)
#> # A tibble: 32 × 1
#>    .pred
#>    <dbl>
#>  1  20.9
#>  2  20.9
#>  3  22.6
#>  4  21.0
#>  5  18.4
#>  6  18.1
#>  7  14.2
#>  8  23.7
#>  9  22.4
#> 10  18.9
#> # ℹ 22 more rows
```

<sup>Created on 2024-08-30 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>