### PR TITLE
fix likely typo 'linear_reg' in 'logistic_reg' documentation

### DIFF
--- a/man/rmd/logistic_reg_glm.Rmd
+++ b/man/rmd/logistic_reg_glm.Rmd
@@ -18,7 +18,7 @@ logistic_reg() %>%
 To use a non-default `family` and/or `link`, pass in as an argument to `set_engine()`:
 
 ```{r glm-reg-engine}
-linear_reg() %>% 
+logistic_reg() %>% 
   set_engine("glm", family = stats::binomial(link = "probit")) %>% 
   translate()
 ```


### PR DESCRIPTION
This example illustrates a non-default model family in an apparent wrong model type, which does not produce an error so would not have been caught during checks.

I apologize if the use of `linear_reg()` was intended, but in that case it should probably be explained.