### PR TITLE
Make sure all sparse data errors look nice

### DIFF
--- a/R/fit.R
+++ b/R/fit.R
@@ -174,6 +174,13 @@ fit.model_spec <-
     eval_env$formula <- formula
     eval_env$weights <- wts
 
+    if (is_sparse_matrix(data)) {
+      cli::cli_abort(c(
+        x = "Sparse matrices cannot be used with {.fn fit}.",
+        i = "Please use {.fn fit_xy} interface instead."
+      ))
+    }
+
     data <- materialize_sparse_tibble(data, object, "data")
     
     fit_interface <-

--- a/R/sparsevctrs.R
+++ b/R/sparsevctrs.R
@@ -1,4 +1,4 @@
-to_sparse_data_frame <- function(x, object) {
+to_sparse_data_frame <- function(x, object, call = rlang::caller_env()) {
   if (is_sparse_matrix(x)) {
     if (allow_sparse(object)) {
       x <- sparsevctrs::coerce_to_sparse_data_frame(x)
@@ -8,8 +8,10 @@ to_sparse_data_frame <- function(x, object) {
       }
     
       cli::cli_abort(
-      "{.arg x} is a sparse matrix, but {.fn {class(object)[1]}} with
-       engine {.code {object$engine}} doesn't accept that.")
+        "{.arg x} is a sparse matrix, but {.fn {class(object)[1]}} with
+        engine {.code {object$engine}} doesn't accept that.",
+        call = call
+      )
     }
   } else if (is.data.frame(x)) {
     x <- materialize_sparse_tibble(x, object, "x")

--- a/R/sparsevctrs.R
+++ b/R/sparsevctrs.R
@@ -1,5 +1,5 @@
 to_sparse_data_frame <- function(x, object) {
-  if (methods::is(x, "sparseMatrix")) {
+  if (is_sparse_matrix(x)) {
     if (allow_sparse(object)) {
       x <- sparsevctrs::coerce_to_sparse_data_frame(x)
     } else {
@@ -19,6 +19,10 @@ to_sparse_data_frame <- function(x, object) {
 
 is_sparse_tibble <- function(x) {
   any(vapply(x, sparsevctrs::is_sparse_vector, logical(1)))
+}
+
+is_sparse_matrix <- function(x) {
+  methods::is(x, "sparseMatrix")
 }
 
 materialize_sparse_tibble <- function(x, object, input) {

--- a/tests/testthat/_snaps/sparsevctrs.md
+++ b/tests/testthat/_snaps/sparsevctrs.md
@@ -22,6 +22,15 @@
       Error in `to_sparse_data_frame()`:
       ! `x` is a sparse matrix, but `linear_reg()` with engine `lm` doesn't accept that.
 
+# sparse matrices can not be passed to `fit()
+
+    Code
+      hotel_fit <- fit(spec, avg_price_per_room ~ ., data = hotel_data)
+    Condition
+      Error in `fit()`:
+      x Sparse matrices cannot be used with `fit()`.
+      i Please use `fit_xy()` interface instead.
+
 # sparse tibble can be passed to `predict()
 
     Code

--- a/tests/testthat/_snaps/sparsevctrs.md
+++ b/tests/testthat/_snaps/sparsevctrs.md
@@ -19,7 +19,7 @@
     Code
       lm_fit <- fit_xy(spec, x = hotel_data[1:100, -1], y = hotel_data[1:100, 1])
     Condition
-      Error in `to_sparse_data_frame()`:
+      Error in `fit_xy()`:
       ! `x` is a sparse matrix, but `linear_reg()` with engine `lm` doesn't accept that.
 
 # sparse matrices can not be passed to `fit()
@@ -44,7 +44,7 @@
     Code
       predict(lm_fit, sparse_mtcars)
     Condition
-      Error in `to_sparse_data_frame()`:
+      Error in `predict()`:
       ! `x` is a sparse matrix, but `linear_reg()` with engine `lm` doesn't accept that.
 
 # to_sparse_data_frame() is used correctly

--- a/tests/testthat/test-sparsevctrs.R
+++ b/tests/testthat/test-sparsevctrs.R
@@ -67,6 +67,21 @@ test_that("sparse matrices can be passed to `fit_xy()", {
   )
 })
 
+test_that("sparse matrices can not be passed to `fit()", {
+  skip_if_not_installed("xgboost")
+
+  hotel_data <- sparse_hotel_rates()
+
+  spec <- boost_tree() %>%
+    set_mode("regression") %>%
+    set_engine("xgboost")
+
+  expect_snapshot(
+    error = TRUE,
+    hotel_fit <- fit(spec, avg_price_per_room ~ ., data = hotel_data)
+  )
+})
+
 test_that("sparse tibble can be passed to `predict()", {
   skip_if_not_installed("ranger")
 


### PR DESCRIPTION
This PR does two things.

First it adds an error if you try to use a sparse matrix with `fit()`, that redirects the user to use `fit_xy()`.

Second, it passes the `call` argument through `to_sparse_data_frame()` for nicer errors.