### PR TITLE
fix abort call and add test for wrong activation

### DIFF
--- a/R/mlp.R
+++ b/R/mlp.R
@@ -196,7 +196,8 @@ keras_mlp <-
     good_activation <- activation %in% allowed_keras_activation
     if (!all(good_activation)) {
       cli::cli_abort(
-        "{.arg activation} should be one of: {allowed_activation}."
+        "{.arg activation} should be one of: {allowed_keras_activation}, not 
+        {.val {activation}}."
       )
     }
 

--- a/tests/testthat/test-mlp_keras.R
+++ b/tests/testthat/test-mlp_keras.R
@@ -275,4 +275,11 @@ test_that('all keras activation functions', {
     keras::backend()$clear_session()
   }
 
+  expect_snapshot(
+    error = TRUE,
+    mlp(mode = "classification", hidden_units = 2, penalty = 0.01, epochs = 2,
+          activation = "invalid")  %>%
+      set_engine("keras", verbose = 0) %>%
+      parsnip::fit(Class ~ A + B, data = modeldata::two_class_dat)
+  )
 })


### PR DESCRIPTION
i was a little too fast in https://github.com/tidymodels/parsnip/pull/1244, this PR fixes the mistake and adds a test