### PR TITLE
add missing values handling templates for model documentation

### DIFF
--- a/man-roxygen/na_casewise_delete.R
+++ b/man-roxygen/na_casewise_delete.R
@@ -1,0 +1,2 @@
+#' @section Missing Values:
+#' This model silently removes rows with missing values (case-wise deletion) before fitting.

--- a/man-roxygen/na_errors.R
+++ b/man-roxygen/na_errors.R
@@ -1,0 +1,2 @@
+#' @section Missing Values:
+#' This model fails with an error if any rows contain missing values. Missing values should be handled before fitting.

--- a/man-roxygen/na_handled.R
+++ b/man-roxygen/na_handled.R
@@ -1,0 +1,2 @@
+#' @section Missing Values:
+#' This model natively handles missing values during training.


### PR DESCRIPTION
Add roxygen2 templates to document how models handle missing values #812 

This commit create three files under man-roxygen/ that describe
how different model engines handle missing values:

- na_casewise_delete.R: for models that silently drop rows with NAs
- na_handled.R: for models that natively support NAs (e.g., rpart)
- naerrors.R: for models that fail when NAs are present

These templates can be added to individual model documentation.