### PR TITLE
toggle mlp activation by engine

### DIFF
--- a/R/mlp.R
+++ b/R/mlp.R
@@ -200,6 +200,7 @@ keras_mlp <-
         {.val {activation}}."
       )
     }
+    activation <- get_activation_fn(activation)
 
     if (penalty > 0 & dropout > 0) {
       cli::cli_abort("Please use either dropout or weight decay.", call = NULL)
@@ -351,7 +352,7 @@ mlp_num_weights <- function(p, hidden_units, classes) {
 }
 
 allowed_keras_activation <-
- c("elu", "exponential", "gelu", "hard_sigmoid", "linear", "relu", "selu", 
+ c("elu", "exponential", "gelu", "hardsigmoid", "linear", "relu", "selu", 
    "sigmoid", "softmax", "softplus", "softsign", "swish", "tanh")
 
 #' Activation functions for neural networks in keras
@@ -361,6 +362,13 @@ allowed_keras_activation <-
 #' @export
 keras_activations <- function() {
   allowed_keras_activation
+}
+
+get_activation_fn <- function(arg, ...) {
+  if (arg == "hardsigmoid") {
+    arg <- "hard_sigmoid"
+  }
+  arg
 }
 
 ## -----------------------------------------------------------------------------

--- a/R/tunable.R
+++ b/R/tunable.R
@@ -355,9 +355,18 @@ tunable.mlp <- function(x, ...) {
       list(list(pkg = "dials", fun = "learn_rate", range = c(-3, -1/2)))
     res$call_info[res$name == "epochs"] <-
       list(list(pkg = "dials", fun = "epochs", range = c(5L, 500L)))
+    activation_values <- rlang::eval_tidy(
+      rlang::call2("brulee_activations", .ns = "brulee")
+    )
+    res$call_info[res$name == "activation"] <- 
+      list(list(pkg = "dials", fun = "activation", values = activation_values))
+  } else if (x$engine == "keras") {
+    activation_values <- parsnip::keras_activations()
+    res$call_info[res$name == "activation"] <- 
+      list(list(pkg = "dials", fun = "activation", values = activation_values))
   }
   res
-}
+  }
 
 #' @export
 tunable.survival_reg <- function(x, ...) {

--- a/tests/testthat/_snaps/mlp_keras.md
+++ b/tests/testthat/_snaps/mlp_keras.md
@@ -6,3 +6,13 @@
       Error:
       ! object 'novar' not found
 
+# all keras activation functions
+
+    Code
+      mlp(mode = "classification", hidden_units = 2, penalty = 0.01, epochs = 2,
+        activation = "invalid") %>% set_engine("keras", verbose = 0) %>% parsnip::fit(
+        Class ~ A + B, data = modeldata::two_class_dat)
+    Condition
+      Error in `parsnip::keras_mlp()`:
+      ! `activation` should be one of: elu, exponential, gelu, hardsigmoid, linear, relu, selu, sigmoid, softmax, softplus, softsign, swish, and tanh, not "invalid".
+

--- a/tests/testthat/test-tunable.R
+++ b/tests/testthat/test-tunable.R
@@ -1,4 +1,5 @@
 test_that('brulee has mixture object', {
+  skip_if_not_installed("brulee")
   # for issue 1236
   mlp_spec <-
     mlp(


### PR DESCRIPTION
```r
library(tidymodels)

model <- 
  mlp(activation = tune()) %>%
  set_engine("keras") %>%
  set_mode("classification")

set.seed(1)
res <- tune_grid(
  workflow(class ~ ., model),
  vfold_cv(sim_classification(1000), v = 2),
  grid = 10
)

res |>
  collect_metrics() |>
  count(activation)
#> # A tibble: 10 × 2
#>    activation       n
#>    <chr>        <int>
#>  1 elu              3
#>  2 exponential      3
#>  3 hard_sigmoid     3
#>  4 linear           3
#>  5 selu             3
#>  6 sigmoid          3
#>  7 softmax          3
#>  8 softplus         3
#>  9 swish            3
#> 10 tanh             3

model <- 
  mlp(activation = tune()) %>%
  set_engine("brulee") %>%
  set_mode("classification")

set.seed(1)
res <- tune_grid(
  workflow(class ~ ., model),
  vfold_cv(sim_classification(1000), v = 2),
  grid = 10
)
#> → A | warning: Current loss in NaN. Training wil be stopped.
#> There were issues with some computations   A: x1
#> There were issues with some computations   A: x2
#> There were issues with some computations   A: x2
#> 

res |>
  collect_metrics() |>
  count(activation)
#> # A tibble: 10 × 2
#>    activation      n
#>    <chr>       <int>
#>  1 elu             3
#>  2 hardshrink      3
#>  3 hardtanh        3
#>  4 leaky_relu      3
#>  5 log_sigmoid     3
#>  6 relu6           3
#>  7 selu            3
#>  8 softplus        3
#>  9 softsign        3
#> 10 tanhshrink      3
```