### PR TITLE
Stricter sparsevctrs tests

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 * `fit_xy()` can now take dgCMatrix input for `x` argument (#1121).
 
-* `fit()` and `fit_xy()` can now take sparse tibbles as data values (#1165).
+* `fit_xy()` can now take sparse tibbles as data values (#1165).
 
 * `predict()` can now take dgCMatrix and sparse tibble input for `new_data` argument, and error informatively when model doesn't support it (#1167).
 

--- a/R/convert_data.R
+++ b/R/convert_data.R
@@ -48,6 +48,13 @@
     )
   }
 
+  if (is_sparse_tibble(data)) {
+    cli::cli_abort(
+      "Sparse data cannot be used with formula interface. Please use 
+      {.fn fit_xy} instead."
+    )
+  }
+
   if (remove_intercept) {
     data <- data[, colnames(data) != "(Intercept)", drop = FALSE]
   }

--- a/R/predict.R
+++ b/R/predict.R
@@ -470,6 +470,10 @@ prepare_data <- function(object, new_data) {
   if (allow_sparse(object) && inherits(new_data, "dgCMatrix")) {
     return(new_data)
   }
+  if (allow_sparse(object) && is_sparse_tibble(new_data)) {
+    new_data <- sparsevctrs::coerce_to_sparse_matrix(new_data)
+    return(new_data)
+  }
 
   fit_interface <- object$spec$method$fit$interface
   switch(

--- a/tests/testthat/_snaps/sparsevctrs.md
+++ b/tests/testthat/_snaps/sparsevctrs.md
@@ -1,4 +1,4 @@
-# sparse tibble can be passed to `fit()
+# sparse tibble can be passed to `fit() - supported
 
     Code
       lm_fit <- fit(spec, avg_price_per_room ~ ., data = hotel_data)
@@ -6,7 +6,7 @@
       Error in `.convert_form_to_xy_fit()`:
       ! Sparse data cannot be used with formula interface. Please use `fit_xy()` instead.
 
----
+# sparse tibble can be passed to `fit() - unsupported
 
     Code
       lm_fit <- fit(spec, avg_price_per_room ~ ., data = hotel_data[1:100, ])
@@ -14,7 +14,7 @@
       Warning:
       `data` is a sparse tibble, but `linear_reg()` with engine "lm" doesn't accept that. Converting to non-sparse.
 
-# sparse matrix can be passed to `fit()
+# sparse matrix can be passed to `fit() - supported
 
     Code
       lm_fit <- fit(spec, avg_price_per_room ~ ., data = hotel_data)
@@ -22,7 +22,7 @@
       Error in `.convert_form_to_xy_fit()`:
       ! Sparse data cannot be used with formula interface. Please use `fit_xy()` instead.
 
----
+# sparse matrix can be passed to `fit() - unsupported
 
     Code
       lm_fit <- fit(spec, avg_price_per_room ~ ., data = hotel_data[1:100, ])
@@ -30,7 +30,7 @@
       Warning:
       `data` is a sparse tibble, but `linear_reg()` with engine "lm" doesn't accept that. Converting to non-sparse.
 
-# sparse tibble can be passed to `fit_xy()
+# sparse tibble can be passed to `fit_xy() - unsupported
 
     Code
       lm_fit <- fit_xy(spec, x = hotel_data[1:100, -1], y = hotel_data[1:100, 1])
@@ -38,7 +38,7 @@
       Warning:
       `x` is a sparse tibble, but `linear_reg()` with engine "lm" doesn't accept that. Converting to non-sparse.
 
-# sparse matrices can be passed to `fit_xy()
+# sparse matrices can be passed to `fit_xy() - unsupported
 
     Code
       lm_fit <- fit_xy(spec, x = hotel_data[1:100, -1], y = hotel_data[1:100, 1])
@@ -46,7 +46,7 @@
       Error in `fit_xy()`:
       ! `x` is a sparse matrix, but `linear_reg()` with engine "lm" doesn't accept that.
 
-# sparse tibble can be passed to `predict()
+# sparse tibble can be passed to `predict() - unsupported
 
     Code
       preds <- predict(lm_fit, sparse_mtcars)
@@ -54,7 +54,7 @@
       Warning:
       `x` is a sparse tibble, but `linear_reg()` with engine "lm" doesn't accept that. Converting to non-sparse.
 
-# sparse matrices can be passed to `predict()
+# sparse matrices can be passed to `predict() - unsupported
 
     Code
       predict(lm_fit, sparse_mtcars)

--- a/tests/testthat/_snaps/sparsevctrs.md
+++ b/tests/testthat/_snaps/sparsevctrs.md
@@ -1,7 +1,7 @@
 # sparse tibble can be passed to `fit() - supported
 
     Code
-      lm_fit <- fit(spec, avg_price_per_room ~ ., data = hotel_data)
+      xgb_fit <- fit(spec, avg_price_per_room ~ ., data = hotel_data)
     Condition
       Error in `.convert_form_to_xy_fit()`:
       ! Sparse data cannot be used with formula interface. Please use `fit_xy()` instead.
@@ -17,7 +17,7 @@
 # sparse matrix can be passed to `fit() - supported
 
     Code
-      lm_fit <- fit(spec, avg_price_per_room ~ ., data = hotel_data)
+      xgb_fit <- fit(spec, avg_price_per_room ~ ., data = hotel_data)
     Condition
       Error in `.convert_form_to_xy_fit()`:
       ! Sparse data cannot be used with formula interface. Please use `fit_xy()` instead.
@@ -65,7 +65,7 @@
 # sparse data work with xgboost engine
 
     Code
-      tree_fit <- fit(spec, avg_price_per_room ~ ., data = hotel_data)
+      xgb_fit <- fit(spec, avg_price_per_room ~ ., data = hotel_data)
     Condition
       Error in `.convert_form_to_xy_fit()`:
       ! Sparse data cannot be used with formula interface. Please use `fit_xy()` instead.

--- a/tests/testthat/_snaps/sparsevctrs.md
+++ b/tests/testthat/_snaps/sparsevctrs.md
@@ -1,12 +1,28 @@
 # sparse tibble can be passed to `fit()
 
     Code
+      lm_fit <- fit(spec, avg_price_per_room ~ ., data = hotel_data)
+    Condition
+      Error in `.convert_form_to_xy_fit()`:
+      ! Sparse data cannot be used with formula interface. Please use `fit_xy()` instead.
+
+---
+
+    Code
       lm_fit <- fit(spec, avg_price_per_room ~ ., data = hotel_data[1:100, ])
     Condition
       Warning:
       `data` is a sparse tibble, but `linear_reg()` with engine "lm" doesn't accept that. Converting to non-sparse.
 
 # sparse matrix can be passed to `fit()
+
+    Code
+      lm_fit <- fit(spec, avg_price_per_room ~ ., data = hotel_data)
+    Condition
+      Error in `.convert_form_to_xy_fit()`:
+      ! Sparse data cannot be used with formula interface. Please use `fit_xy()` instead.
+
+---
 
     Code
       lm_fit <- fit(spec, avg_price_per_room ~ ., data = hotel_data[1:100, ])
@@ -45,6 +61,14 @@
     Condition
       Error in `predict()`:
       ! `x` is a sparse matrix, but `linear_reg()` with engine "lm" doesn't accept that.
+
+# sparse data work with xgboost engine
+
+    Code
+      tree_fit <- fit(spec, avg_price_per_room ~ ., data = hotel_data)
+    Condition
+      Error in `.convert_form_to_xy_fit()`:
+      ! Sparse data cannot be used with formula interface. Please use `fit_xy()` instead.
 
 # to_sparse_data_frame() is used correctly
 

--- a/tests/testthat/helper-objects.R
+++ b/tests/testthat/helper-objects.R
@@ -28,7 +28,7 @@ is_tf_ok <- function() {
 # ------------------------------------------------------------------------------
 # For sparse tibble testing
 
-sparse_hotel_rates <- function() {
+sparse_hotel_rates <- function(tibble = FALSE) {
   # 99.2 sparsity
   hotel_rates <- modeldata::hotel_rates
 
@@ -49,5 +49,15 @@ sparse_hotel_rates <- function() {
   )
 
   res <- as.matrix(res)
-  Matrix::Matrix(res, sparse = TRUE)
+  res <- Matrix::Matrix(res, sparse = TRUE)
+
+  if (tibble) {
+    res <- sparsevctrs::coerce_to_sparse_tibble(res)
+
+    # materialize outcome
+    withr::local_options("sparsevctrs.verbose_materialize" = NULL)
+    res$avg_price_per_room <- res$avg_price_per_room[]
+  }
+
+  res
 }

--- a/tests/testthat/test-sparsevctrs.R
+++ b/tests/testthat/test-sparsevctrs.R
@@ -1,4 +1,4 @@
-test_that("sparse tibble can be passed to `fit()", {
+test_that("sparse tibble can be passed to `fit() - supported", {
   skip_if_not_installed("xgboost")
   withr::local_options("sparsevctrs.verbose_materialize" = 3)
 
@@ -12,19 +12,21 @@ test_that("sparse tibble can be passed to `fit()", {
     error = TRUE,
     lm_fit <- fit(spec, avg_price_per_room ~ ., data = hotel_data)
   )
+})
+
+test_that("sparse tibble can be passed to `fit() - unsupported", {
+  hotel_data <- sparse_hotel_rates(tibble = TRUE)
 
   spec <- linear_reg() %>%
     set_mode("regression") %>%
     set_engine("lm")
-
-  withr::local_options("sparsevctrs.verbose_materialize" = NULL)
 
   expect_snapshot(
     lm_fit <- fit(spec, avg_price_per_room ~ ., data = hotel_data[1:100, ])
   )
 })
 
-test_that("sparse matrix can be passed to `fit()", {
+test_that("sparse matrix can be passed to `fit() - supported", {
   skip_if_not_installed("xgboost")
   withr::local_options("sparsevctrs.verbose_materialize" = 3)
   
@@ -39,7 +41,10 @@ test_that("sparse matrix can be passed to `fit()", {
     lm_fit <- fit(spec, avg_price_per_room ~ ., data = hotel_data)
   )
 
-  withr::local_options("sparsevctrs.verbose_materialize" = NULL)
+})
+
+test_that("sparse matrix can be passed to `fit() - unsupported", {
+  hotel_data <- sparse_hotel_rates()
 
   spec <- linear_reg() %>%
     set_mode("regression") %>%
@@ -50,12 +55,11 @@ test_that("sparse matrix can be passed to `fit()", {
   )
 })
 
-test_that("sparse tibble can be passed to `fit_xy()", {
+test_that("sparse tibble can be passed to `fit_xy() - supported", {
   skip_if_not_installed("xgboost")
+  withr::local_options("sparsevctrs.verbose_materialize" = 3)
   
   hotel_data <- sparse_hotel_rates(tibble = TRUE)
-  
-  withr::local_options("sparsevctrs.verbose_materialize" = 3)
 
   spec <- boost_tree() %>%
     set_mode("regression") %>%
@@ -64,8 +68,10 @@ test_that("sparse tibble can be passed to `fit_xy()", {
   expect_no_error(
     lm_fit <- fit_xy(spec, x = hotel_data[, -1], y = hotel_data[, 1])
   )
+})
 
-  withr::local_options("sparsevctrs.verbose_materialize" = NULL)
+test_that("sparse tibble can be passed to `fit_xy() - unsupported", {
+  hotel_data <- sparse_hotel_rates(tibble = TRUE)
 
   spec <- linear_reg() %>%
     set_mode("regression") %>%
@@ -76,7 +82,7 @@ test_that("sparse tibble can be passed to `fit_xy()", {
   )
 })
 
-test_that("sparse matrices can be passed to `fit_xy()", {
+test_that("sparse matrices can be passed to `fit_xy() - supported", {
   skip_if_not_installed("xgboost")
   withr::local_options("sparsevctrs.verbose_materialize" = 3)
 
@@ -89,6 +95,10 @@ test_that("sparse matrices can be passed to `fit_xy()", {
   expect_no_error(
     lm_fit <- fit_xy(spec, x = hotel_data[, -1], y = hotel_data[, 1])
   )
+})
+
+test_that("sparse matrices can be passed to `fit_xy() - unsupported", {
+  hotel_data <- sparse_hotel_rates()
 
   spec <- linear_reg() %>%
     set_mode("regression") %>%
@@ -100,12 +110,11 @@ test_that("sparse matrices can be passed to `fit_xy()", {
   )
 })
 
-test_that("sparse tibble can be passed to `predict()", {
+test_that("sparse tibble can be passed to `predict() - supported", {
   skip_if_not_installed("ranger")
+  withr::local_options("sparsevctrs.verbose_materialize" = 3)
 
   hotel_data <- sparse_hotel_rates(tibble = TRUE)
-  
-  withr::local_options("sparsevctrs.verbose_materialize" = 3)
 
   spec <- rand_forest(trees = 10) %>%
     set_mode("regression") %>%
@@ -116,8 +125,10 @@ test_that("sparse tibble can be passed to `predict()", {
   expect_no_error(
     predict(tree_fit, hotel_data)
   )
+})
 
-  withr::local_options("sparsevctrs.verbose_materialize" = NULL)
+test_that("sparse tibble can be passed to `predict() - unsupported", {
+  hotel_data <- sparse_hotel_rates(tibble = TRUE)
 
   spec <- linear_reg() %>%
     set_mode("regression") %>%
@@ -134,7 +145,7 @@ test_that("sparse tibble can be passed to `predict()", {
   )
 })
 
-test_that("sparse matrices can be passed to `predict()", {
+test_that("sparse matrices can be passed to `predict() - supported", {
   skip_if_not_installed("ranger")
   withr::local_options("sparsevctrs.verbose_materialize" = 3)
 
@@ -149,6 +160,10 @@ test_that("sparse matrices can be passed to `predict()", {
   expect_no_error(
     predict(tree_fit, hotel_data)
   )
+})
+
+test_that("sparse matrices can be passed to `predict() - unsupported", {
+  hotel_data <- sparse_hotel_rates()
 
   spec <- linear_reg() %>%
     set_mode("regression") %>%

--- a/tests/testthat/test-sparsevctrs.R
+++ b/tests/testthat/test-sparsevctrs.R
@@ -1,5 +1,7 @@
 test_that("sparse tibble can be passed to `fit() - supported", {
   skip_if_not_installed("xgboost")
+  # Make materialization of sparse vectors throw an error
+  # https://r-lib.github.io/sparsevctrs/dev/reference/sparsevctrs_options.html
   withr::local_options("sparsevctrs.verbose_materialize" = 3)
 
   hotel_data <- sparse_hotel_rates(tibble = TRUE)
@@ -28,6 +30,8 @@ test_that("sparse tibble can be passed to `fit() - unsupported", {
 
 test_that("sparse matrix can be passed to `fit() - supported", {
   skip_if_not_installed("xgboost")
+  # Make materialization of sparse vectors throw an error
+  # https://r-lib.github.io/sparsevctrs/dev/reference/sparsevctrs_options.html
   withr::local_options("sparsevctrs.verbose_materialize" = 3)
   
   hotel_data <- sparse_hotel_rates()
@@ -57,6 +61,8 @@ test_that("sparse matrix can be passed to `fit() - unsupported", {
 
 test_that("sparse tibble can be passed to `fit_xy() - supported", {
   skip_if_not_installed("xgboost")
+  # Make materialization of sparse vectors throw an error
+  # https://r-lib.github.io/sparsevctrs/dev/reference/sparsevctrs_options.html
   withr::local_options("sparsevctrs.verbose_materialize" = 3)
   
   hotel_data <- sparse_hotel_rates(tibble = TRUE)
@@ -84,6 +90,8 @@ test_that("sparse tibble can be passed to `fit_xy() - unsupported", {
 
 test_that("sparse matrices can be passed to `fit_xy() - supported", {
   skip_if_not_installed("xgboost")
+  # Make materialization of sparse vectors throw an error
+  # https://r-lib.github.io/sparsevctrs/dev/reference/sparsevctrs_options.html
   withr::local_options("sparsevctrs.verbose_materialize" = 3)
 
   hotel_data <- sparse_hotel_rates()
@@ -112,6 +120,8 @@ test_that("sparse matrices can be passed to `fit_xy() - unsupported", {
 
 test_that("sparse tibble can be passed to `predict() - supported", {
   skip_if_not_installed("ranger")
+  # Make materialization of sparse vectors throw an error
+  # https://r-lib.github.io/sparsevctrs/dev/reference/sparsevctrs_options.html
   withr::local_options("sparsevctrs.verbose_materialize" = 3)
 
   hotel_data <- sparse_hotel_rates(tibble = TRUE)
@@ -147,6 +157,8 @@ test_that("sparse tibble can be passed to `predict() - unsupported", {
 
 test_that("sparse matrices can be passed to `predict() - supported", {
   skip_if_not_installed("ranger")
+  # Make materialization of sparse vectors throw an error
+  # https://r-lib.github.io/sparsevctrs/dev/reference/sparsevctrs_options.html
   withr::local_options("sparsevctrs.verbose_materialize" = 3)
 
   hotel_data <- sparse_hotel_rates()
@@ -181,6 +193,8 @@ test_that("sparse matrices can be passed to `predict() - unsupported", {
 
 test_that("sparse data work with xgboost engine", {
   skip_if_not_installed("xgboost")
+  # Make materialization of sparse vectors throw an error
+  # https://r-lib.github.io/sparsevctrs/dev/reference/sparsevctrs_options.html
   withr::local_options("sparsevctrs.verbose_materialize" = 3)
 
   spec <- boost_tree() %>%
@@ -219,6 +233,8 @@ test_that("sparse data work with xgboost engine", {
 
 test_that("to_sparse_data_frame() is used correctly", {
   skip_if_not_installed("xgboost")
+  # Make materialization of sparse vectors throw an error
+  # https://r-lib.github.io/sparsevctrs/dev/reference/sparsevctrs_options.html
   withr::local_options("sparsevctrs.verbose_materialize" = 3)
   
   local_mocked_bindings(
@@ -260,6 +276,8 @@ test_that("to_sparse_data_frame() is used correctly", {
 
 test_that("maybe_sparse_matrix() is used correctly", {
   skip_if_not_installed("xgboost")
+  # Make materialization of sparse vectors throw an error
+  # https://r-lib.github.io/sparsevctrs/dev/reference/sparsevctrs_options.html
   withr::local_options("sparsevctrs.verbose_materialize" = 3)
   
   local_mocked_bindings(

--- a/tests/testthat/test-sparsevctrs.R
+++ b/tests/testthat/test-sparsevctrs.R
@@ -1,5 +1,6 @@
 test_that("sparse tibble can be passed to `fit()", {
   skip_if_not_installed("xgboost")
+  withr::local_options("sparsevctrs.verbose_materialize" = 3)
 
   hotel_data <- sparse_hotel_rates()
   hotel_data <- sparsevctrs::coerce_to_sparse_tibble(hotel_data)
@@ -7,14 +8,17 @@ test_that("sparse tibble can be passed to `fit()", {
   spec <- boost_tree() %>%
     set_mode("regression") %>%
     set_engine("xgboost")
-
-  expect_no_error(
+  
+  expect_snapshot(
+    error = TRUE,
     lm_fit <- fit(spec, avg_price_per_room ~ ., data = hotel_data)
   )
 
   spec <- linear_reg() %>%
     set_mode("regression") %>%
     set_engine("lm")
+
+  withr::local_options("sparsevctrs.verbose_materialize" = NULL)
 
   expect_snapshot(
     lm_fit <- fit(spec, avg_price_per_room ~ ., data = hotel_data[1:100, ])
@@ -23,16 +27,20 @@ test_that("sparse tibble can be passed to `fit()", {
 
 test_that("sparse matrix can be passed to `fit()", {
   skip_if_not_installed("xgboost")
-
+  withr::local_options("sparsevctrs.verbose_materialize" = 3)
+  
   hotel_data <- sparse_hotel_rates()
-
+  
   spec <- boost_tree() %>%
     set_mode("regression") %>%
     set_engine("xgboost")
 
-  expect_no_error(
+  expect_snapshot(
+    error = TRUE,
     lm_fit <- fit(spec, avg_price_per_room ~ ., data = hotel_data)
   )
+
+  withr::local_options("sparsevctrs.verbose_materialize" = NULL)
 
   spec <- linear_reg() %>%
     set_mode("regression") %>%
@@ -45,9 +53,14 @@ test_that("sparse matrix can be passed to `fit()", {
 
 test_that("sparse tibble can be passed to `fit_xy()", {
   skip_if_not_installed("xgboost")
-
+  
   hotel_data <- sparse_hotel_rates()
   hotel_data <- sparsevctrs::coerce_to_sparse_tibble(hotel_data)
+  
+  # materialize outcome
+  hotel_data$avg_price_per_room <- hotel_data$avg_price_per_room[]
+  
+  withr::local_options("sparsevctrs.verbose_materialize" = 3)
 
   spec <- boost_tree() %>%
     set_mode("regression") %>%
@@ -56,6 +69,8 @@ test_that("sparse tibble can be passed to `fit_xy()", {
   expect_no_error(
     lm_fit <- fit_xy(spec, x = hotel_data[, -1], y = hotel_data[, 1])
   )
+
+  withr::local_options("sparsevctrs.verbose_materialize" = NULL)
 
   spec <- linear_reg() %>%
     set_mode("regression") %>%
@@ -68,6 +83,7 @@ test_that("sparse tibble can be passed to `fit_xy()", {
 
 test_that("sparse matrices can be passed to `fit_xy()", {
   skip_if_not_installed("xgboost")
+  withr::local_options("sparsevctrs.verbose_materialize" = 3)
 
   hotel_data <- sparse_hotel_rates()
 
@@ -94,6 +110,11 @@ test_that("sparse tibble can be passed to `predict()", {
 
   hotel_data <- sparse_hotel_rates()
   hotel_data <- sparsevctrs::coerce_to_sparse_tibble(hotel_data)
+    
+  # materialize outcome
+  hotel_data$avg_price_per_room <- hotel_data$avg_price_per_room[]
+  
+  withr::local_options("sparsevctrs.verbose_materialize" = 3)
 
   spec <- rand_forest(trees = 10) %>%
     set_mode("regression") %>%
@@ -104,6 +125,8 @@ test_that("sparse tibble can be passed to `predict()", {
   expect_no_error(
     predict(tree_fit, hotel_data)
   )
+
+  withr::local_options("sparsevctrs.verbose_materialize" = NULL)
 
   spec <- linear_reg() %>%
     set_mode("regression") %>%
@@ -122,6 +145,7 @@ test_that("sparse tibble can be passed to `predict()", {
 
 test_that("sparse matrices can be passed to `predict()", {
   skip_if_not_installed("ranger")
+  withr::local_options("sparsevctrs.verbose_materialize" = 3)
 
   hotel_data <- sparse_hotel_rates()
 
@@ -151,6 +175,7 @@ test_that("sparse matrices can be passed to `predict()", {
 
 test_that("sparse data work with xgboost engine", {
   skip_if_not_installed("xgboost")
+  withr::local_options("sparsevctrs.verbose_materialize" = 3)
 
   spec <- boost_tree() %>%
     set_mode("regression") %>%
@@ -161,7 +186,7 @@ test_that("sparse data work with xgboost engine", {
   expect_no_error(
     tree_fit <- fit_xy(spec, x = hotel_data[, -1], y = hotel_data[, 1])
    )
- 
+   
    expect_no_error(
      predict(tree_fit, hotel_data)
    )
@@ -169,7 +194,8 @@ test_that("sparse data work with xgboost engine", {
   hotel_data <- sparsevctrs::coerce_to_sparse_tibble(hotel_data)
 
 
-  expect_no_error(
+  expect_snapshot(
+    error = TRUE,
     tree_fit <- fit(spec, avg_price_per_room ~ ., data = hotel_data)
   )
 
@@ -177,6 +203,11 @@ test_that("sparse data work with xgboost engine", {
     predict(tree_fit, hotel_data)
   )
   
+  # materialize outcome
+  withr::local_options("sparsevctrs.verbose_materialize" = NULL)
+  hotel_data$avg_price_per_room <- hotel_data$avg_price_per_room[]
+  withr::local_options("sparsevctrs.verbose_materialize" = 3)
+
   expect_no_error(
    tree_fit <- fit_xy(spec, x = hotel_data[, -1], y = hotel_data[, 1])
   )
@@ -188,6 +219,7 @@ test_that("sparse data work with xgboost engine", {
 
 test_that("to_sparse_data_frame() is used correctly", {
   skip_if_not_installed("xgboost")
+  withr::local_options("sparsevctrs.verbose_materialize" = 3)
   
   local_mocked_bindings(
     to_sparse_data_frame = function(x, object) {
@@ -228,6 +260,7 @@ test_that("to_sparse_data_frame() is used correctly", {
 
 test_that("maybe_sparse_matrix() is used correctly", {
   skip_if_not_installed("xgboost")
+  withr::local_options("sparsevctrs.verbose_materialize" = 3)
   
   local_mocked_bindings(
     maybe_sparse_matrix = function(x) {

--- a/tests/testthat/test-sparsevctrs.R
+++ b/tests/testthat/test-sparsevctrs.R
@@ -10,7 +10,7 @@ test_that("sparse tibble can be passed to `fit() - supported", {
   
   expect_snapshot(
     error = TRUE,
-    lm_fit <- fit(spec, avg_price_per_room ~ ., data = hotel_data)
+    xgb_fit <- fit(spec, avg_price_per_room ~ ., data = hotel_data)
   )
 })
 
@@ -38,7 +38,7 @@ test_that("sparse matrix can be passed to `fit() - supported", {
 
   expect_snapshot(
     error = TRUE,
-    lm_fit <- fit(spec, avg_price_per_room ~ ., data = hotel_data)
+    xgb_fit <- fit(spec, avg_price_per_room ~ ., data = hotel_data)
   )
 
 })
@@ -66,7 +66,7 @@ test_that("sparse tibble can be passed to `fit_xy() - supported", {
     set_engine("xgboost")
 
   expect_no_error(
-    lm_fit <- fit_xy(spec, x = hotel_data[, -1], y = hotel_data[, 1])
+    xgb_fit <- fit_xy(spec, x = hotel_data[, -1], y = hotel_data[, 1])
   )
 })
 
@@ -93,7 +93,7 @@ test_that("sparse matrices can be passed to `fit_xy() - supported", {
     set_engine("xgboost")
 
   expect_no_error(
-    lm_fit <- fit_xy(spec, x = hotel_data[, -1], y = hotel_data[, 1])
+    xgb_fit <- fit_xy(spec, x = hotel_data[, -1], y = hotel_data[, 1])
   )
 })
 
@@ -190,30 +190,30 @@ test_that("sparse data work with xgboost engine", {
   hotel_data <- sparse_hotel_rates()
 
   expect_no_error(
-    tree_fit <- fit_xy(spec, x = hotel_data[, -1], y = hotel_data[, 1])
+    xgb_fit <- fit_xy(spec, x = hotel_data[, -1], y = hotel_data[, 1])
    )
    
    expect_no_error(
-     predict(tree_fit, hotel_data)
+     predict(xgb_fit, hotel_data)
    )
 
   hotel_data <- sparse_hotel_rates(tibble = TRUE)
 
   expect_snapshot(
     error = TRUE,
-    tree_fit <- fit(spec, avg_price_per_room ~ ., data = hotel_data)
+    xgb_fit <- fit(spec, avg_price_per_room ~ ., data = hotel_data)
   )
 
   expect_no_error(
-    predict(tree_fit, hotel_data)
+    predict(xgb_fit, hotel_data)
   )
   
   expect_no_error(
-   tree_fit <- fit_xy(spec, x = hotel_data[, -1], y = hotel_data[, 1])
+    xgb_fit <- fit_xy(spec, x = hotel_data[, -1], y = hotel_data[, 1])
   )
 
   expect_no_error(
-    predict(tree_fit, hotel_data)
+    predict(xgb_fit, hotel_data)
   )
 })
 

--- a/tests/testthat/test-sparsevctrs.R
+++ b/tests/testthat/test-sparsevctrs.R
@@ -2,8 +2,7 @@ test_that("sparse tibble can be passed to `fit()", {
   skip_if_not_installed("xgboost")
   withr::local_options("sparsevctrs.verbose_materialize" = 3)
 
-  hotel_data <- sparse_hotel_rates()
-  hotel_data <- sparsevctrs::coerce_to_sparse_tibble(hotel_data)
+  hotel_data <- sparse_hotel_rates(tibble = TRUE)
 
   spec <- boost_tree() %>%
     set_mode("regression") %>%
@@ -54,11 +53,7 @@ test_that("sparse matrix can be passed to `fit()", {
 test_that("sparse tibble can be passed to `fit_xy()", {
   skip_if_not_installed("xgboost")
   
-  hotel_data <- sparse_hotel_rates()
-  hotel_data <- sparsevctrs::coerce_to_sparse_tibble(hotel_data)
-  
-  # materialize outcome
-  hotel_data$avg_price_per_room <- hotel_data$avg_price_per_room[]
+  hotel_data <- sparse_hotel_rates(tibble = TRUE)
   
   withr::local_options("sparsevctrs.verbose_materialize" = 3)
 
@@ -108,11 +103,7 @@ test_that("sparse matrices can be passed to `fit_xy()", {
 test_that("sparse tibble can be passed to `predict()", {
   skip_if_not_installed("ranger")
 
-  hotel_data <- sparse_hotel_rates()
-  hotel_data <- sparsevctrs::coerce_to_sparse_tibble(hotel_data)
-    
-  # materialize outcome
-  hotel_data$avg_price_per_room <- hotel_data$avg_price_per_room[]
+  hotel_data <- sparse_hotel_rates(tibble = TRUE)
   
   withr::local_options("sparsevctrs.verbose_materialize" = 3)
 
@@ -191,8 +182,7 @@ test_that("sparse data work with xgboost engine", {
      predict(tree_fit, hotel_data)
    )
 
-  hotel_data <- sparsevctrs::coerce_to_sparse_tibble(hotel_data)
-
+  hotel_data <- sparse_hotel_rates(tibble = TRUE)
 
   expect_snapshot(
     error = TRUE,
@@ -203,11 +193,6 @@ test_that("sparse data work with xgboost engine", {
     predict(tree_fit, hotel_data)
   )
   
-  # materialize outcome
-  withr::local_options("sparsevctrs.verbose_materialize" = NULL)
-  hotel_data$avg_price_per_room <- hotel_data$avg_price_per_room[]
-  withr::local_options("sparsevctrs.verbose_materialize" = 3)
-
   expect_no_error(
    tree_fit <- fit_xy(spec, x = hotel_data[, -1], y = hotel_data[, 1])
   )


### PR DESCRIPTION
All sparsvctrs tests now have option set such that unintentional materialization results in an error.

In addition, we now error on formula interface for sparse data, due to the `model.matrix()` issue we are running into