### PR TITLE
Quiet linear svm models

### DIFF
--- a/R/svm_linear_data.R
+++ b/R/svm_linear_data.R
@@ -172,7 +172,7 @@ set_fit(
     data = c(formula = "x", data = "data"),
     protect = c("x", "data"),
     func = c(pkg = "kernlab", fun = "ksvm"),
-    defaults = list(kernel = "vanilladot")
+    defaults = list(kernel = "vanilladot", kpar = list())
   )
 )
 
@@ -185,7 +185,7 @@ set_fit(
     data = c(formula = "x", data = "data"),
     protect = c("x", "data"),
     func = c(pkg = "kernlab", fun = "ksvm"),
-    defaults = list(kernel = "vanilladot")
+    defaults = list(kernel = "vanilladot", kpar = list())
   )
 )
 

--- a/tests/testthat/_snaps/translate.md
+++ b/tests/testthat/_snaps/translate.md
@@ -1966,6 +1966,9 @@
       $kernel
       [1] "vanilladot"
       
+      $kpar
+      list()
+      
 
 ---
 
@@ -1985,6 +1988,9 @@
       
       $kernel
       [1] "vanilladot"
+      
+      $kpar
+      list()
       
 
 # arguments (svm_poly)


### PR DESCRIPTION
Related to tidymodels/tune#1039

Linear SVMs _have no kernel parameters_ but loudly complain that none were specified. Adding `kpar = list()` appears to shush it.


## Before

``` r
library(parsnip)
library(modeldata)
#> 
#> Attaching package: 'modeldata'
#> The following object is masked from 'package:datasets':
#> 
#>     penguins

res <- 
  svm_linear(mode = "classification", engine = "kernlab") |> 
  fit(Class ~ ., data = two_class_dat)
#>  Setting default kernel parameters
```

<sup>Created on 2025-07-15 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

## After

``` r
library(parsnip)
library(modeldata)
#> 
#> Attaching package: 'modeldata'
#> The following object is masked from 'package:datasets':
#> 
#>     penguins

res <- 
  svm_linear(mode = "classification", engine = "kernlab") |> 
  fit(Class ~ ., data = two_class_dat)
```

<sup>Created on 2025-07-15 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>