### PR TITLE
correct formatting in model registration error

### DIFF
--- a/R/aaa_models.R
+++ b/R/aaa_models.R
@@ -796,7 +796,7 @@ is_discordant_info <- function(model, mode, eng, candidate,
   if (component == "predict" & !is.null(pred_type)) {
 
     current <- dplyr::filter(current, type == pred_type)
-    p_type <- paste0("and prediction type '", pred_type, "'")
+    p_type <- "and prediction type {.val {pred_type}} "
   } else {
     p_type <- ""
   }
@@ -809,9 +809,12 @@ is_discordant_info <- function(model, mode, eng, candidate,
 
   if (!same_info) {
     cli::cli_abort(
-      "The combination of engine {.var {eng}} and mode {.var {mode}} \\
-      {.val {p_type}} already has {component} data for model {.var {model}} \\
-      and the new information being registered is different.",
+      paste0(
+        "The combination of engine {.var {eng}} and mode {.var {mode}} ",
+        p_type,
+        "already has {component} data for model {.var {model}}
+         and the new information being registered is different."
+      ),
       call = call
     )
   }

--- a/tests/testthat/_snaps/re_registration.md
+++ b/tests/testthat/_snaps/re_registration.md
@@ -7,7 +7,7 @@
           keeptrees = TRUE, keepcall = FALSE)))
     Condition
       Error in `set_fit()`:
-      ! The combination of engine `dbarts` and mode `regression` "" already has fit data for model `bart` and the new information being registered is different.
+      ! The combination of engine `dbarts` and mode `regression` already has fit data for model `bart` and the new information being registered is different.
 
 # re-registration of encoding information
 
@@ -17,7 +17,7 @@
         allow_sparse_x = FALSE))
     Condition
       Error in `set_encoding()`:
-      ! The combination of engine `dbarts` and mode `regression` "" already has encoding data for model `bart` and the new information being registered is different.
+      ! The combination of engine `dbarts` and mode `regression` already has encoding data for model `bart` and the new information being registered is different.
 
 # re-registration of prediction information
 
@@ -27,5 +27,5 @@
         args = list(obj = quote(object), new_data = quote(new_data), type = "tuba")))
     Condition
       Error in `set_pred()`:
-      ! The combination of engine `dbarts` and mode `regression` "and prediction type 'numeric'" already has predict data for model `bart` and the new information being registered is different.
+      ! The combination of engine `dbarts` and mode `regression` and prediction type "numeric" already has predict data for model `bart` and the new information being registered is different.
 


### PR DESCRIPTION
Closes #1201. Don't love the `paste0()` smell but seems the substitution of a string that _also_ contains a substitution is a no-go.