### PR TITLE
Added "Predict type" section to each model type documentation.

### DIFF
--- a/man/rmd/.gitignore
+++ b/man/rmd/.gitignore
@@ -1,0 +1,2 @@
+/.quarto/
+**/*.quarto_ipynb

--- a/man/rmd/C5_rules_C5.0.Rmd
+++ b/man/rmd/C5_rules_C5.0.Rmd
@@ -60,6 +60,16 @@ C5_rules(
 #| child: template-uses-case-weights.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("C5_rules_predict") |>
+  dplyr::select(mode, type)
+
+```
+
 ## Saving fitted model objects
 
 ```{r}

--- a/man/rmd/auto_ml_h2o.Rmd
+++ b/man/rmd/auto_ml_h2o.Rmd
@@ -23,9 +23,12 @@ Engine arguments of interest
 
 ```{r}
 #| label: h2o-reg
-auto_ml() |>  
-  set_engine("h2o") |> 
-  set_mode("regression") |> 
+
+library(agua)
+
+auto_ml() |>
+  set_engine("h2o") |>
+  set_mode("regression") |>
   translate()
 ```
 
@@ -50,6 +53,16 @@ auto_ml() |>
 
 ```{r}
 #| child: template-h2o-init.Rmd
+```
+
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("auto_ml_predict") |>
+  dplyr::select(mode, type)
+
 ```
 
 ## Saving fitted model objects

--- a/man/rmd/bag_mars_earth.Rmd
+++ b/man/rmd/bag_mars_earth.Rmd
@@ -75,6 +75,16 @@ bag_mars(
 
 Note that the `earth` package documentation has: "In the current implementation, _building models with weights can be slow_."
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("bag_mars_predict") |>
+  dplyr::select(mode, type)
+
+```
+
 ## References
 
  - Breiman, L. 1996. "Bagging predictors". Machine Learning. 24 (2): 123-140

--- a/man/rmd/bag_mlp_nnet.Rmd
+++ b/man/rmd/bag_mlp_nnet.Rmd
@@ -78,6 +78,16 @@ bag_mlp(penalty = double(1), hidden_units = integer(1)) |>
 #| child: template-no-case-weights.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("bag_mlp_predict") |>
+  dplyr::select(mode, type)
+
+```
+
 
 ## References
 

--- a/man/rmd/bag_tree_C5.0.Rmd
+++ b/man/rmd/bag_tree_C5.0.Rmd
@@ -56,6 +56,16 @@ bag_tree(min_n = integer()) |>
 #| child: template-uses-case-weights.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("bag_mars_predict") |>
+  dplyr::filter(engine == "C5.0") |>
+  dplyr::select(mode, type)
+
+```
 
 ## References
 

--- a/man/rmd/bag_tree_rpart.Rmd
+++ b/man/rmd/bag_tree_rpart.Rmd
@@ -89,6 +89,17 @@ bag_tree(tree_depth = integer(1), min_n = integer(1), cost_complexity = double(1
 #| child: template-uses-case-weights.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("bag_mars_predict") |>
+  dplyr::filter(engine == "rpart") |>
+  dplyr::select(mode, type)
+
+```
+
 ## Other details
 
 ```{r}

--- a/man/rmd/bart_dbarts.Rmd
+++ b/man/rmd/bart_dbarts.Rmd
@@ -93,6 +93,15 @@ parsnip::bart(
 
 [dbarts::bart()] will also convert the factors to indicators if the user does not create them first. 
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("bart_predict") |>
+  dplyr::select(mode, type)
+
+```
 
 ## References
 

--- a/man/rmd/boost_tree_C5.0.Rmd
+++ b/man/rmd/boost_tree_C5.0.Rmd
@@ -56,6 +56,17 @@ boost_tree(trees = integer(), min_n = integer(), sample_size = numeric()) |>
 #| child: template-uses-case-weights.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("boost_tree_predict") |>
+  dplyr::filter(engine == "C5.0") |>
+  dplyr::select(mode, type)
+
+```
+
 ## Saving fitted model objects
 
 ```{r}

--- a/man/rmd/boost_tree_h2o.Rmd
+++ b/man/rmd/boost_tree_h2o.Rmd
@@ -82,6 +82,17 @@ Non-numeric predictors (i.e., factors) are internally converted to numeric. In t
 #| child: template-mtry-prop.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("boost_tree_predict") |>
+  dplyr::filter(stringr::(str_starts(engine, "h2o"))) |>
+  dplyr::select(mode, type)
+
+```
+
 ## Initializing h2o 
 
 ```{r}

--- a/man/rmd/boost_tree_lightgbm.Rmd
+++ b/man/rmd/boost_tree_lightgbm.Rmd
@@ -85,6 +85,17 @@ Non-numeric predictors (i.e., factors) are internally converted to numeric. In t
 #| child: template-mtry-prop.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("boost_tree_predict") |>
+  dplyr::filter(engine == "lightgbm") |>
+  dplyr::select(mode, type)
+
+```
+
 ### Bagging
 
 The `sample_size` argument is translated to the `bagging_fraction` parameter in the `param` argument of `lgb.train`. The argument is interpreted by lightgbm as a _proportion_ rather than a count, so bonsai internally reparameterizes the `sample_size` argument with [dials::sample_prop()] during tuning. 

--- a/man/rmd/boost_tree_mboost.Rmd
+++ b/man/rmd/boost_tree_mboost.Rmd
@@ -54,6 +54,17 @@ boost_tree() |>
 #| child: template-tree-split-factors.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("boost_tree_predict") |>
+  dplyr::filter(engine == "mboost") |>
+  dplyr::select(mode, type)
+
+```
+
 ## Other details
 
 ```{r}

--- a/man/rmd/boost_tree_spark.Rmd
+++ b/man/rmd/boost_tree_spark.Rmd
@@ -73,6 +73,17 @@ boost_tree(
 
 Note that, for spark engines, the `case_weight` argument value should be a character string to specify the column with the numeric case weights. 
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("boost_tree_predict") |>
+  dplyr::filter(engine == "spark") |>
+  dplyr::select(mode, type)
+
+```
+
 ## Other details
 
 ```{r}

--- a/man/rmd/boost_tree_xgboost.Rmd
+++ b/man/rmd/boost_tree_xgboost.Rmd
@@ -75,6 +75,17 @@ For classification, non-numeric outcomes (i.e., factors) are internally converte
 #| child: template-uses-case-weights.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("boost_tree_predict") |>
+  dplyr::filter(engine == "xgboost") |>
+  dplyr::select(mode, type)
+
+```
+
 ## Sparse Data
 
 ```{r}

--- a/man/rmd/cubist_rules_Cubist.Rmd
+++ b/man/rmd/cubist_rules_Cubist.Rmd
@@ -54,6 +54,16 @@ cubist_rules(
 #| child: template-tree-split-factors.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("cubist_rules_predict") |>
+  dplyr::select(mode, type)
+
+```
+
 ## References
 
  - Quinlan R (1992). "Learning with Continuous Classes." Proceedings of the 5th Australian Joint Conference On Artificial Intelligence, pp. 343-348.

--- a/man/rmd/decision_tree_C5.0.Rmd
+++ b/man/rmd/decision_tree_C5.0.Rmd
@@ -54,6 +54,17 @@ decision_tree(min_n = integer()) |>
 #| child: template-uses-case-weights.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("decision_tree_predict") |>
+  dplyr::filter(engine == "C5.0") |>
+  dplyr::select(mode, type)
+
+```
+
 ## Saving fitted model objects
 
 ```{r}

--- a/man/rmd/decision_tree_partykit.Rmd
+++ b/man/rmd/decision_tree_partykit.Rmd
@@ -89,6 +89,17 @@ decision_tree(tree_depth = integer(1), min_n = integer(1)) |>
 #| child: template-tree-split-factors.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("decision_tree_predict") |>
+  dplyr::filter(engine == "partykit") |>
+  dplyr::select(mode, type)
+
+```
+
 ## Other details
 
 ```{r}

--- a/man/rmd/decision_tree_rpart.Rmd
+++ b/man/rmd/decision_tree_rpart.Rmd
@@ -82,6 +82,17 @@ decision_tree(
 #| child: template-uses-case-weights.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("decision_tree_predict") |>
+  dplyr::filter(engine == "rpart") |>
+  dplyr::select(mode, type)
+
+```
+
 ## Other details
 
 ```{r}

--- a/man/rmd/decision_tree_spark.Rmd
+++ b/man/rmd/decision_tree_spark.Rmd
@@ -65,6 +65,17 @@ decision_tree(tree_depth = integer(1), min_n = integer(1)) |>
 
 Note that, for spark engines, the `case_weight` argument value should be a character string to specify the column with the numeric case weights. 
 
+
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("decision_tree_predict") |>
+  dplyr::filter(engine == "spark") |>
+  dplyr::select(mode, type)
+
+```
 ## Other details
 
 ```{r}

--- a/man/rmd/discrim_flexible_earth.Rmd
+++ b/man/rmd/discrim_flexible_earth.Rmd
@@ -59,6 +59,16 @@ discrim_flexible(
 #| child: template-uses-case-weights.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("discrim_flexible_predict") |>
+  dplyr::select(mode, type)
+
+```
+
 ## References
 
  - Hastie, Tibshirani & Buja (1994) Flexible Discriminant Analysis by Optimal 

--- a/man/rmd/discrim_linear_MASS.Rmd
+++ b/man/rmd/discrim_linear_MASS.Rmd
@@ -38,6 +38,17 @@ discrim_linear() |>
 #| child: template-no-case-weights.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("discrim_linear_predict") |>
+  dplyr::filter(engine == "MASS") |>
+  dplyr::select(mode, type)
+
+```
+
 ## References
 
  - Kuhn, M, and K Johnson. 2013. _Applied Predictive Modeling_. Springer.

--- a/man/rmd/discrim_linear_mda.Rmd
+++ b/man/rmd/discrim_linear_mda.Rmd
@@ -59,6 +59,17 @@ discrim_linear(penalty = numeric(0)) |>
 #| child: template-uses-case-weights.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("discrim_linear_predict") |>
+  dplyr::filter(engine == "mda") |>
+  dplyr::select(mode, type)
+
+```
+
 ## References
 
  - Hastie, Tibshirani & Buja (1994) Flexible Discriminant Analysis by Optimal 

--- a/man/rmd/discrim_linear_sda.Rmd
+++ b/man/rmd/discrim_linear_sda.Rmd
@@ -48,6 +48,17 @@ discrim_linear() |>
 #| child: template-no-case-weights.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("discrim_linear_predict") |>
+  dplyr::filter(engine == "sda") |>
+  dplyr::select(mode, type)
+
+```
+
 ## References
 
  - Ahdesmaki, A., and K. Strimmer. 2010. Feature selection in omics prediction problems using cat scores and false non-discovery rate control. Ann. Appl. Stat. 4: 503-519. [Preprint](https://arxiv.org/abs/0903.2003).

--- a/man/rmd/discrim_linear_sparsediscrim.Rmd
+++ b/man/rmd/discrim_linear_sparsediscrim.Rmd
@@ -65,6 +65,17 @@ discrim_linear(regularization_method = character(0)) |>
 #| child: template-no-case-weights.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("discrim_linear_predict") |>
+  dplyr::filter(engine == "sparsediscrim") |>
+  dplyr::select(mode, type)
+
+```
+
 ## References
 
 

--- a/man/rmd/discrim_quad_MASS.Rmd
+++ b/man/rmd/discrim_quad_MASS.Rmd
@@ -38,6 +38,17 @@ discrim_quad() |>
 #| child: template-no-case-weights.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("discrim_quad_predict") |>
+  dplyr::filter(engine == "MASS") |>
+  dplyr::select(mode, type)
+
+```
+
 ## References
 
  - Kuhn, M, and K Johnson. 2013. _Applied Predictive Modeling_. Springer.

--- a/man/rmd/discrim_quad_sparsediscrim.Rmd
+++ b/man/rmd/discrim_quad_sparsediscrim.Rmd
@@ -64,6 +64,17 @@ discrim_quad(regularization_method = character(0)) |>
 #| child: template-no-case-weights.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("discrim_quad_predict") |>
+  dplyr::filter(engine == "sparsediscrim") |>
+  dplyr::select(mode, type)
+
+```
+
 ## References
 
  - `qda_diag()`: Dudoit, Fridlyand and Speed (2002) Comparison of Discrimination Methods for the Classification of Tumors Using Gene Expression Data, _Journal of the American Statistical Association_, 97:457, 77-87. 

--- a/man/rmd/discrim_regularized_klaR.Rmd
+++ b/man/rmd/discrim_regularized_klaR.Rmd
@@ -67,6 +67,16 @@ discrim_regularized(frac_identity = numeric(0), frac_common_cov = numeric(0)) |>
 #| child: template-no-case-weights.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("discrim_regularized_predict") |>
+  dplyr::select(mode, type)
+
+```
+
 ## References
 
  - Friedman, J (1989). Regularized Discriminant Analysis. _Journal of the American Statistical Association_, 84, 165-175.

--- a/man/rmd/gen_additive_mod_mgcv.Rmd
+++ b/man/rmd/gen_additive_mod_mgcv.Rmd
@@ -99,6 +99,16 @@ To learn more about the differences between these formulas, see [`?model_formula
 #| child: template-uses-case-weights.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("gen_additive_mod_predict") |>
+  dplyr::select(mode, type)
+
+```
+
 ## Saving fitted model objects
 
 ```{r}

--- a/man/rmd/linear_reg_brulee.Rmd
+++ b/man/rmd/linear_reg_brulee.Rmd
@@ -67,6 +67,17 @@ linear_reg(penalty = double(1)) |>
 #| child: template-no-case-weights.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("linear_reg_predict") |>
+  dplyr::filter(engine == "brulee") |>
+  dplyr::select(mode, type)
+
+```
+
 ## References
 
  - Kuhn, M, and K Johnson. 2013. _Applied Predictive Modeling_. Springer.

--- a/man/rmd/linear_reg_gee.Rmd
+++ b/man/rmd/linear_reg_gee.Rmd
@@ -79,6 +79,17 @@ Also, because of issues with the `gee()` function, a supplementary call to `glm(
 #| child: template-no-case-weights.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("linear_reg_predict") |>
+  dplyr::filter(engine == "gee") |>
+  dplyr::select(mode, type)
+
+```
+
 ## References
 
  - Liang, K.Y. and Zeger, S.L. (1986) Longitudinal data analysis using generalized linear models. _Biometrika_, 73 13–22.

--- a/man/rmd/linear_reg_glm.Rmd
+++ b/man/rmd/linear_reg_glm.Rmd
@@ -41,6 +41,17 @@ linear_reg() |>
 
 _However_, the documentation in [stats::glm()] assumes that is specific type of case weights are being used:"Non-NULL weights can be used to indicate that different observations have different dispersions (with the values in weights being inversely proportional to the dispersions); or equivalently, when the elements of weights are positive integers `w_i`, that each response `y_i` is the mean of `w_i` unit-weight observations. For a binomial GLM prior weights are used to give the number of trials when the response is the proportion of successes: they would rarely be used for a Poisson GLM."
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("linear_reg_predict") |>
+  dplyr::filter(engine == "glm") |>
+  dplyr::select(mode, type)
+
+```
+
 ## Saving fitted model objects
 
 ```{r}

--- a/man/rmd/linear_reg_glmer.Rmd
+++ b/man/rmd/linear_reg_glmer.Rmd
@@ -78,6 +78,17 @@ fit(glmer_wflow, data = riesby)
 #| child: template-uses-case-weights.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("linear_reg_predict") |>
+  dplyr::filter(engine == "glmer") |>
+  dplyr::select(mode, type)
+
+```
+
 ## References
 
  - 	J Pinheiro, and D Bates. 2000. _Mixed-effects models in S and S-PLUS_. Springer, New York, NY

--- a/man/rmd/linear_reg_glmnet.Rmd
+++ b/man/rmd/linear_reg_glmnet.Rmd
@@ -59,6 +59,17 @@ By default, [glmnet::glmnet()] uses the argument `standardize = TRUE` to center 
 #| child: template-uses-case-weights.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("linear_reg_predict") |>
+  dplyr::filter(engine == "glmnet") |>
+  dplyr::select(mode, type)
+
+```
+
 ## Sparse Data
 
 ```{r}

--- a/man/rmd/linear_reg_gls.Rmd
+++ b/man/rmd/linear_reg_gls.Rmd
@@ -70,6 +70,17 @@ fit(gls_wflow, data = riesby)
 #| child: template-no-case-weights.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("linear_reg_predict") |>
+  dplyr::filter(engine == "gls") |>
+  dplyr::select(mode, type)
+
+```
+
 ## References
 
 - J Pinheiro, and D Bates. 2000. _Mixed-effects models in S and S-PLUS_. Springer, New York, NY

--- a/man/rmd/linear_reg_h2o.Rmd
+++ b/man/rmd/linear_reg_h2o.Rmd
@@ -58,6 +58,17 @@ linear_reg(penalty = 1, mixture = 0.5) |>
 
 By default, [h2o::h2o.glm()] uses the argument `standardize = TRUE` to center and scale the data. 
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("linear_reg_predict") |>
+  dplyr::filter(engine == "h2o") |>
+  dplyr::select(mode, type)
+
+```
+
 ## Initializing h2o 
 
 ```{r}

--- a/man/rmd/linear_reg_keras.Rmd
+++ b/man/rmd/linear_reg_keras.Rmd
@@ -58,6 +58,17 @@ linear_reg(penalty = double(1)) |>
 #| child: template-no-case-weights.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("linear_reg_predict") |>
+  dplyr::filter(engine == "keras") |>
+  dplyr::select(mode, type)
+
+```
+
 ## Examples 
 
 The "Fitting and Predicting with parsnip" article contains [examples](https://parsnip.tidymodels.org/articles/articles/Examples.html#linear-reg-keras) for `linear_reg()` with the `"keras"` engine.

--- a/man/rmd/linear_reg_lm.Rmd
+++ b/man/rmd/linear_reg_lm.Rmd
@@ -34,6 +34,17 @@ _However_, the documentation in [stats::lm()] assumes that is specific type of c
 
 Depending on your application, the degrees of freedom for the model (and other statistics) might be incorrect. 
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("linear_reg_predict") |>
+  dplyr::filter(engine == "lm") |>
+  dplyr::select(mode, type)
+
+```
+
 ## Saving fitted model objects
 
 ```{r}

--- a/man/rmd/linear_reg_lme.Rmd
+++ b/man/rmd/linear_reg_lme.Rmd
@@ -70,6 +70,17 @@ fit(lme_wflow, data = riesby)
 #| child: template-no-case-weights.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("linear_reg_predict") |>
+  dplyr::filter(engine == "lme") |>
+  dplyr::select(mode, type)
+
+```
+
 ## References
 
 - J Pinheiro, and D Bates. 2000. _Mixed-effects models in S and S-PLUS_. Springer, New York, NY

--- a/man/rmd/linear_reg_lmer.Rmd
+++ b/man/rmd/linear_reg_lmer.Rmd
@@ -70,6 +70,17 @@ fit(lmer_wflow, data = riesby)
 #| child: template-uses-case-weights.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("linear_reg_predict") |>
+  dplyr::filter(engine == "lmer") |>
+  dplyr::select(mode, type)
+
+```
+
 ## References
 
  - 	J Pinheiro, and D Bates. 2000. _Mixed-effects models in S and S-PLUS_. Springer, New York, NY

--- a/man/rmd/linear_reg_quantreg.Rmd
+++ b/man/rmd/linear_reg_quantreg.Rmd
@@ -66,6 +66,17 @@ as.matrix(qr_pred$.pred_quantile)
 #| child: template-makes-dummies.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("linear_reg_predict") |>
+  dplyr::filter(engine == "quantreg") |>
+  dplyr::select(mode, type)
+
+```
+
 ## Case weights
 
 ```{r}

--- a/man/rmd/linear_reg_spark.Rmd
+++ b/man/rmd/linear_reg_spark.Rmd
@@ -65,6 +65,17 @@ By default, `ml_linear_regression()` uses the argument `standardization = TRUE` 
 
 Note that, for spark engines, the `case_weight` argument value should be a character string to specify the column with the numeric case weights. 
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("linear_reg_predict") |>
+  dplyr::filter(engine == "spark") |>
+  dplyr::select(mode, type)
+
+```
+
 ## Other details
 
 ```{r}

--- a/man/rmd/linear_reg_stan.Rmd
+++ b/man/rmd/linear_reg_stan.Rmd
@@ -49,6 +49,17 @@ For prediction, the `"stan"` engine can compute posterior  intervals analogous t
 #| child: template-uses-case-weights.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("linear_reg_predict") |>
+  dplyr::filter(engine == "stan") |>
+  dplyr::select(mode, type)
+
+```
+
 ## Examples 
 
 The "Fitting and Predicting with parsnip" article contains [examples](https://parsnip.tidymodels.org/articles/articles/Examples.html#linear-reg-stan) for `linear_reg()` with the `"stan"` engine.

--- a/man/rmd/linear_reg_stan_glmer.Rmd
+++ b/man/rmd/linear_reg_stan_glmer.Rmd
@@ -85,6 +85,17 @@ For prediction, the `"stan_glmer"` engine can compute posterior intervals analog
 #| child: template-uses-case-weights.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("linear_reg_predict") |>
+  dplyr::filter(engine == "stan_glmer") |>
+  dplyr::select(mode, type)
+
+```
+
 ## References
 
  - McElreath, R. 2020 _Statistical Rethinking_. CRC Press.

--- a/man/rmd/logistic_reg_LiblineaR.Rmd
+++ b/man/rmd/logistic_reg_LiblineaR.Rmd
@@ -52,6 +52,17 @@ logistic_reg(penalty = double(1), mixture = double(1)) |>
 #| child: template-same-scale.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("logistic_reg_predict") |>
+  dplyr::filter(engine == "LiblineaR") |>
+  dplyr::select(mode, type)
+
+```
+
 ## Sparse Data
 
 ```{r}

--- a/man/rmd/logistic_reg_brulee.Rmd
+++ b/man/rmd/logistic_reg_brulee.Rmd
@@ -66,6 +66,17 @@ logistic_reg(penalty = double(1)) |>
 #| child: template-no-case-weights.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("logistic_reg_predict") |>
+  dplyr::filter(engine == "brulee") |>
+  dplyr::select(mode, type)
+
+```
+
 ## References
 
  - Kuhn, M, and K Johnson. 2013. _Applied Predictive Modeling_. Springer.

--- a/man/rmd/logistic_reg_gee.Rmd
+++ b/man/rmd/logistic_reg_gee.Rmd
@@ -79,6 +79,17 @@ Also, because of issues with the `gee()` function, a supplementary call to `glm(
 #| child: template-no-case-weights.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("logistic_reg_predict") |>
+  dplyr::filter(engine == "gee") |>
+  dplyr::select(mode, type)
+
+```
+
 ## References
 
  - Liang, K.Y. and Zeger, S.L. (1986) Longitudinal data analysis using generalized linear models. _Biometrika_, 73 13–22.

--- a/man/rmd/logistic_reg_glm.Rmd
+++ b/man/rmd/logistic_reg_glm.Rmd
@@ -41,6 +41,17 @@ logistic_reg() |>
 
 _However_, the documentation in [stats::glm()] assumes that is specific type of case weights are being used:"Non-NULL weights can be used to indicate that different observations have different dispersions (with the values in weights being inversely proportional to the dispersions); or equivalently, when the elements of weights are positive integers `w_i`, that each response `y_i` is the mean of `w_i` unit-weight observations. For a binomial GLM prior weights are used to give the number of trials when the response is the proportion of successes: they would rarely be used for a Poisson GLM."
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("logistic_reg_predict") |>
+  dplyr::filter(engine == "glm") |>
+  dplyr::select(mode, type)
+
+```
+
 ## Saving fitted model objects
 
 ```{r}

--- a/man/rmd/logistic_reg_glmer.Rmd
+++ b/man/rmd/logistic_reg_glmer.Rmd
@@ -69,6 +69,17 @@ fit(glmer_wflow, data = toenail)
 #| child: template-uses-case-weights.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("logistic_reg_predict") |>
+  dplyr::filter(engine == "glmer") |>
+  dplyr::select(mode, type)
+
+```
+
 ## References
 
  - 	J Pinheiro, and D Bates. 2000. _Mixed-effects models in S and S-PLUS_. Springer, New York, NY

--- a/man/rmd/logistic_reg_glmnet.Rmd
+++ b/man/rmd/logistic_reg_glmnet.Rmd
@@ -61,6 +61,17 @@ By default, [glmnet::glmnet()] uses the argument `standardize = TRUE` to center 
 #| child: template-uses-case-weights.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("logistic_reg_predict") |>
+  dplyr::filter(engine == "glmnet") |>
+  dplyr::select(mode, type)
+
+```
+
 ## Sparse Data
 
 ```{r}

--- a/man/rmd/logistic_reg_h2o.Rmd
+++ b/man/rmd/logistic_reg_h2o.Rmd
@@ -68,6 +68,16 @@ logistic_reg() |>
 
 By default, [h2o::h2o.glm()] uses the argument `standardize = TRUE` to center and scale all numeric columns. 
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("logistic_reg_predict") |>
+  dplyr::filter(engine == "h2o") |>
+  dplyr::select(mode, type)
+
+```
 
 ## Initializing h2o 
 

--- a/man/rmd/logistic_reg_keras.Rmd
+++ b/man/rmd/logistic_reg_keras.Rmd
@@ -58,6 +58,17 @@ logistic_reg(penalty = double(1)) |>
 #| child: template-no-case-weights.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("logistic_reg_predict") |>
+  dplyr::filter(engine == "keras") |>
+  dplyr::select(mode, type)
+
+```
+
 ## Saving fitted model objects
 
 ```{r}

--- a/man/rmd/logistic_reg_spark.Rmd
+++ b/man/rmd/logistic_reg_spark.Rmd
@@ -64,6 +64,17 @@ By default, `ml_logistic_regression()` uses the argument `standardization = TRUE
 
 Note that, for spark engines, the `case_weight` argument value should be a character string to specify the column with the numeric case weights. 
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("logistic_reg_predict") |>
+  dplyr::filter(engine == "spark") |>
+  dplyr::select(mode, type)
+
+```
+
 ## Other details
 
 ```{r}

--- a/man/rmd/logistic_reg_stan.Rmd
+++ b/man/rmd/logistic_reg_stan.Rmd
@@ -49,6 +49,17 @@ For prediction, the `"stan"` engine can compute posterior intervals analogous to
 #| child: template-uses-case-weights.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("logistic_reg_predict") |>
+  dplyr::filter(engine == "stan") |>
+  dplyr::select(mode, type)
+
+```
+
 ## Examples 
 
 The "Fitting and Predicting with parsnip" article contains [examples](https://parsnip.tidymodels.org/articles/articles/Examples.html#logistic-reg-stan) for `logistic_reg()` with the `"stan"` engine.

--- a/man/rmd/logistic_reg_stan_glmer.Rmd
+++ b/man/rmd/logistic_reg_stan_glmer.Rmd
@@ -84,6 +84,17 @@ For prediction, the `"stan_glmer"` engine can compute posterior intervals analog
 #| child: template-uses-case-weights.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("logistic_reg_predict") |>
+  dplyr::filter(engine == "stan_glmer") |>
+  dplyr::select(mode, type)
+
+```
+
 ## References
 
  - McElreath, R. 2020 _Statistical Rethinking_. CRC Press.

--- a/man/rmd/mars_earth.Rmd
+++ b/man/rmd/mars_earth.Rmd
@@ -68,6 +68,16 @@ An alternate method for using MARs for categorical outcomes can be found in [dis
 
 Note that the `earth` package documentation has: "In the current implementation, _building models with weights can be slow_."
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("mars_predict") |>
+  dplyr::select(mode, type)
+
+```
+
 ## Saving fitted model objects
 
 ```{r}

--- a/man/rmd/mlp_brulee.Rmd
+++ b/man/rmd/mlp_brulee.Rmd
@@ -102,6 +102,17 @@ mlp(
 #| child: template-no-case-weights.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("mlp_predict") |>
+  dplyr::filter(engine == "brulee") |>
+  dplyr::select(mode, type)
+
+```
+
 ## References
 
  - Kuhn, M, and K Johnson. 2013. _Applied Predictive Modeling_. Springer.

--- a/man/rmd/mlp_brulee_two_layer.Rmd
+++ b/man/rmd/mlp_brulee_two_layer.Rmd
@@ -108,6 +108,17 @@ mlp(
 #| child: template-no-case-weights.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("mlp_predict") |>
+  dplyr::filter(engine == "brulee_two_layer") |>
+  dplyr::select(mode, type)
+
+```
+
 ## References
 
  - Kuhn, M, and K Johnson. 2013. _Applied Predictive Modeling_. Springer.

--- a/man/rmd/mlp_h2o.Rmd
+++ b/man/rmd/mlp_h2o.Rmd
@@ -91,6 +91,16 @@ mlp(
 
 By default, [h2o::h2o.deeplearning()] uses the argument `standardize = TRUE` to center and scale all numeric columns. 
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("mlp_predict") |>
+  dplyr::filter(engine == "h2o") |>
+  dplyr::select(mode, type)
+
+```
 
 ## Initializing h2o 
 

--- a/man/rmd/mlp_keras.Rmd
+++ b/man/rmd/mlp_keras.Rmd
@@ -78,6 +78,17 @@ mlp(
 #| child: template-no-case-weights.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("mlp_predict") |>
+  dplyr::filter(engine == "keras") |>
+  dplyr::select(mode, type)
+
+```
+
 ## Saving fitted model objects
 
 ```{r}

--- a/man/rmd/mlp_nnet.Rmd
+++ b/man/rmd/mlp_nnet.Rmd
@@ -79,6 +79,17 @@ mlp(
 #| child: template-no-case-weights.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("mlp_predict") |>
+  dplyr::filter(engine == "nnet") |>
+  dplyr::select(mode, type)
+
+```
+
 ## Saving fitted model objects
 
 ```{r}

--- a/man/rmd/multinom_reg_brulee.Rmd
+++ b/man/rmd/multinom_reg_brulee.Rmd
@@ -66,6 +66,17 @@ multinom_reg(penalty = double(1)) |>
 #| child: template-no-case-weights.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("multinom_reg_predict") |>
+  dplyr::filter(engine == "brulee") |>
+  dplyr::select(mode, type)
+
+```
+
 ## References
 
  - Kuhn, M, and K Johnson. 2013. _Applied Predictive Modeling_. Springer.

--- a/man/rmd/multinom_reg_glmnet.Rmd
+++ b/man/rmd/multinom_reg_glmnet.Rmd
@@ -65,6 +65,17 @@ The "Fitting and Predicting with parsnip" article contains [examples](https://pa
 #| child: template-uses-case-weights.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("multinom_reg_predict") |>
+  dplyr::filter(engine == "glmnet") |>
+  dplyr::select(mode, type)
+
+```
+
 ## Sparse Data
 
 ```{r}

--- a/man/rmd/multinom_reg_h2o.Rmd
+++ b/man/rmd/multinom_reg_h2o.Rmd
@@ -57,6 +57,17 @@ multinom_reg(penalty = double(1), mixture = double(1)) |>
 
 By default, [h2o::h2o.glm()] uses the argument `standardize = TRUE` to center and scale the data. 
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("multinom_reg_predict") |>
+  dplyr::filter(engine == "h2o") |>
+  dplyr::select(mode, type)
+
+```
+
 ## Initializing h2o 
 
 ```{r}

--- a/man/rmd/multinom_reg_keras.Rmd
+++ b/man/rmd/multinom_reg_keras.Rmd
@@ -58,6 +58,17 @@ multinom_reg(penalty = double(1)) |>
 #| child: template-no-case-weights.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("multinom_reg_predict") |>
+  dplyr::filter(engine == "keras") |>
+  dplyr::select(mode, type)
+
+```
+
 ## Saving fitted model objects
 
 ```{r}

--- a/man/rmd/multinom_reg_nnet.Rmd
+++ b/man/rmd/multinom_reg_nnet.Rmd
@@ -50,6 +50,17 @@ multinom_reg(penalty = double(1)) |>
 #| child: template-same-scale.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("multinom_reg_predict") |>
+  dplyr::filter(engine == "nnet") |>
+  dplyr::select(mode, type)
+
+```
+
 ## Examples 
 
 The "Fitting and Predicting with parsnip" article contains [examples](https://parsnip.tidymodels.org/articles/articles/Examples.html#multinom-reg-nnet) for `multinom_reg()` with the `"nnet"` engine.

--- a/man/rmd/multinom_reg_spark.Rmd
+++ b/man/rmd/multinom_reg_spark.Rmd
@@ -64,6 +64,16 @@ By default, `ml_multinom_regression()` uses the argument `standardization = TRUE
 
 Note that, for spark engines, the `case_weight` argument value should be a character string to specify the column with the numeric case weights. 
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("multinom_reg_predict") |>
+  dplyr::filter(engine == "spark") |>
+  dplyr::select(mode, type)
+
+```
 
 ## Other details
 

--- a/man/rmd/naive_Bayes_h2o.Rmd
+++ b/man/rmd/naive_Bayes_h2o.Rmd
@@ -54,6 +54,17 @@ naive_Bayes(Laplace = numeric(0)) |>
   translate()
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("naive_Bayes_predict") |>
+  dplyr::filter(engine == "h2o") |>
+  dplyr::select(mode, type)
+
+```
+
 ## Initializing h2o 
 
 ```{r}

--- a/man/rmd/naive_Bayes_klaR.Rmd
+++ b/man/rmd/naive_Bayes_klaR.Rmd
@@ -59,6 +59,17 @@ The columns for qualitative predictors should always be represented as factors (
 #| child: template-no-case-weights.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("naive_Bayes_predict") |>
+  dplyr::filter(engine == "klaR") |>
+  dplyr::select(mode, type)
+
+```
+
 ## References
 
  - Kuhn, M, and K Johnson. 2013. _Applied Predictive Modeling_. Springer.

--- a/man/rmd/naive_Bayes_naivebayes.Rmd
+++ b/man/rmd/naive_Bayes_naivebayes.Rmd
@@ -61,6 +61,17 @@ For count data, integers can be estimated using a Poisson distribution if the ar
 #| child: template-no-case-weights.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("naive_Bayes_predict") |>
+  dplyr::filter(engine == "naivebayes") |>
+  dplyr::select(mode, type)
+
+```
+
 ## References
 
  - Kuhn, M, and K Johnson. 2013. _Applied Predictive Modeling_. Springer.

--- a/man/rmd/nearest_neighbor_kknn.Rmd
+++ b/man/rmd/nearest_neighbor_kknn.Rmd
@@ -82,6 +82,16 @@ The "Fitting and Predicting with parsnip" article contains [examples](https://pa
 #| child: template-no-case-weights.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("nearest_neighbor_predict") |>
+  dplyr::select(mode, type)
+
+```
+
 ## Saving fitted model objects
 
 ```{r}

--- a/man/rmd/null-model.Rmd
+++ b/man/rmd/null-model.Rmd
@@ -21,3 +21,12 @@ null_model() |>
   translate()
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("null_model_predict") |>
+  dplyr::select(mode, type)
+
+```

--- a/man/rmd/pls_mixOmics.Rmd
+++ b/man/rmd/pls_mixOmics.Rmd
@@ -101,6 +101,16 @@ This package is available via the Bioconductor repository and is not accessible 
 #| child: template-no-case-weights.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("pls") |>
+  dplyr::select(mode, type)
+
+```
+
 ## References
 
  - Rohart F and Gautier B and Singh A and Le Cao K-A  (2017). "mixOmics: An R package for 'omics feature selection and multiple data integration." PLoS computational biology, 13(11), e1005752.

--- a/man/rmd/poisson_reg_gee.Rmd
+++ b/man/rmd/poisson_reg_gee.Rmd
@@ -76,6 +76,17 @@ fit(gee_wflow, data = longitudinal_counts)
 
 Also, because of issues with the `gee()` function, a supplementary call to `glm()` is needed to get the rank and QR decomposition objects so that `predict()` can be used.
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("poisson_reg_predict") |>
+  dplyr::filter(engine == "gee") |>
+  dplyr::select(mode, type)
+
+```
+
 ## References
 
  - Liang, K.Y. and Zeger, S.L. (1986) Longitudinal data analysis using generalized linear models. _Biometrika_, 73 13–22.

--- a/man/rmd/poisson_reg_glm.Rmd
+++ b/man/rmd/poisson_reg_glm.Rmd
@@ -45,6 +45,17 @@ _However_, the documentation in [stats::glm()] assumes that is specific type of 
 
 If frequency weights are being used in your application, the [glm_grouped()] model (and corresponding engine) may be more appropriate. 
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("poisson_reg_predict") |>
+  dplyr::filter(engine == "glm") |>
+  dplyr::select(mode, type)
+
+```
+
 ## Saving fitted model objects
 
 ```{r}

--- a/man/rmd/poisson_reg_glmer.Rmd
+++ b/man/rmd/poisson_reg_glmer.Rmd
@@ -68,6 +68,17 @@ fit(glmer_wflow, data = longitudinal_counts)
 #| child: template-uses-case-weights.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("poisson_reg_predict") |>
+  dplyr::filter(engine == "glmer") |>
+  dplyr::select(mode, type)
+
+```
+
 ## References
 
  - 	J Pinheiro, and D Bates. 2000. _Mixed-effects models in S and S-PLUS_. Springer, New York, NY

--- a/man/rmd/poisson_reg_glmnet.Rmd
+++ b/man/rmd/poisson_reg_glmnet.Rmd
@@ -66,6 +66,17 @@ By default, `glmnet::glmnet()` uses the argument `standardize = TRUE` to center 
 #| child: template-uses-case-weights.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("poisson_reg_predict") |>
+  dplyr::filter(engine == "glmnet") |>
+  dplyr::select(mode, type)
+
+```
+
 ## Saving fitted model objects
 
 ```{r}

--- a/man/rmd/poisson_reg_h2o.Rmd
+++ b/man/rmd/poisson_reg_h2o.Rmd
@@ -61,6 +61,16 @@ poisson_reg(penalty = double(1), mixture = double(1)) |>
 
 By default, `h2o::h2o.glm()` uses the argument `standardize = TRUE` to center and scale all numerical columns. 
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("poisson_reg_predict") |>
+  dplyr::filter(engine == "h2o") |>
+  dplyr::select(mode, type)
+
+```
 
 ## Initializing h2o  
 

--- a/man/rmd/poisson_reg_hurdle.Rmd
+++ b/man/rmd/poisson_reg_hurdle.Rmd
@@ -72,3 +72,14 @@ The reason for this is that [workflows::add_formula()] will try to create the mo
 ```{r}
 #| child: template-uses-case-weights.Rmd
 ```
+
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("poisson_reg_predict") |>
+  dplyr::filter(engine == "hurdle") |>
+  dplyr::select(mode, type)
+
+```

--- a/man/rmd/poisson_reg_stan.Rmd
+++ b/man/rmd/poisson_reg_stan.Rmd
@@ -53,6 +53,17 @@ For prediction, the `"stan"` engine can compute posterior intervals analogous to
 #| child: template-uses-case-weights.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("poisson_reg_predict") |>
+  dplyr::filter(engine == "stan") |>
+  dplyr::select(mode, type)
+
+```
+
 ## Examples 
 
 The "Fitting and Predicting with parsnip" article contains [examples](https://parsnip.tidymodels.org/articles/articles/Examples.html#linear-reg-stan) for `poisson_reg()` with the `"stan"` engine.

--- a/man/rmd/poisson_reg_stan_glmer.Rmd
+++ b/man/rmd/poisson_reg_stan_glmer.Rmd
@@ -83,6 +83,17 @@ For prediction, the `"stan_glmer"` engine can compute posterior intervals analog
 #| child: template-uses-case-weights.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("poisson_reg_predict") |>
+  dplyr::filter(engine == "stan_glmer") |>
+  dplyr::select(mode, type)
+
+```
+
 ## References
 
  - McElreath, R. 2020 _Statistical Rethinking_. CRC Press.

--- a/man/rmd/poisson_reg_zeroinfl.Rmd
+++ b/man/rmd/poisson_reg_zeroinfl.Rmd
@@ -72,3 +72,14 @@ The reason for this is that [workflows::add_formula()] will try to create the mo
 ```{r}
 #| child: template-uses-case-weights.Rmd
 ```
+
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("poisson_reg_predict") |>
+  dplyr::filter(engine == "zeroinfl") |>
+  dplyr::select(mode, type)
+
+```

--- a/man/rmd/proportional_hazards_glmnet.Rmd
+++ b/man/rmd/proportional_hazards_glmnet.Rmd
@@ -120,6 +120,17 @@ Note that columns used in the `strata()` function _will_ also be estimated in th
 #| child: template-butcher.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("proportional_hazards") |>
+  dplyr::filter(engine == "gee") |>
+  dplyr::select(mode, type)
+
+```
+
 # References
 
  - Simon N, Friedman J, Hastie T, Tibshirani R. 2011. "Regularization Paths for Cox’s Proportional Hazards Model via Coordinate Descent." _Journal of Statistical Software_, Articles 39 (5): 1–13. \doi{10.18637/jss.v039.i05}.
@@ -128,3 +139,13 @@ Note that columns used in the `strata()` function _will_ also be estimated in th
  
  - Kuhn M, Johnson K. 2013. _Applied Predictive Modeling_. Springer.
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("proportional_hazards_predict") |>
+  dplyr::filter(engine == "glmnet") |>
+  dplyr::select(mode, type)
+
+```

--- a/man/rmd/proportional_hazards_survival.Rmd
+++ b/man/rmd/proportional_hazards_survival.Rmd
@@ -61,6 +61,17 @@ Note that columns used in the `strata()` function will not be estimated in the r
 #| child: template-uses-case-weights.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("proportional_hazards_predict") |>
+  dplyr::filter(engine == "survival") |>
+  dplyr::select(mode, type)
+
+```
+
 ## References
 
 - Andersen P, Gill R. 1982. Cox's regression model for counting processes, a large sample study. _Annals of Statistics_ 10, 1100-1120.

--- a/man/rmd/rand_forest_aorsf.Rmd
+++ b/man/rmd/rand_forest_aorsf.Rmd
@@ -89,6 +89,17 @@ rand_forest() |>
 #| child: template-uses-case-weights.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("rand_forest_predict") |>
+  dplyr::filter(engine == "aorsf") |>
+  dplyr::select(mode, type)
+
+```
+
 ## Other details
 
 Predictions of survival probability at a time exceeding the maximum observed event time are the predicted survival probability at the maximum observed time in the training data.

--- a/man/rmd/rand_forest_h2o.Rmd
+++ b/man/rmd/rand_forest_h2o.Rmd
@@ -69,6 +69,16 @@ rand_forest(
 #| child: template-tree-split-factors.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("rand_forest_predict") |>
+  dplyr::filter(engine == "h2o") |>
+  dplyr::select(mode, type)
+
+```
 
 ## Initializing h2o 
 

--- a/man/rmd/rand_forest_partykit.Rmd
+++ b/man/rmd/rand_forest_partykit.Rmd
@@ -84,6 +84,17 @@ rand_forest() |>
 #| child: template-tree-split-factors.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("rand_forest_predict") |>
+  dplyr::filter(engine == "partykit") |>
+  dplyr::select(mode, type)
+
+```
+
 ## Other details
 
 ```{r}

--- a/man/rmd/rand_forest_randomForest.Rmd
+++ b/man/rmd/rand_forest_randomForest.Rmd
@@ -75,6 +75,16 @@ rand_forest(
 #| child: template-butcher.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("rand_forest_predict") |>
+  dplyr::filter(engine == "randomForest") |>
+  dplyr::select(mode, type)
+
+```
 
 ## Examples 
 

--- a/man/rmd/rand_forest_ranger.Rmd
+++ b/man/rmd/rand_forest_ranger.Rmd
@@ -97,6 +97,16 @@ While this engine supports sparse data as an input, it doesn't use it any differ
 #| child: template-butcher.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("rand_forest_predict") |>
+  dplyr::filter(engine == "ranger") |>
+  dplyr::select(mode, type)
+
+```
 
 ## Examples 
 

--- a/man/rmd/rand_forest_spark.Rmd
+++ b/man/rmd/rand_forest_spark.Rmd
@@ -81,6 +81,16 @@ rand_forest(
 
 Note that, for spark engines, the `case_weight` argument value should be a character string to specify the column with the numeric case weights. 
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("rand_forest_predict") |>
+  dplyr::filter(engine == "spark") |>
+  dplyr::select(mode, type)
+
+```
 
 ## References
 

--- a/man/rmd/rule_fit_h2o.Rmd
+++ b/man/rmd/rule_fit_h2o.Rmd
@@ -88,6 +88,17 @@ rule_fit(
 #| child: template-makes-dummies.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("rule_fit_predict") |>
+  dplyr::filter(engine == "h2o") |>
+  dplyr::select(mode, type)
+
+```
+
 ## Other details
 
 ```{r}

--- a/man/rmd/rule_fit_xrf.Rmd
+++ b/man/rmd/rule_fit_xrf.Rmd
@@ -118,6 +118,17 @@ These differences will create a disparity in the values of the `penalty` argumen
 #| child: template-no-case-weights.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("rule_fit_predict") |>
+  dplyr::filter(engine == "xrf") |>
+  dplyr::select(mode, type)
+
+```
+
 ## References
 
  - Friedman and Popescu. "Predictive learning via rule ensembles." Ann. Appl. Stat. 2 (3) 916- 954, September 2008

--- a/man/rmd/survival_reg_flexsurv.Rmd
+++ b/man/rmd/survival_reg_flexsurv.Rmd
@@ -66,6 +66,16 @@ For this engine, stratification cannot be specified via [`survival::strata()`], 
 #| child: template-butcher.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("survival_reg_predict") |>
+  dplyr::filter(engine == "flexsurv") |>
+  dplyr::select(mode, type)
+
+```
 
 ## References
 

--- a/man/rmd/survival_reg_flexsurvspline.Rmd
+++ b/man/rmd/survival_reg_flexsurvspline.Rmd
@@ -41,6 +41,16 @@ For this engine, stratification cannot be specified via [`survival::strata()`], 
 #| child: template-uses-case-weights.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("survival_reg_predict") |>
+  dplyr::filter(engine == "flexsurvspline") |>
+  dplyr::select(mode, type)
+
+```
 
 ## Saving fitted model objects
 

--- a/man/rmd/survival_reg_survival.Rmd
+++ b/man/rmd/survival_reg_survival.Rmd
@@ -72,6 +72,17 @@ survival_reg() |>
 #| child: template-uses-case-weights.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("survival_reg_predict") |>
+  dplyr::filter(engine == "survival") |>
+  dplyr::select(mode, type)
+
+```
+
 ## Saving fitted model objects
 
 ```{r}

--- a/man/rmd/svm_linear_LiblineaR.Rmd
+++ b/man/rmd/svm_linear_LiblineaR.Rmd
@@ -78,6 +78,17 @@ Note that the `LiblineaR` engine does not produce class probabilities. When opti
 #| child: template-no-case-weights.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("svm_linear_predict") |>
+  dplyr::filter(engine == "LiblineaR") |>
+  dplyr::select(mode, type)
+
+```
+
 ## Sparse Data
 
 ```{r}

--- a/man/rmd/svm_linear_kernlab.Rmd
+++ b/man/rmd/svm_linear_kernlab.Rmd
@@ -76,6 +76,17 @@ Note that the `"kernlab"` engine does not naturally estimate class probabilities
 #| child: template-no-case-weights.Rmd
 ```
 
+j## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("svm_linear_predict") |>
+  dplyr::filter(engine == "kernlab") |>
+  dplyr::select(mode, type)
+
+```
+
 ## Saving fitted model objects
 
 ```{r}

--- a/man/rmd/svm_poly_kernlab.Rmd
+++ b/man/rmd/svm_poly_kernlab.Rmd
@@ -80,6 +80,16 @@ Note that the `"kernlab"` engine does not naturally estimate class probabilities
 #| child: template-no-case-weights.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("svm_poly_predict") |>
+  dplyr::select(mode, type)
+
+```
+
 ## Examples 
 
 The "Fitting and Predicting with parsnip" article contains [examples](https://parsnip.tidymodels.org/articles/articles/Examples.html#svm-poly-kernlab) for `svm_poly()` with the `"kernlab"` engine.

--- a/man/rmd/svm_rbf_kernlab.Rmd
+++ b/man/rmd/svm_rbf_kernlab.Rmd
@@ -80,6 +80,16 @@ Note that the `"kernlab"` engine does not naturally estimate class probabilities
 #| child: template-no-case-weights.Rmd
 ```
 
+## Prediction types
+
+```{r}
+#| label: predict-types
+
+parsnip:::get_from_env("svm_rbf_predict") |>
+  dplyr::select(mode, type)
+
+```
+
 ## Saving fitted model objects
 
 ```{r}


### PR DESCRIPTION
Edited all .Rmd files to include a "Predict type" section, but was unable to knit due to a dependency on the `catboost` package that I was unable to resolve.