### PR TITLE
restore `tidy.glmnet(penalty)` default

### DIFF
--- a/R/tidy_glmnet.R
+++ b/R/tidy_glmnet.R
@@ -58,6 +58,9 @@ get_glmn_coefs <- function(x, penalty = 0.01) {
 tidy_glmnet <- function(x, penalty = NULL, ..., call = caller_env()) {
   check_installs(x$spec)
   load_libs(x$spec, quiet = TRUE, attach = TRUE)
+  if (is.null(penalty)) {
+    penalty <- x$spec$args$penalty
+  }
   check_number_decimal(penalty, min = 0, max = 1, allow_null = TRUE, call = call)
   get_glmn_coefs(x$fit, penalty = penalty)
 }


### PR DESCRIPTION
https://github.com/tidymodels/parsnip/commit/227ab92dfb803f5a6f42373e30cc15f9332712cd resulted in a [few new failures on extratests](https://github.com/tidymodels/extratests/actions/runs/10786271230/job/29912882661#step:8:381):

```
══ Failed ══════════════════════════════════════════════════════════════════════
── 1. Error ('test-encodings-glmnet.R:18:3'): parsnip models with formula interf
Error in `dimnames(x) <- dn`: length of 'dimnames' [2] not equal to array extent
Backtrace:
    ▆
 1. ├─generics::tidy(parsnip_form_fit) at test-encodings-glmnet.R:18:3
 2. └─parsnip:::tidy._elnet(parsnip_form_fit)
 3.   └─parsnip:::tidy_glmnet(x, penalty) at parsnip/R/tidy_glmnet.R:14:3
 4.     └─parsnip:::get_glmn_coefs(x$fit, penalty = penalty) at parsnip/R/tidy_glmnet.R:62:3
 5.       └─base::`colnames<-`(`*tmp*`, value = "estimate") at parsnip/R/tidy_glmnet.R:46:3
```

The code used to have a default penalty based on that used in the model fit; restoring that functionality.