### PR TITLE
add tanh to allowed act_funs

### DIFF
--- a/R/mlp.R
+++ b/R/mlp.R
@@ -192,8 +192,8 @@ keras_mlp <-
            seeds = sample.int(10^5, size = 3),
            ...) {
 
-    act_funs <- c("linear", "softmax", "relu", "elu")
-    rlang::arg_match(activation, act_funs,)
+    act_funs <- c("linear", "softmax", "relu", "elu", "tanh")
+    rlang::arg_match(activation, act_funs)
 
     if (penalty > 0 & dropout > 0) {
       cli::cli_abort("Please use either dropout or weight decay.", call = NULL)


### PR DESCRIPTION
to close #1228 

it seems fairly clear to me that the line was copied from https://github.com/tidymodels/parsnip/commit/525baee0b78c9fda37236b65d2d129256a194138#diff-cc3c0fc4a8fe94138bbf865fcad37457b96799008c3910abe158f2e187f7134bL149, but `tanh` is a valid input as well.

``` r
library(tidymodels)

model <- 
  mlp(activation = tune()) %>%
  set_engine("keras") %>%
  set_mode("classification")

set.seed(1)
res <- tune_grid(
  workflow(class ~ ., model),
  vfold_cv(sim_classification(1000)),
  grid = 3
)

res |>
  collect_metrics()
#> # A tibble: 9 × 7
#>   activation .metric     .estimator  mean     n std_err .config             
#>   <chr>      <chr>       <chr>      <dbl> <int>   <dbl> <chr>               
#> 1 relu       accuracy    binary     0.722    10 0.0137  Preprocessor1_Model1
#> 2 relu       brier_class binary     0.184    10 0.00557 Preprocessor1_Model1
#> 3 relu       roc_auc     binary     0.803    10 0.00916 Preprocessor1_Model1
#> 4 tanh       accuracy    binary     0.745    10 0.0139  Preprocessor1_Model2
#> 5 tanh       brier_class binary     0.169    10 0.00733 Preprocessor1_Model2
#> 6 tanh       roc_auc     binary     0.832    10 0.0177  Preprocessor1_Model2
#> 7 softmax    accuracy    binary     0.736    10 0.0142  Preprocessor1_Model3
#> 8 softmax    brier_class binary     0.194    10 0.00731 Preprocessor1_Model3
#> 9 softmax    roc_auc     binary     0.793    10 0.0309  Preprocessor1_Model3
```
