### PR TITLE
predict ordinal factors from ordinal regression models

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,8 @@
 
 ## Bug Fixes
 
+* Make sure that parsnip does not convert ordered factor predictions to be unordered.
+
 * Ensure that `knit_engine_docs()` has the required packages installed (#1156).
 
 * Fixed bug where some models fit using `fit_xy()` couldn't predict (#1166).

--- a/R/fit.R
+++ b/R/fit.R
@@ -87,6 +87,7 @@
 #' \itemize{
 #'   \item \code{lvl}: If the outcome is a factor, this contains
 #'    the factor levels at the time of model fitting.
+#'   \item \code{ordered}: If the outcome is a factor, was it an ordered factor?
 #'   \item \code{spec}: The model specification object
 #'    (\code{object} in the call to \code{fit})
 #'   \item \code{fit}: when the model is executed without error,

--- a/R/fit_helpers.R
+++ b/R/fit_helpers.R
@@ -40,7 +40,8 @@ form_form <-
     fit_call <- make_form_call(object, env = env)
 
     res <- list(
-      lvl = y_levels,
+      lvl = y_levels$lvl,
+      ordered = y_levels$ordered,
       spec = object
     )
 
@@ -98,7 +99,7 @@ xy_xy <- function(object,
 
   fit_call <- make_xy_call(object, target, env, call)
 
-  res <- list(lvl = levels(env$y), spec = object)
+  res <- list(lvl = levels(env$y), ordered = is.ordered(env$y), spec = object)
 
   time <- proc.time()
   res$fit <- eval_mod(

--- a/R/misc.R
+++ b/R/misc.R
@@ -260,9 +260,12 @@ convert_arg <- function(x) {
 
 levels_from_formula <- function(f, dat) {
   if (inherits(dat, "tbl_spark")) {
-    res <- NULL
+    res <- list(lvls = NULL, ordered = FALSE)
   } else {
-    res <- levels(eval_tidy(rlang::f_lhs(f), dat))
+    res <- list()
+    y_data <- eval_tidy(rlang::f_lhs(f), dat)
+    res$lvls <- levels(y_data)
+    res$ordered <- is.ordered(y_data)
   }
   res
 }

--- a/R/predict_class.R
+++ b/R/predict_class.R
@@ -41,14 +41,16 @@ predict_class.model_fit <- function(object, new_data, ...) {
 
   # coerce levels to those in `object`
   if (is.vector(res) || is.factor(res)) {
-    res <- factor(as.character(res), levels = object$lvl)
+    res <- factor(as.character(res), levels = object$lvl, ordered = object$ordered)
   } else {
     if (!inherits(res, "tbl_spark")) {
       # Now case where a parsnip model generated `res`
       if (is.data.frame(res) && ncol(res) == 1 && is.factor(res[[1]])) {
         res <- res[[1]]
       } else {
-        res$values <- factor(as.character(res$values), levels = object$lvl)
+        res$values <- factor(as.character(res$values),
+                             levels = object$lvl,
+                             ordered = object$ordered)
       }
     }
   }

--- a/man/fit.Rd
+++ b/man/fit.Rd
@@ -52,6 +52,7 @@ A \code{model_fit} object that contains several elements:
 \itemize{
 \item \code{lvl}: If the outcome is a factor, this contains
 the factor levels at the time of model fitting.
+\item \code{ordered}: If the outcome is a factor, was it an ordered factor?
 \item \code{spec}: The model specification object
 (\code{object} in the call to \code{fit})
 \item \code{fit}: when the model is executed without error,

--- a/tests/testthat/test-predict_formats.R
+++ b/tests/testthat/test-predict_formats.R
@@ -46,6 +46,7 @@ test_that('classification predictions', {
 
 test_that('ordinal classification predictions', {
   skip_if_not_installed("modeldata")
+  skip_if_not_installed("rpart")
 
   set.seed(382)
   dat_tr <-


### PR DESCRIPTION
Currently, we accidentally strip off the `ordered` element of factors when we make class predictions. 

Relevant to #953