### PR TITLE
make sure xgboost works with sparse data

### DIFF
--- a/R/convert_data.R
+++ b/R/convert_data.R
@@ -124,6 +124,10 @@
         options = options
       )
   } else if (composition == "dgCMatrix") {
+    y_cols <- attr(mod_terms, "response")
+    if (length(y_cols) > 0) {
+      data <- data[, -y_cols, drop = FALSE]
+    }
     x <- sparsevctrs::coerce_to_sparse_matrix(data)
     res <-
       list(

--- a/tests/testthat/test-sparsevctrs.R
+++ b/tests/testthat/test-sparsevctrs.R
@@ -127,6 +127,43 @@ test_that("sparse matrices can be passed to `predict()", {
   )
 })
 
+test_that("sparse data work with xgboost engine", {
+  skip_if_not_installed("xgboost")
+
+  spec <- boost_tree() %>%
+    set_mode("regression") %>%
+    set_engine("xgboost")
+
+  hotel_data <- sparse_hotel_rates()
+
+  expect_no_error(
+    tree_fit <- fit_xy(spec, x = hotel_data[, -1], y = hotel_data[, 1])
+   )
+ 
+   expect_no_error(
+     predict(tree_fit, hotel_data)
+   )
+
+  hotel_data <- sparsevctrs::coerce_to_sparse_tibble(hotel_data)
+
+
+  expect_no_error(
+    tree_fit <- fit(spec, avg_price_per_room ~ ., data = hotel_data)
+  )
+
+  expect_no_error(
+    predict(tree_fit, hotel_data)
+  )
+  
+  expect_no_error(
+   tree_fit <- fit_xy(spec, x = hotel_data[, -1], y = hotel_data[, 1])
+  )
+
+  expect_no_error(
+    predict(tree_fit, hotel_data)
+  )
+})
+
 test_that("to_sparse_data_frame() is used correctly", {
   skip_if_not_installed("xgboost")
   


### PR DESCRIPTION
Ref: https://github.com/tidymodels/parsnip/issues/1125

xgboost is the only model that supports sparse data that has a non-standard interface. This PR makes it so those special connections still work. And tests them.