### PR TITLE
Error in parsnip tunable information for brulee

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # parsnip (development version)
 
+* Bug fix in how tunable parameters were configured for brulee neural networks. 
+
 # parsnip 1.3.2
 
 * Switch to base R pipe

--- a/R/tunable.R
+++ b/R/tunable.R
@@ -228,8 +228,8 @@ brulee_mlp_args <-
       list(pkg = "dials", fun = "learn_rate", range = c(-3, -1/5)),
       list(pkg = "dials", fun = "momentum", range = c(0.50, 0.95)),
       list(pkg = "dials", fun = "batch_size"),
-      list(pkg = "dials", fun = "stop_iter"),
       list(pkg = "dials", fun = "class_weights"),
+      list(pkg = "dials", fun = "stop_iter"),
       list(pkg = "dials", fun = "rate_schedule", values = tune_sched)
     )
   ) |>

--- a/man/details_boost_tree_lightgbm.Rd
+++ b/man/details_boost_tree_lightgbm.Rd
@@ -175,7 +175,7 @@ that the booster will perform bagging at every \code{k}th boosting iteration.
 Thus, by default, the \code{sample_size} argument would be ignored without
 setting this argument manually. Other boosting libraries, like xgboost,
 do not have an analogous argument to \code{bagging_freq} and use \code{k = 1} when
-the analogue to \code{bagging_fraction} is in $(0, 1)$. \emph{bonsai will thus
+the analogue to \code{bagging_fraction} is in $\verb{(0, 1)}$. \emph{bonsai will thus
 automatically set} \code{bagging_freq = 1} \emph{in} \code{set_engine("lightgbm", ...)}
 if \code{sample_size} (i.e. \code{bagging_fraction}) is not equal to 1 and no
 \code{bagging_freq} value is supplied. This default can be overridden by


### PR DESCRIPTION
`brulee_mlp_args` had switched the dials info for `stop_iter()` and `class_weights()`. 