### PR TITLE
`expect_error(regexp = NA)` -> `expect_no_condition()`

### DIFF
--- a/tests/testthat/test-boost_tree_C5.0.R
+++ b/tests/testthat/test-boost_tree_C5.0.R
@@ -13,24 +13,22 @@ test_that('C5.0 execution', {
 
   skip_if_not_installed("C50")
 
-  expect_error(
+  expect_no_condition(
     res <- fit(
       lc_basic,
       Class ~ log(funded_amnt) + int_rate,
       data = lending_club,
       control = ctrl
-    ),
-    regexp = NA
+    )
   )
 
-  expect_error(
+  expect_no_condition(
     res <- fit_xy(
       lc_basic,
       x = lending_club[, num_pred],
       y = lending_club$Class,
       control = ctrl
-    ),
-    regexp = NA
+    )
   )
 
   expect_true(has_multi_predict(res))

--- a/tests/testthat/test-boost_tree_xgboost.R
+++ b/tests/testthat/test-boost_tree_xgboost.R
@@ -18,7 +18,7 @@ test_that('xgboost execution, classification', {
   wts <- ifelse(runif(nrow(hpc)) < .1, 0, 1)
   wts <- importance_weights(wts)
 
-  expect_error({
+  expect_no_condition({
     set.seed(1)
     res_f <- parsnip::fit(
       hpc_xgboost,
@@ -26,10 +26,8 @@ test_that('xgboost execution, classification', {
       data = hpc,
       control = ctrl
     )
-  },
-  regexp = NA
-  )
-  expect_error({
+  })
+  expect_no_condition({
     set.seed(1)
     res_xy <- parsnip::fit_xy(
       hpc_xgboost,
@@ -37,10 +35,8 @@ test_that('xgboost execution, classification', {
       y = hpc$class,
       control = ctrl
     )
-  },
-  regexp = NA
-  )
-  expect_error({
+  })
+  expect_no_condition({
     set.seed(1)
     res_f_wts <- parsnip::fit(
       hpc_xgboost,
@@ -49,10 +45,8 @@ test_that('xgboost execution, classification', {
       control = ctrl,
       case_weights = wts
     )
-  },
-  regexp = NA
-  )
-  expect_error({
+  })
+  expect_no_condition({
     set.seed(1)
     res_xy_wts <- parsnip::fit_xy(
       hpc_xgboost,
@@ -61,9 +55,7 @@ test_that('xgboost execution, classification', {
       control = ctrl,
       case_weights = wts
     )
-  },
-  regexp = NA
-  )
+  })
 
   expect_equal(res_f$fit$evaluation_log,     res_xy$fit$evaluation_log)
   expect_equal(res_f_wts$fit$evaluation_log, res_xy_wts$fit$evaluation_log)
@@ -140,24 +132,22 @@ test_that('xgboost execution, regression', {
 
   ctrl$verbosity <- 0L
 
-  expect_error(
+  expect_no_condition(
     res <- parsnip::fit(
       car_basic,
       mpg ~ .,
       data = mtcars,
       control = ctrl
-    ),
-    regexp = NA
+    )
   )
 
-  expect_error(
+  expect_no_condition(
     res <- parsnip::fit_xy(
       car_basic,
       x = mtcars[, num_pred],
       y = mtcars$mpg,
       control = ctrl
-    ),
-    regexp = NA
+    )
   )
 
   expect_error(
@@ -285,32 +275,29 @@ test_that('validation sets', {
 
   ctrl$verbosity <- 0L
 
-  expect_error(
+  expect_no_condition(
     reg_fit <-
       boost_tree(trees = 20, mode = "regression") %>%
       set_engine("xgboost", validation = .1) %>%
-      fit(mpg ~ ., data = mtcars[-(1:4), ]),
-    regex = NA
+      fit(mpg ~ ., data = mtcars[-(1:4), ])
   )
 
   expect_equal(colnames(extract_fit_engine(reg_fit)$evaluation_log)[2], "validation_rmse")
 
-  expect_error(
+  expect_no_condition(
     reg_fit <-
       boost_tree(trees = 20, mode = "regression") %>%
       set_engine("xgboost", validation = .1, eval_metric = "mae") %>%
-      fit(mpg ~ ., data = mtcars[-(1:4), ]),
-    regex = NA
+      fit(mpg ~ ., data = mtcars[-(1:4), ])
   )
 
   expect_equal(colnames(extract_fit_engine(reg_fit)$evaluation_log)[2], "validation_mae")
 
-  expect_error(
+  expect_no_condition(
     reg_fit <-
       boost_tree(trees = 20, mode = "regression") %>%
       set_engine("xgboost", eval_metric = "mae") %>%
-      fit(mpg ~ ., data = mtcars[-(1:4), ]),
-    regex = NA
+      fit(mpg ~ ., data = mtcars[-(1:4), ])
   )
 
   expect_equal(colnames(extract_fit_engine(reg_fit)$evaluation_log)[2], "training_mae")
@@ -334,23 +321,21 @@ test_that('early stopping', {
   ctrl$verbosity <- 0L
 
   set.seed(233456)
-  expect_error(
+  expect_no_condition(
     reg_fit <-
       boost_tree(trees = 200, stop_iter = 5, mode = "regression") %>%
       set_engine("xgboost", validation = .1) %>%
-      fit(mpg ~ ., data = mtcars[-(1:4), ]),
-    regex = NA
+      fit(mpg ~ ., data = mtcars[-(1:4), ])
   )
 
   expect_equal(extract_fit_engine(reg_fit)$niter - extract_fit_engine(reg_fit)$best_iteration, 5)
   expect_true(extract_fit_engine(reg_fit)$niter < 200)
 
-  expect_error(
+  expect_no_condition(
     reg_fit <-
       boost_tree(trees = 20, mode = "regression") %>%
       set_engine("xgboost", validation = .1, eval_metric = "mae") %>%
-      fit(mpg ~ ., data = mtcars[-(1:4), ]),
-    regex = NA
+      fit(mpg ~ ., data = mtcars[-(1:4), ])
   )
 
   expect_warning(
@@ -380,29 +365,29 @@ test_that('xgboost data conversion', {
   mtcar_smat <- Matrix::Matrix(mtcar_mat, sparse = TRUE)
   wts <- 1:32
 
-  expect_error(from_df <- parsnip:::as_xgb_data(mtcar_x, mtcars$mpg), regexp = NA)
+  expect_no_condition(from_df <- parsnip:::as_xgb_data(mtcar_x, mtcars$mpg))
   expect_true(inherits(from_df$data, "xgb.DMatrix"))
   expect_true(inherits(from_df$watchlist$training, "xgb.DMatrix"))
 
-  expect_error(from_mat <- parsnip:::as_xgb_data(mtcar_mat, mtcars$mpg), regexp = NA)
+  expect_no_condition(from_mat <- parsnip:::as_xgb_data(mtcar_mat, mtcars$mpg))
   expect_true(inherits(from_mat$data, "xgb.DMatrix"))
   expect_true(inherits(from_mat$watchlist$training, "xgb.DMatrix"))
 
-  expect_error(from_sparse <- parsnip:::as_xgb_data(mtcar_smat, mtcars$mpg), regexp = NA)
+  expect_no_condition(from_sparse <- parsnip:::as_xgb_data(mtcar_smat, mtcars$mpg))
   expect_true(inherits(from_mat$data, "xgb.DMatrix"))
   expect_true(inherits(from_mat$watchlist$training, "xgb.DMatrix"))
 
-  expect_error(from_df <- parsnip:::as_xgb_data(mtcar_x, mtcars$mpg, validation = .1), regexp = NA)
+  expect_no_condition(from_df <- parsnip:::as_xgb_data(mtcar_x, mtcars$mpg, validation = .1))
   expect_true(inherits(from_df$data, "xgb.DMatrix"))
   expect_true(inherits(from_df$watchlist$validation, "xgb.DMatrix"))
   expect_true(nrow(from_df$data) > nrow(from_df$watchlist$validation))
 
-  expect_error(from_mat <- parsnip:::as_xgb_data(mtcar_mat, mtcars$mpg, validation = .1), regexp = NA)
+  expect_no_condition(from_mat <- parsnip:::as_xgb_data(mtcar_mat, mtcars$mpg, validation = .1))
   expect_true(inherits(from_mat$data, "xgb.DMatrix"))
   expect_true(inherits(from_mat$watchlist$validation, "xgb.DMatrix"))
   expect_true(nrow(from_mat$data) > nrow(from_mat$watchlist$validation))
 
-  expect_error(from_sparse <- parsnip:::as_xgb_data(mtcar_smat, mtcars$mpg, validation = .1), regexp = NA)
+  expect_no_condition(from_sparse <- parsnip:::as_xgb_data(mtcar_smat, mtcars$mpg, validation = .1))
   expect_true(inherits(from_mat$data, "xgb.DMatrix"))
   expect_true(inherits(from_mat$watchlist$validation, "xgb.DMatrix"))
   expect_true(nrow(from_sparse$data) > nrow(from_sparse$watchlist$validation))
@@ -410,9 +395,9 @@ test_that('xgboost data conversion', {
   # set event_level for factors
 
   mtcars_y <- factor(mtcars$mpg < 15, levels = c(TRUE, FALSE), labels = c("low", "high"))
-  expect_error(from_df <- parsnip:::as_xgb_data(mtcar_x, mtcars_y), regexp = NA)
+  expect_no_condition(from_df <- parsnip:::as_xgb_data(mtcar_x, mtcars_y))
   expect_equal(xgboost::getinfo(from_df$data, name = "label")[1:5],  rep(0, 5))
-  expect_error(from_df <- parsnip:::as_xgb_data(mtcar_x, mtcars_y, event_level = "second"), regexp = NA)
+  expect_no_condition(from_df <- parsnip:::as_xgb_data(mtcar_x, mtcars_y, event_level = "second"))
   expect_equal(xgboost::getinfo(from_df$data, name = "label")[1:5],  rep(1, 5))
 
   mtcars_y <- factor(mtcars$mpg < 15, levels = c(TRUE, FALSE, "na"), labels = c("low", "high", "missing"))
@@ -421,9 +406,13 @@ test_that('xgboost data conversion', {
   )
 
   # case weights added
-  expect_error(wted <- parsnip:::as_xgb_data(mtcar_x, mtcars$mpg, weights = wts), regexp = NA)
+  expect_no_condition(
+    wted <- parsnip:::as_xgb_data(mtcar_x, mtcars$mpg, weights = wts)
+  )
   expect_equal(wts, xgboost::getinfo(wted$data, "weight"))
-  expect_error(wted_val <- parsnip:::as_xgb_data(mtcar_x, mtcars$mpg, weights = wts, validation = 1/4), regexp = NA)
+  expect_no_condition(
+    wted_val <- parsnip:::as_xgb_data(mtcar_x, mtcars$mpg, weights = wts, validation = 1/4)
+  )
   expect_true(all(xgboost::getinfo(wted_val$data, "weight") %in% wts))
   expect_null(xgboost::getinfo(wted_val$watchlist$validation, "weight"))
 
@@ -461,9 +450,13 @@ test_that('xgboost data and sparse matrices', {
   expect_equal(extract_fit_engine(from_df), extract_fit_engine(from_sparse), ignore_function_env = TRUE)
 
   # case weights added
-  expect_error(wted <- parsnip:::as_xgb_data(mtcar_smat, mtcars$mpg, weights = wts), regexp = NA)
+  expect_no_condition(
+    wted <- parsnip:::as_xgb_data(mtcar_smat, mtcars$mpg, weights = wts)
+  )
   expect_equal(wts, xgboost::getinfo(wted$data, "weight"))
-  expect_error(wted_val <- parsnip:::as_xgb_data(mtcar_smat, mtcars$mpg, weights = wts, validation = 1/4), regexp = NA)
+  expect_no_condition(
+    wted_val <- parsnip:::as_xgb_data(mtcar_smat, mtcars$mpg, weights = wts, validation = 1/4)
+  )
   expect_true(all(xgboost::getinfo(wted_val$data, "weight") %in% wts))
   expect_null(xgboost::getinfo(wted_val$watchlist$validation, "weight"))
 

--- a/tests/testthat/test-case-weights.R
+++ b/tests/testthat/test-case-weights.R
@@ -10,22 +10,21 @@ test_that('case weights with xy method', {
   two_class_subset <- two_class_dat[wts != 0, ]
   wts <- importance_weights(wts)
 
-  expect_error({
+  expect_no_condition({
     set.seed(1)
     C5_bst_wt_fit <-
       boost_tree(trees = 5) %>%
       set_engine("C5.0") %>%
       set_mode("classification") %>%
       fit(Class ~ ., data = two_class_dat, case_weights = wts)
-  },
-  regexp = NA)
+  })
 
   expect_output(
     print(C5_bst_wt_fit$fit$call),
     "weights = weights"
   )
 
-  expect_error({
+  expect_no_condition({
     set.seed(1)
     C5_bst_wt_fit <-
       boost_tree(trees = 5) %>%
@@ -36,8 +35,7 @@ test_that('case weights with xy method', {
         y = two_class_dat$Class,
         case_weights = wts
       )
-  },
-  regexp = NA)
+  })
 
   expect_output(
     print(C5_bst_wt_fit$fit$call),
@@ -57,21 +55,20 @@ test_that('case weights with xy method - non-standard argument names', {
   two_class_subset <- two_class_dat[wts != 0, ]
   wts <- importance_weights(wts)
 
-  expect_error({
+  expect_no_condition({
     set.seed(1)
     rf_wt_fit <-
       rand_forest(trees = 5) %>%
       set_mode("classification") %>%
       fit(Class ~ ., data = two_class_dat, case_weights = wts)
-  },
-  regexp = NA)
+  })
 
   # expect_output(
   #   print(rf_wt_fit$fit$call),
   #   "case\\.weights = weights"
   # )
 
-  expect_error({
+  expect_no_condition({
     set.seed(1)
     rf_wt_fit <-
       rand_forest(trees = 5) %>%
@@ -81,8 +78,7 @@ test_that('case weights with xy method - non-standard argument names', {
         y = two_class_dat$Class,
         case_weights = wts
       )
-  },
-  regexp = NA)
+  })
 })
 
 test_that('case weights with formula method', {
@@ -97,11 +93,11 @@ test_that('case weights with formula method', {
   ames_subset <- ames[wts != 0, ]
   wts <- frequency_weights(wts)
 
-  expect_error(
+  expect_no_condition(
     lm_wt_fit <-
       linear_reg() %>%
-      fit(Sale_Price ~ Longitude + Latitude, data = ames, case_weights = wts),
-    regexp = NA)
+      fit(Sale_Price ~ Longitude + Latitude, data = ames, case_weights = wts)
+  )
 
   lm_sub_fit <-
     linear_reg() %>%
@@ -141,15 +137,14 @@ test_that('case weights with formula method that goes through `fit_xy()`', {
   ames_subset <- ames[wts != 0, ]
   wts <- frequency_weights(wts)
 
-  expect_error(
+  expect_no_condition(
     lm_wt_fit <-
       linear_reg() %>%
       fit_xy(
         x = ames[c("Longitude", "Latitude")],
         y = ames$Sale_Price,
         case_weights = wts
-      ),
-    regexp = NA)
+  ))
 
   lm_sub_fit <-
     linear_reg() %>%

--- a/tests/testthat/test-descriptors.R
+++ b/tests/testthat/test-descriptors.R
@@ -199,17 +199,15 @@ test_that("can be temporarily overriden at evaluation time", {
 
 test_that("system-level descriptor tests", {
   skip_if_not_installed("xgboost")
-  expect_error(
+  expect_no_condition(
     boost_tree(mode = "regression", mtry = .cols()) %>%
       set_engine("xgboost") %>%
-      fit_xy(x = mtcars[, -1], y = mtcars$mpg),
-    NA
+      fit_xy(x = mtcars[, -1], y = mtcars$mpg)
   )
-  expect_error(
+  expect_no_condition(
     boost_tree(mode = "regression", mtry = .cols()) %>%
       set_engine("xgboost") %>%
-      fit(mpg ~ ., data = mtcars),
-    NA
+      fit(mpg ~ ., data = mtcars)
   )
 
 })

--- a/tests/testthat/test-extract.R
+++ b/tests/testthat/test-extract.R
@@ -90,9 +90,8 @@ test_that("extract_parameter_dials doesn't error if namespaced args are used", {
     logistic_reg(mode = "classification", penalty = hardhat::tune()) %>%
       set_engine("glmnet", family = stats::gaussian("log"))
 
-  expect_error(
-    extract_parameter_dials(bst_model, parameter = "penalty"),
-    NA
+  expect_no_condition(
+    extract_parameter_dials(bst_model, parameter = "penalty")
   )
 })
 

--- a/tests/testthat/test-fit_interfaces.R
+++ b/tests/testthat/test-fit_interfaces.R
@@ -34,19 +34,17 @@ test_that('wrong args', {
 
 test_that('single column df for issue #129', {
 
-  expect_error(
+  expect_no_condition(
     lm1 <-
       linear_reg() %>%
       set_engine("lm") %>%
-      fit_xy(x = mtcars[, 2:4], y = mtcars[,1, drop = FALSE]),
-    regexp = NA
+      fit_xy(x = mtcars[, 2:4], y = mtcars[,1, drop = FALSE])
   )
-  expect_error(
+  expect_no_condition(
     lm2 <-
       linear_reg() %>%
       set_engine("lm") %>%
-      fit_xy(x = mtcars[, 2:4], y = as.matrix(mtcars)[,1, drop = FALSE]),
-    regexp = NA
+      fit_xy(x = mtcars[, 2:4], y = as.matrix(mtcars)[,1, drop = FALSE])
   )
   lm3 <-
     linear_reg() %>%
@@ -113,9 +111,8 @@ test_that("elapsed time parsnip mods", {
 })
 
 test_that('No loaded engines', {
-  expect_error(
-    linear_reg() %>% fit(mpg ~., data = mtcars),
-    regexp = NA
+  expect_no_condition(
+    linear_reg() %>% fit(mpg ~., data = mtcars)
   )
   expect_snapshot_error({cubist_rules() %>% fit(mpg ~., data = mtcars)})
   expect_snapshot_error({poisson_reg() %>% fit(mpg ~., data = mtcars)})

--- a/tests/testthat/test-gen_additive_model.R
+++ b/tests/testthat/test-gen_additive_model.R
@@ -11,13 +11,12 @@ test_that('regression', {
     set_engine("mgcv") %>%
     set_mode("regression")
 
-  expect_error(
+  expect_no_condition(
     f_res <- fit(
       reg_mod,
       mpg ~ s(disp) + wt + gear,
       data = mtcars
-    ),
-    regexp = NA
+    )
   )
   expect_error(
     xy_res <- fit_xy(
@@ -55,13 +54,12 @@ test_that('classification', {
     set_engine("mgcv") %>%
     set_mode("classification")
 
-  expect_error(
+  expect_no_condition(
     f_res <- fit(
       cls_mod,
       Class ~ s(A, k = 10) + B,
       data = two_class_dat
-    ),
-    regexp = NA
+    )
   )
   expect_error(
     xy_res <- fit_xy(

--- a/tests/testthat/test-glm_grouped.R
+++ b/tests/testthat/test-glm_grouped.R
@@ -6,9 +6,8 @@ test_that('correct results for glm_grouped()', {
 
   ungrouped <- glm(Admit ~ Gender + Dept, data = ucb_long, family = binomial)
 
-  expect_error(
-    grouped <- glm_grouped(Admit ~ Gender + Dept, data = ucb_weighted, weights = ucb_weighted$Freq),
-    regexp = NA
+  expect_no_condition(
+    grouped <- glm_grouped(Admit ~ Gender + Dept, data = ucb_weighted, weights = ucb_weighted$Freq)
   )
 
   expect_equal(grouped$df.null, 11)

--- a/tests/testthat/test-linear_reg.R
+++ b/tests/testthat/test-linear_reg.R
@@ -29,24 +29,22 @@ hpc_basic <- linear_reg() %>% set_engine("lm")
 
 test_that('lm execution', {
 
-  expect_error(
+  expect_no_condition(
     res <- fit(
       hpc_basic,
       input_fields ~ log(compounds) + class,
       data = hpc,
       control = ctrl
-    ),
-    regexp = NA
+    )
   )
 
-  expect_error(
+  expect_no_condition(
     res <- fit_xy(
       hpc_basic,
       x = hpc[, num_pred],
       y = hpc$input_fields,
       control = ctrl
-    ),
-    regexp = NA
+    )
   )
 
   expect_error(
@@ -90,24 +88,22 @@ test_that('lm execution', {
 
   ## multivariate y
 
-  expect_error(
+  expect_no_condition(
     res <- fit(
       hpc_basic,
       cbind(compounds, iterations) ~ .,
       data = hpc,
       control = ctrl
-    ),
-    regexp = NA
+    )
   )
 
-  expect_error(
+  expect_no_condition(
     res <- fit_xy(
       hpc_basic,
       x = hpc[, 1:2],
       y = hpc[3:4],
       control = ctrl
-    ),
-    regexp = NA
+    )
   )
 })
 
@@ -115,24 +111,22 @@ test_that('glm execution', {
 
   hpc_glm <- linear_reg() %>% set_engine("glm")
 
-  expect_error(
+  expect_no_condition(
     res <- fit(
       hpc_glm,
       input_fields ~ log(compounds) + class,
       data = hpc,
       control = ctrl
-    ),
-    regexp = NA
+    )
   )
 
-  expect_error(
+  expect_no_condition(
     res <- fit_xy(
       hpc_glm,
       x = hpc[, num_pred],
       y = hpc$input_fields,
       control = ctrl
-    ),
-    regexp = NA
+    )
   )
 
   expect_error(
@@ -344,8 +338,8 @@ test_that("check_args() works", {
   expect_snapshot(
     error = TRUE,
     {
-      spec <- linear_reg(mixture = -1) %>% 
-        set_engine("lm") %>% 
+      spec <- linear_reg(mixture = -1) %>%
+        set_engine("lm") %>%
         set_mode("regression")
       fit(spec, compounds ~ ., hpc)
     }
@@ -353,8 +347,8 @@ test_that("check_args() works", {
   expect_snapshot(
     error = TRUE,
     {
-      spec <- linear_reg(penalty = -1) %>% 
-        set_engine("lm") %>% 
+      spec <- linear_reg(penalty = -1) %>%
+        set_engine("lm") %>%
         set_mode("regression")
       fit(spec, compounds ~ ., hpc)
     }

--- a/tests/testthat/test-linear_reg_keras.R
+++ b/tests/testthat/test-linear_reg_keras.R
@@ -21,28 +21,26 @@ test_that('model fitting', {
 
   set_tf_seed(257)
 
-  expect_error(
+  expect_no_condition(
     fit1 <-
       fit_xy(
         basic_mod,
         control = ctrl,
         x = hpc[,2:4],
         y = hpc$compounds
-      ),
-    regexp = NA
+      )
   )
 
   set_tf_seed(257)
 
-  expect_error(
+  expect_no_condition(
     fit2 <-
       fit_xy(
         basic_mod,
         control = ctrl,
         x = hpc[,2:4],
         y = hpc$compounds
-      ),
-    regexp = NA
+      )
   )
   expect_equal(
     unlist(keras::get_weights(extract_fit_engine(fit1))),
@@ -50,35 +48,32 @@ test_that('model fitting', {
     tolerance = .1
   )
 
-  expect_error(
+  expect_no_condition(
     fit(
       basic_mod,
       compounds ~ .,
       data = hpc[, -5],
       control = ctrl
-    ),
-    regexp = NA
+    )
   )
 
-  expect_error(
+  expect_no_condition(
     fit1 <-
       fit_xy(
         ridge_mod,
         control = ctrl,
         x = hpc[,2:4],
         y = hpc$compounds
-      ),
-    regexp = NA
+      )
   )
 
-  expect_error(
+  expect_no_condition(
     fit(
       ridge_mod,
       compounds ~ .,
       data = hpc[, -5],
       control = ctrl
-    ),
-    regexp = NA
+    )
   )
 
 })

--- a/tests/testthat/test-logistic_reg.R
+++ b/tests/testthat/test-logistic_reg.R
@@ -37,15 +37,14 @@ test_that('glm execution', {
 
 
   # passes interactively but not on R CMD check
-  # expect_error(
+  # expect_no_condition(
   #   res <- fit(
   #     lc_basic,
   #     lc_form,
   #     data = lending_club,
   #     control = ctrl,
   #     engine = "glm"
-  #   ),
-  #   regexp = NA
+  #   )
   # )
   expect_no_condition(
     res <- fit_xy(
@@ -177,9 +176,8 @@ test_that('liblinear execution', {
     )
   )
 
-  expect_error(
-    tidy_res <- tidy(res),
-    NA
+  expect_no_condition(
+    tidy_res <- tidy(res)
   )
   expect_s3_class(tidy_res, "tbl_df")
   expect_equal(colnames(tidy_res), c("term", "estimate"))

--- a/tests/testthat/test-logistic_reg.R
+++ b/tests/testthat/test-logistic_reg.R
@@ -47,14 +47,13 @@ test_that('glm execution', {
   #   ),
   #   regexp = NA
   # )
-  expect_error(
+  expect_no_condition(
     res <- fit_xy(
       lc_basic,
       x = lending_club[, num_pred],
       y = lending_club$Class,
       control = ctrl
-    ),
-    regexp = NA
+    )
   )
 
   expect_error(
@@ -160,14 +159,13 @@ test_that('liblinear execution', {
 
   skip_if_not_installed("LiblineaR")
 
-  expect_error(
+  expect_no_condition(
     res <- fit_xy(
       ll_basic,
       x = lending_club[, num_pred],
       y = lending_club$Class,
       control = ctrl
-    ),
-    regexp = NA
+    )
   )
 
   expect_error(
@@ -253,8 +251,8 @@ test_that("check_args() works", {
   expect_snapshot(
     error = TRUE,
     {
-      spec <- logistic_reg(mixture = -1) %>% 
-        set_engine("glm") %>% 
+      spec <- logistic_reg(mixture = -1) %>%
+        set_engine("glm") %>%
         set_mode("classification")
       fit(spec, Class ~ ., lending_club)
     }
@@ -262,8 +260,8 @@ test_that("check_args() works", {
   expect_snapshot(
     error = TRUE,
     {
-      spec <- logistic_reg(penalty = -1) %>% 
-        set_engine("glm") %>% 
+      spec <- logistic_reg(penalty = -1) %>%
+        set_engine("glm") %>%
         set_mode("classification")
       fit(spec, Class ~ ., lending_club)
     }
@@ -271,8 +269,8 @@ test_that("check_args() works", {
   expect_snapshot(
     error = TRUE,
     {
-      spec <- logistic_reg(mixture = 0.5) %>% 
-        set_engine("LiblineaR") %>% 
+      spec <- logistic_reg(mixture = 0.5) %>%
+        set_engine("LiblineaR") %>%
         set_mode("classification")
       fit(spec, Class ~ ., lending_club)
     }
@@ -280,8 +278,8 @@ test_that("check_args() works", {
   expect_snapshot(
     error = TRUE,
     {
-      spec <- logistic_reg(penalty = 0) %>% 
-        set_engine("LiblineaR") %>% 
+      spec <- logistic_reg(penalty = 0) %>%
+        set_engine("LiblineaR") %>%
         set_mode("classification")
       fit(spec, Class ~ ., lending_club)
     }

--- a/tests/testthat/test-logistic_reg_keras.R
+++ b/tests/testthat/test-logistic_reg_keras.R
@@ -31,28 +31,26 @@ test_that('model fitting', {
 
   set_tf_seed(257)
 
-  expect_error(
+  expect_no_condition(
     fit1 <-
       fit_xy(
       basic_mod,
       control = ctrl,
       x = tr_dat[, -1],
       y = tr_dat$Class
-    ),
-    regexp = NA
+    )
   )
 
   set_tf_seed(257)
 
-  expect_error(
+  expect_no_condition(
     fit2 <-
       fit_xy(
         basic_mod,
         control = ctrl,
         x = tr_dat[, -1],
         y = tr_dat$Class
-      ),
-    regexp = NA
+      )
   )
   expect_equal(
     unlist(keras::get_weights(fit1$fit)),
@@ -60,35 +58,32 @@ test_that('model fitting', {
     tolerance = .1
   )
 
-  expect_error(
+  expect_no_condition(
     fit(
       basic_mod,
       Class ~ .,
       data = tr_dat,
       control = ctrl
-    ),
-    regexp = NA
+    )
   )
 
-  expect_error(
+  expect_no_condition(
     fit1 <-
       fit_xy(
         reg_mod,
         control = ctrl,
         x = tr_dat[, -1],
         y = tr_dat$Class
-      ),
-    regexp = NA
+      )
   )
 
-  expect_error(
+  expect_no_condition(
     fit(
       reg_mod,
       Class ~ .,
       data = tr_dat,
       control = ctrl
-    ),
-    regexp = NA
+    )
   )
 
 })

--- a/tests/testthat/test-mars.R
+++ b/tests/testthat/test-mars.R
@@ -36,24 +36,22 @@ hpc_basic <- mars(mode = "regression") %>% set_engine("earth")
 test_that('mars execution', {
   skip_if_not_installed("earth")
 
-  expect_error(
+  expect_no_condition(
     res <- fit(
       hpc_basic,
       compounds ~ log(input_fields) + class,
       data = hpc,
       control = ctrl
-    ),
-    regexp = NA
+    )
   )
 
-  expect_error(
+  expect_no_condition(
     res <- fit_xy(
       hpc_basic,
       x = hpc[, num_pred],
       y = hpc$num_pending,
       control = ctrl
-    ),
-    regexp = NA
+    )
   )
 
   expect_true(has_multi_predict(res))
@@ -71,24 +69,22 @@ test_that('mars execution', {
 
   ## multivariate y
 
-  expect_error(
+  expect_no_condition(
     res <- fit(
       hpc_basic,
       cbind(compounds, input_fields) ~ .,
       data = hpc,
       control = ctrl
-    ),
-    regexp = NA
+    )
   )
 
-  expect_error(
+  expect_no_condition(
     res <- fit_xy(
       hpc_basic,
       x = hpc[, 1:2],
       y = hpc[3:4],
       control = ctrl
-    ),
-    regexp = NA
+    )
   )
   parsnip:::load_libs(res, attach = TRUE)
 
@@ -200,12 +196,11 @@ test_that('submodel prediction', {
 test_that('classification', {
   skip_if_not_installed("earth")
 
-  expect_error(
+  expect_no_condition(
     glm_mars <-
       mars(mode = "classification")  %>%
       set_engine("earth") %>%
-      fit(Class ~ ., data = lending_club[-(1:5),]),
-    regexp = NA
+      fit(Class ~ ., data = lending_club[-(1:5),])
   )
   expect_true(!is.null(extract_fit_engine(glm_mars)$glm.list))
   parsnip_pred <- predict(glm_mars, new_data = lending_club[1:5, -ncol(lending_club)], type = "prob")
@@ -219,12 +214,12 @@ test_that('classification', {
 
 test_that("check_args() works", {
   skip_if_not_installed("earth")
-  
+
   expect_snapshot(
     error = TRUE,
     {
-      spec <- mars(prod_degree = 0) %>% 
-        set_engine("earth") %>% 
+      spec <- mars(prod_degree = 0) %>%
+        set_engine("earth") %>%
         set_mode("classification")
       fit(spec, class ~ ., hpc)
     }
@@ -232,8 +227,8 @@ test_that("check_args() works", {
   expect_snapshot(
     error = TRUE,
     {
-      spec <- mars(num_terms = 0) %>% 
-        set_engine("earth") %>% 
+      spec <- mars(num_terms = 0) %>%
+        set_engine("earth") %>%
         set_mode("classification")
       fit(spec, class ~ ., hpc)
     }
@@ -241,8 +236,8 @@ test_that("check_args() works", {
   expect_snapshot(
     error = TRUE,
     {
-      spec <- mars(prune_method = 2) %>% 
-        set_engine("earth") %>% 
+      spec <- mars(prune_method = 2) %>%
+        set_engine("earth") %>%
         set_mode("classification")
       fit(spec, class ~ ., hpc)
     }

--- a/tests/testthat/test-misc.R
+++ b/tests/testthat/test-misc.R
@@ -35,25 +35,23 @@ test_that('other objects', {
 
 test_that('S3 method dispatch/registration', {
 
-  expect_error(
+  expect_no_condition(
     res <-
       null_model() %>%
       set_engine("parsnip") %>%
       set_mode("regression") %>%
       fit(mpg ~ ., data = mtcars) %>%
-      tidy(),
-    regex = NA
+      tidy()
   )
   expect_true(tibble::is_tibble(res))
 
-  expect_error(
+  expect_no_condition(
     res <-
       null_model() %>%
       set_engine("parsnip") %>%
       set_mode("classification") %>%
       fit(class ~ ., data = hpc) %>%
-      tidy(),
-    regex = NA
+      tidy()
   )
   expect_true(tibble::is_tibble(res))
 

--- a/tests/testthat/test-misc.R
+++ b/tests/testthat/test-misc.R
@@ -73,13 +73,11 @@ test_that('control class', {
   class(ctrl) <- c("potato", "chair")
   # This doesn't error anymore because `condense_control()` doesn't care about
   # classes, it cares about elements
-  expect_error(
-    fit(x, mpg ~ ., data = mtcars, control = ctrl),
-    NA
+  expect_no_condition(
+    fit(x, mpg ~ ., data = mtcars, control = ctrl)
   )
-  expect_error(
-    fit_xy(x, x = mtcars[, -1], y = mtcars$mpg, control = ctrl),
-    NA
+  expect_no_condition(
+    fit_xy(x, x = mtcars[, -1], y = mtcars$mpg, control = ctrl)
   )
 })
 
@@ -161,10 +159,7 @@ test_that('arguments can be passed to model spec inside function', {
   exp_res <- nearest_neighbor(mode = "regression", neighbors = 5) %>%
     fit(mpg ~ ., data = mtcars)
 
-  expect_error(
-    fun_res <- f(),
-    NA
-  )
+  expect_no_condition(fun_res <- f())
 
   expect_equal(exp_res$fit[-c(8, 9)], fun_res$fit[-c(8, 9)])
 })

--- a/tests/testthat/test-mlp_keras.R
+++ b/tests/testthat/test-mlp_keras.R
@@ -16,14 +16,13 @@ test_that('keras execution, classification', {
   skip_if_not_installed("keras")
   skip_if(!is_tf_ok())
 
-  expect_error(
+  expect_no_condition(
     res <- parsnip::fit(
       hpc_keras,
       class ~ compounds + input_fields,
       data = hpc,
       control = ctrl
-    ),
-    regexp = NA
+    )
   )
 
 
@@ -32,14 +31,13 @@ test_that('keras execution, classification', {
 
   keras::backend()$clear_session()
 
-  expect_error(
+  expect_no_condition(
     res <- parsnip::fit_xy(
       hpc_keras,
       x = hpc[, num_pred],
       y = hpc$class,
       control = ctrl
-    ),
-    regexp = NA
+    )
   )
 
   keras::backend()$clear_session()
@@ -160,26 +158,24 @@ test_that('keras execution, regression', {
   skip_if_not_installed("keras")
   skip_if(!is_tf_ok())
 
-  expect_error(
+  expect_no_condition(
     res <- parsnip::fit(
       car_basic,
       mpg ~ .,
       data = mtcars,
       control = ctrl
-    ),
-    regexp = NA
+    )
   )
 
   keras::backend()$clear_session()
 
-  expect_error(
+  expect_no_condition(
     res <- parsnip::fit_xy(
       car_basic,
       x = mtcars[, num_pred],
       y = mtcars$mpg,
       control = ctrl
-    ),
-    regexp = NA
+    )
   )
 })
 

--- a/tests/testthat/test-mlp_nnet.R
+++ b/tests/testthat/test-mlp_nnet.R
@@ -12,24 +12,22 @@ test_that('nnet execution, classification', {
 
   skip_if_not_installed("nnet")
 
-  expect_error(
+  expect_no_condition(
     res <- parsnip::fit(
       hpc_nnet,
       class ~ compounds + input_fields,
       data = hpc,
       control = ctrl
-    ),
-    regexp = NA
+    )
   )
 
-  expect_error(
+  expect_no_condition(
     res <- parsnip::fit_xy(
       hpc_nnet,
       x = hpc[, num_pred],
       y = hpc$class,
       control = ctrl
-    ),
-    regexp = NA
+    )
   )
 
   expect_error(
@@ -93,24 +91,22 @@ test_that('nnet execution, regression', {
 
   skip_if_not_installed("nnet")
 
-  expect_error(
+  expect_no_condition(
     res <- parsnip::fit(
       car_basic,
       mpg ~ .,
       data = mtcars,
       control = ctrl
-    ),
-    regexp = NA
+    )
   )
 
-  expect_error(
+  expect_no_condition(
     res <- parsnip::fit_xy(
       car_basic,
       x = mtcars[, num_pred],
       y = mtcars$mpg,
       control = ctrl
-    ),
-    regexp = NA
+    )
   )
 })
 

--- a/tests/testthat/test-multinom_reg_keras.R
+++ b/tests/testthat/test-multinom_reg_keras.R
@@ -29,28 +29,26 @@ test_that('model fitting', {
 
   set_tf_seed(257)
 
-  expect_error(
+  expect_no_condition(
     fit1 <-
       fit_xy(
         basic_mod,
         control = ctrl,
         x = tr_dat[, -5],
         y = tr_dat$class
-      ),
-    regexp = NA
+      )
   )
 
   set_tf_seed(257)
 
-  expect_error(
+  expect_no_condition(
     fit2 <-
       fit_xy(
         basic_mod,
         control = ctrl,
         x = tr_dat[, -5],
         y = tr_dat$class
-      ),
-    regexp = NA
+      )
   )
   expect_equal(
     unlist(keras::get_weights(extract_fit_engine(fit1))),
@@ -58,35 +56,32 @@ test_that('model fitting', {
     tolerance = .1
   )
 
-  expect_error(
+  expect_no_condition(
     fit(
       basic_mod,
       class ~ .,
       data = tr_dat,
       control = ctrl
-    ),
-    regexp = NA
+    )
   )
 
-  expect_error(
+  expect_no_condition(
     fit1 <-
       fit_xy(
         reg_mod,
         control = ctrl,
         x = tr_dat[, -5],
         y = tr_dat$class
-      ),
-    regexp = NA
+      )
   )
 
-  expect_error(
+  expect_no_condition(
     fit(
       reg_mod,
       class ~ .,
       data = tr_dat,
       control = ctrl
-    ),
-    regexp = NA
+    )
   )
 
 })

--- a/tests/testthat/test-multinom_reg_nnet.R
+++ b/tests/testthat/test-multinom_reg_nnet.R
@@ -22,39 +22,36 @@ test_that('model fitting', {
   skip_if_not_installed("nnet")
 
   set.seed(257)
-  expect_error(
+  expect_no_condition(
     fit1 <-
       fit_xy(
         basic_mod,
         control = ctrl,
         x = tr_dat[, -5],
         y = tr_dat$class
-      ),
-    regexp = NA
+      )
   )
 
   set.seed(257)
-  expect_error(
+  expect_no_condition(
     fit2 <-
       fit_xy(
         basic_mod,
         control = ctrl,
         x = tr_dat[, -5],
         y = tr_dat$class
-      ),
-    regexp = NA
+      )
   )
   fit1$elapsed <- fit2$elapsed
   expect_equal(fit1, fit2, ignore_formula_env = TRUE)
 
-  expect_error(
+  expect_no_condition(
     fit(
       basic_mod,
       class ~ .,
       data = tr_dat,
       control = ctrl
-    ),
-    regexp = NA
+    )
   )
 
 })

--- a/tests/testthat/test-nearest_neighbor_kknn.R
+++ b/tests/testthat/test-nearest_neighbor_kknn.R
@@ -29,14 +29,13 @@ test_that('kknn execution', {
 
   # nominal
   # expect no error
-  expect_error(
+  expect_no_condition(
     res <- fit_xy(
       hpc_basic,
       control = ctrl,
       x = hpc[, c("input_fields", "iterations")],
       y = hpc$class
-    ),
-    regexp = NA
+    )
   )
 
   expect_true(has_multi_predict(res))

--- a/tests/testthat/test-nullmodel.R
+++ b/tests/testthat/test-nullmodel.R
@@ -119,11 +119,10 @@ test_that('nullmodel prediction', {
 
 test_that('classification', {
 
-  expect_error(
+  expect_no_condition(
     null_model <- null_model(mode = "classification") %>%
       set_engine("parsnip") %>%
-      fit(class ~ ., data = hpc),
-    regexp = NA
+      fit(class ~ ., data = hpc)
   )
   expect_true(!is.null(null_model$fit))
 })

--- a/tests/testthat/test-packages.R
+++ b/tests/testthat/test-packages.R
@@ -35,7 +35,7 @@ test_that('missing packages', {
   has_earth <- parsnip:::is_installed("earth")
 
   if (has_earth) {
-    expect_error(predict(mars_model, mtcars[1:3, -1]), regexp = NA)
+    expect_no_condition(predict(mars_model, mtcars[1:3, -1]))
 
   } else {
     expect_error(predict(mars_model, mtcars[1:3, -1]), regexp = "earth")

--- a/tests/testthat/test-partykit.R
+++ b/tests/testthat/test-partykit.R
@@ -8,27 +8,23 @@ test_that('fit ctree models', {
   data(Chicago, package = "modeldata")
   data(ad_data, package = "modeldata")
 
-  expect_error(
-    fit_1 <- ctree_train(ridership ~ ., data = Chicago[, 1:20]),
-    regex = NA
+  expect_no_condition(
+    fit_1 <- ctree_train(ridership ~ ., data = Chicago[, 1:20])
   )
-  expect_error(
+  expect_no_condition(
     fit_2 <- ctree_train(ridership ~ ., data = Chicago[, 1:20],
-                         mincriterion = 1/2, maxdepth = 2),
-    regex = NA
+                         mincriterion = 1/2, maxdepth = 2)
   )
   expect_equal(fit_2$info$control$logmincriterion, log(1/2))
   expect_equal(fit_2$info$control$maxdepth, 2)
-  expect_error(
+  expect_no_condition(
     fit_3 <- ctree_train(ridership ~ ., data = Chicago[, 1:20],
                          mincriterion = 1/2, maxdepth = 2,
-                         weights = 1:nrow(Chicago)),
-    regex = NA
+                         weights = 1:nrow(Chicago))
   )
   expect_false(isTRUE(all.equal(fit_2$fitted, fit_3$fitted)))
-  expect_error(
-    fit_4 <- ctree_train(Class ~ ., data = ad_data),
-    regex = NA
+  expect_no_condition(
+    fit_4 <- ctree_train(Class ~ ., data = ad_data)
   )
   expect_snapshot_error(
     ctree_train(ridership ~ ., data = Chicago[, 1:20],
@@ -45,33 +41,28 @@ test_that('fit cforest models', {
   data(Chicago, package = "modeldata")
   data(ad_data, package = "modeldata")
 
-  expect_error(
-    fit_1 <- cforest_train(ridership ~ ., data = Chicago[, 1:5], ntree = 2),
-    regex = NA
+  expect_no_condition(
+    fit_1 <- cforest_train(ridership ~ ., data = Chicago[, 1:5], ntree = 2)
   )
   expect_equal(length(fit_1$nodes), 2)
-  expect_error(
+  expect_no_condition(
     fit_2 <- cforest_train(ridership ~ ., data = Chicago[, 1:5], ntree = 2,
-                           mincriterion = 1/2, maxdepth = 2, mtry = 4),
-    regex = NA
+                           mincriterion = 1/2, maxdepth = 2, mtry = 4)
   )
   expect_equal(fit_2$info$control$logmincriterion, log(1/2))
   expect_equal(fit_2$info$control$maxdepth, 2)
   expect_equal(fit_2$info$control$mtry, 4)
-  expect_error(
+  expect_no_condition(
     fit_3 <- cforest_train(ridership ~ ., data = Chicago[, 1:5], ntree = 2,
                            mincriterion = 1/2, maxdepth = 2, mtry = 4,
-                           weights = 1:nrow(Chicago)),
-    regex = NA
+                           weights = 1:nrow(Chicago))
   )
   expect_false(isTRUE(all.equal(fit_2$fitted, fit_3$fitted)))
-  expect_error(
-    fit_4 <- cforest_train(Class ~ ., data = ad_data, ntree = 2),
-    regex = NA
+  expect_no_condition(
+    fit_4 <- cforest_train(Class ~ ., data = ad_data, ntree = 2)
   )
-  expect_error(
-    fit_5 <- cforest_train(Class ~ ., data = ad_data, ntree = 2, mtry = 2000),
-    regex = NA
+  expect_no_condition(
+    fit_5 <- cforest_train(Class ~ ., data = ad_data, ntree = 2, mtry = 2000)
   )
   expect_equal(fit_5$info$control$mtry, 130)
   expect_snapshot_error(

--- a/tests/testthat/test-predict_formats.R
+++ b/tests/testthat/test-predict_formats.R
@@ -63,15 +63,13 @@ test_that('predict(type = "prob") with level "class" (see #720)', {
     beep = rnorm(100)
   )
 
-  expect_error(
-    regexp = NA,
+  expect_no_condition(
     mod <- logistic_reg() %>%
       set_mode(mode = "classification") %>%
       fit(boop ~ bop + beep, data = x)
   )
 
-  expect_error(
-    regexp = NA,
+  expect_no_condition(
     predict(mod, type = "class", new_data = x)
   )
 
@@ -120,6 +118,6 @@ test_that("predict() works for model fit with fit_xy() (#1166)", {
   tree_fit <- fit_xy(spec, x = mtcars[, -1], y = mtcars[, 1])
 
   res <- predict(tree_fit, mtcars)
-  
+
   expect_identical(exp, res)
 })

--- a/tests/testthat/test-rand_forest_ranger.R
+++ b/tests/testthat/test-rand_forest_ranger.R
@@ -17,14 +17,13 @@ test_that('ranger classification execution', {
 
   skip_if_not_installed("ranger")
 
-  expect_error(
+  expect_no_condition(
     res <- fit(
       lc_ranger,
       Class ~ funded_amnt + term,
       data = lending_club,
       control = ctrl
-    ),
-    regexp = NA
+    )
   )
 
   expect_error(
@@ -37,15 +36,14 @@ test_that('ranger classification execution', {
     regexp = "For a classification model"
   )
 
-  expect_error(
+  expect_no_condition(
     res <- fit_xy(
       lc_ranger,
       x = lending_club[, num_pred],
       y = lending_club$Class,
 
       control = ctrl
-    ),
-    regexp = NA
+    )
   )
 
   expect_error(
@@ -182,24 +180,22 @@ test_that('ranger regression execution', {
 
   skip_if_not_installed("ranger")
 
-  expect_error(
+  expect_no_condition(
     res <- fit(
       car_basic,
       mpg ~ .,
       data = mtcars,
       control = ctrl
-    ),
-    regexp = NA
+    )
   )
 
-  expect_error(
+  expect_no_condition(
     res <- fit_xy(
       car_basic,
       x = mtcars,
       y = mtcars$mpg,
       control = ctrl
-    ),
-    regexp = NA
+    )
   )
 
 

--- a/tests/testthat/test-re_registration.R
+++ b/tests/testthat/test-re_registration.R
@@ -4,16 +4,15 @@
 
 test_that('re-registration of mode', {
   old_val <- get_from_env("bart_modes")
-  expect_error(set_model_mode("bart", "classification"), regexp = NA)
+  expect_no_condition(set_model_mode("bart", "classification"))
   new_val <- get_from_env("bart_modes")
   expect_equal(old_val, new_val)
 })
 
 test_that('re-registration of engine', {
   old_val <- get_from_env("bart")
-  expect_error(
-    set_model_engine("bart", mode = "classification", eng = "dbarts"),
-    regexp = NA
+  expect_no_condition(
+    set_model_engine("bart", mode = "classification", eng = "dbarts")
   )
   new_val <- get_from_env("bart")
   expect_equal(old_val, new_val)
@@ -22,17 +21,16 @@ test_that('re-registration of engine', {
 
 test_that('re-registration of package dependencies', {
   old_val <- get_from_env("bart_pkgs")
-  expect_error(
-    set_dependency("bart", "dbarts", "dbarts"),
-    regexp = NA
-  )
+  expect_no_error(expect_no_warning(
+    set_dependency("bart", "dbarts", "dbarts")
+  ))
   new_val <- get_from_env("bart_pkgs")
   expect_equal(old_val, new_val)
 })
 
 test_that('re-registration of fit information', {
   old_val <- get_from_env("bart_fit")
-  expect_error(
+  expect_no_condition(
     set_fit(
       model = "bart",
       eng = "dbarts",
@@ -44,8 +42,7 @@ test_that('re-registration of fit information', {
         func = c(pkg = "dbarts", fun = "bart"),
         defaults = list(verbose = FALSE, keeptrees = TRUE, keepcall = FALSE)
       )
-    ),
-    regexp = NA
+    )
   )
   new_val <- get_from_env("bart_fit")
   expect_equal(old_val, new_val)
@@ -71,7 +68,7 @@ test_that('re-registration of fit information', {
 
 test_that('re-registration of encoding information', {
   old_val <- get_from_env("bart_encoding")
-  expect_error(
+  expect_no_condition(
     set_encoding(
       model = "bart",
       eng = "dbarts",
@@ -82,8 +79,7 @@ test_that('re-registration of encoding information', {
         remove_intercept = FALSE,
         allow_sparse_x = FALSE
       )
-    ),
-    regexp = NA
+    )
   )
   new_val <- get_from_env("bart_encoding")
   expect_equal(old_val, new_val)
@@ -109,7 +105,7 @@ test_that('re-registration of encoding information', {
 
 test_that('re-registration of prediction information', {
   old_val <- get_from_env("bart_predict")
-  expect_error(
+  expect_no_condition(
     set_pred(
       model = "bart",
       eng = "dbarts",
@@ -126,8 +122,7 @@ test_that('re-registration of prediction information', {
             type = "numeric"
           )
       )
-    ),
-    regexp = NA
+    )
   )
   new_val <- get_from_env("bart_predict")
   expect_equal(old_val, new_val)

--- a/tests/testthat/test-surv_reg_flexsurv.R
+++ b/tests/testthat/test-surv_reg_flexsurv.R
@@ -11,23 +11,21 @@ test_that('flexsurv execution', {
   rlang::local_options(lifecycle_verbosity = "quiet")
   surv_basic <- surv_reg() %>% set_engine("flexsurv")
 
-  expect_error(
+  expect_no_condition(
     res <- fit(
       surv_basic,
       survival::Surv(time, status) ~ age,
       data = lung,
       control = ctrl
-    ),
-    regexp = NA
+    )
   )
-  expect_error(
+  expect_no_condition(
     res <- fit(
       surv_basic,
       survival::Surv(time) ~ age,
       data = lung,
       control = ctrl
-    ),
-    regexp = NA
+    )
   )
   expect_false(has_multi_predict(res))
   expect_equal(multi_predict_args(res), NA_character_)

--- a/tests/testthat/test-surv_reg_survreg.R
+++ b/tests/testthat/test-surv_reg_survreg.R
@@ -16,24 +16,22 @@ test_that('survival execution', {
   surv_basic <- surv_reg() %>% set_engine("survival")
   surv_lnorm <- surv_reg(dist = "lognormal") %>% set_engine("survival")
 
-  expect_error(
+  expect_no_condition(
     res <- fit(
       surv_basic,
       survival::Surv(time, status) ~ age + sex,
       data = lung,
       control = ctrl
-    ),
-    regexp = NA
+    )
   )
 
-  expect_error(
+  expect_no_condition(
     res <- fit(
       surv_lnorm,
       survival::Surv(time) ~ age + sex,
       data = lung,
       control = ctrl
-    ),
-    regexp = NA
+    )
   )
   expect_error(
     res <- fit_xy(

--- a/tests/testthat/test-svm_linear.R
+++ b/tests/testthat/test-svm_linear.R
@@ -37,14 +37,13 @@ test_that('linear svm regression: LiblineaR', {
 
   skip_if_not_installed("LiblineaR")
 
-  expect_error(
+  expect_no_condition(
     res <- fit_xy(
       reg_mod,
       control = ctrl,
       x = hpc[,2:4],
       y = hpc$input_fields
-    ),
-    regexp = NA
+    )
   )
   expect_false(has_multi_predict(res))
   expect_equal(multi_predict_args(res), NA_character_)
@@ -56,14 +55,13 @@ test_that('linear svm regression: LiblineaR', {
   expect_s3_class(tidy_res, "tbl_df")
   expect_equal(colnames(tidy_res), c("term", "estimate"))
 
-  expect_error(
+  expect_no_condition(
     fit(
       reg_mod,
       input_fields ~ .,
       data = hpc[, -5],
       control = ctrl
-    ),
-    regexp = NA
+    )
   )
 
 })
@@ -123,24 +121,22 @@ test_that('linear svm classification: LiblineaR', {
 
   ind <- c(2, 1, 143)
 
-  expect_error(
+  expect_no_condition(
     fit_xy(
       cls_mod,
       control = ctrl,
       x = hpc_no_m[, -5],
       y = hpc_no_m$class
-    ),
-    regexp = NA
+    )
   )
 
-  expect_error(
+  expect_no_condition(
     fit(
       cls_mod,
       class ~ .,
       data = hpc_no_m,
       control = ctrl
-    ),
-    regexp = NA
+    )
   )
 
 })
@@ -216,26 +212,24 @@ test_that('linear svm regression: kernlab', {
 
   skip_if_not_installed("kernlab")
 
-  expect_error(
+  expect_no_condition(
     res <- fit_xy(
       reg_mod,
       control = ctrl,
       x = hpc[,2:4],
       y = hpc$input_fields
-    ),
-    regexp = NA
+    )
   )
   expect_false(has_multi_predict(res))
   expect_equal(multi_predict_args(res), NA_character_)
 
-  expect_error(
+  expect_no_condition(
     fit(
       reg_mod,
       input_fields ~ .,
       data = hpc[, -5],
       control = ctrl
-    ),
-    regexp = NA
+    )
   )
 
 })
@@ -295,24 +289,22 @@ test_that('linear svm classification: kernlab', {
 
   ind <- c(2, 1, 143)
 
-  expect_error(
+  expect_no_condition(
     fit_xy(
       cls_mod,
       control = ctrl,
       x = hpc_no_m[, -5],
       y = hpc_no_m$class
-    ),
-    regexp = NA
+    )
   )
 
-  expect_error(
+  expect_no_condition(
     fit(
       cls_mod,
       class ~ .,
       data = hpc_no_m,
       control = ctrl
-    ),
-    regexp = NA
+    )
   )
 
 })

--- a/tests/testthat/test-svm_linear.R
+++ b/tests/testthat/test-svm_linear.R
@@ -48,10 +48,7 @@ test_that('linear svm regression: LiblineaR', {
   expect_false(has_multi_predict(res))
   expect_equal(multi_predict_args(res), NA_character_)
 
-  expect_error(
-    tidy_res <- tidy(res),
-    NA
-  )
+  expect_no_condition(tidy_res <- tidy(res))
   expect_s3_class(tidy_res, "tbl_df")
   expect_equal(colnames(tidy_res), c("term", "estimate"))
 

--- a/tests/testthat/test-svm_poly.R
+++ b/tests/testthat/test-svm_poly.R
@@ -34,27 +34,25 @@ test_that('svm poly regression', {
 
   skip_if_not_installed("kernlab")
 
-  expect_error(
+  expect_no_condition(
     res <- fit_xy(
       reg_mod,
       control = ctrl,
       x = hpc[,2:4],
       y = hpc$compounds
-    ),
-    regexp = NA
+    )
   )
 
   expect_false(has_multi_predict(res))
   expect_equal(multi_predict_args(res), NA_character_)
 
-  expect_error(
+  expect_no_condition(
     fit(
       reg_mod,
       compounds ~ .,
       data = hpc[, -5],
       control = ctrl
-    ),
-    regexp = NA
+    )
   )
 
 })
@@ -111,24 +109,22 @@ test_that('svm poly classification', {
 
   skip_if_not_installed("kernlab")
 
-  expect_error(
+  expect_no_condition(
     fit_xy(
       cls_mod,
       control = ctrl,
       x = hpc[, -5],
       y = hpc$class
-    ),
-    regexp = NA
+    )
   )
 
-  expect_error(
+  expect_no_condition(
     fit(
       cls_mod,
       class ~ .,
       data = hpc,
       control = ctrl
-    ),
-    regexp = NA
+    )
   )
 
 })

--- a/tests/testthat/test-svm_rbf.R
+++ b/tests/testthat/test-svm_rbf.R
@@ -42,26 +42,24 @@ test_that('svm poly regression', {
 
   skip_if_not_installed("kernlab")
 
-  expect_error(
+  expect_no_condition(
     res <- fit_xy(
       reg_mod,
       control = ctrl,
       x = hpc[,2:4],
       y = hpc$input_fields
-    ),
-    regexp = NA
+    )
   )
   expect_false(has_multi_predict(res))
   expect_equal(multi_predict_args(res), NA_character_)
 
-  expect_error(
+  expect_no_condition(
     fit(
       reg_mod,
       input_fields ~ .,
       data = hpc[, -5],
       control = ctrl
-    ),
-    regexp = NA
+    )
   )
 
 })
@@ -121,24 +119,22 @@ test_that('svm rbf classification', {
 
   ind <- c(2, 1, 143)
 
-  expect_error(
+  expect_no_condition(
     fit_xy(
       cls_mod,
       control = ctrl,
       x = hpc_no_m[, -5],
       y = hpc_no_m$class
-    ),
-    regexp = NA
+    )
   )
 
-  expect_error(
+  expect_no_condition(
     fit(
       cls_mod,
       class ~ .,
       data = hpc_no_m,
       control = ctrl
-    ),
-    regexp = NA
+    )
   )
 
 })


### PR DESCRIPTION
Related to #1096 but does not close—these are just the cases where `regexp = NA`, i.e. we're testing that there's no error. For all but one case, we can actually test the more stricter version, that there is no condition.