### PR TITLE
add early exits in `.model_param_name_key()`

### DIFF
--- a/R/extract.R
+++ b/R/extract.R
@@ -92,6 +92,17 @@ extract_parameter_set_dials.model_spec <- function(x, ...) {
   all_args <- generics::tunable(x)
   tuning_param <- generics::tune_args(x)
 
+  if (nrow(all_args) == 0 || nrow(tuning_param) == 0) {
+    res <- tibble::new_tibble(list(
+      name = character(0),
+      id = character(0),
+      source = character(0),
+      component = character(0),
+      call_info = list(),
+      component_id = character(0),
+      object = list()
+    ))
+  } else {
   res <-
     dplyr::inner_join(
       tuning_param |> dplyr::select(-tunable, -component_id),
@@ -100,6 +111,7 @@ extract_parameter_set_dials.model_spec <- function(x, ...) {
     ) |>
     mutate(object = purrr::map(call_info, eval_call_info))
 
+  }
   dials::parameters_constr(
     res$name,
     res$id,

--- a/R/translate.R
+++ b/R/translate.R
@@ -206,6 +206,14 @@ add_methods <- function(x, engine) {
 
   # To translate from given names/ids in grid to parsnip names:
   params <- object |> hardhat::extract_parameter_set_dials()
+  if (nrow(params) == 0) {
+    res <- tibble::new_tibble(list(
+      user = character(0),
+      parsnip = character(0),
+      engine = character(0)
+    ))
+    return(res)
+  }
   params <- tibble::as_tibble(params) |>
     dplyr::select(user = id, parsnip = name)
   # Go from parsnip names to engine names


### PR DESCRIPTION
Follow up on https://github.com/tidymodels/tune/pull/1071.

If there isn't any tuning parameters set in a workflow, we can early exit, which for the following example leads to an almost 20% speed increase

After 

``` r
library(tidymodels)
ames <- ames |>
  select(where(is.numeric))

svm_spec <- null_model(mode = "regression")

set.seed(1)
cv1 <- rsample::bootstraps(ames)

set.seed(1)

bench::mark(
  run = fit_resamples(
    svm_spec,
    Sale_Price ~ .,
    cv1, metrics = metric_set(yardstick::rmse),
    control = control_grid(save_pred = TRUE)
  ), iterations = 10
)
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 run           378ms    388ms      2.41     162MB     10.4
```

<sup>Created on 2025-08-01 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>