### PR TITLE
reduce overhead of `to_sparse_data_frame()`

### DIFF
--- a/R/sparsevctrs.R
+++ b/R/sparsevctrs.R
@@ -18,7 +18,7 @@ is_sparse_tibble <- function(x) {
 }
 
 materialize_sparse_tibble <- function(x, object, input) {
-  if ((!allow_sparse(object)) && is_sparse_tibble(x)) {
+  if (is_sparse_tibble(x) && (!allow_sparse(object))) {
     cli::cli_warn(
       "{.arg {input}} is a sparse tibble, but {.fn {class(object)[1]}} with
       engine {.code {object$engine}} doesn't accept that. Converting to 


### PR DESCRIPTION
Noticed this when reviewing #1167 but it's unrelated to that PR. If we do the "cheap" side of the `&&` first, we can cut down on the overhead of "not converting to sparse when we don't want to." :)

Before this PR:

```
d <- data.frame(sparse = "no")
lr <- linear_reg()
bench::mark(
  to_sparse_data_frame(d, lr)
)
#> # A tibble: 1 × 13
#>   expression              min median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc total_time result
#>   <bch:expr>           <bch:> <bch:>     <dbl> <bch:byt>    <dbl> <int> <dbl>   <bch:tm> <list>
#> 1 to_sparse_data_fram… 26.9µs 28.5µs    33538.        0B     16.8  9995     5      298ms <df>  
# ℹ 3 more variables: memory <list>, time <list>, gc <list>
```

Now:

```
#> # A tibble: 1 × 13
#>   expression              min median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc total_time result
#>   <bch:expr>           <bch:> <bch:>     <dbl> <bch:byt>    <dbl> <int> <dbl>   <bch:tm> <list>
#> 1 to_sparse_data_fram… 16.1µs 17.5µs    54942.        0B     16.5  9997     3      182ms <df> 
```

We're talking about 1.5% of the total time in `fit(lr, mpg ~ ., mtcars)` vs 2.5%, but seems like a simple enough change to be worth it!