### PR TITLE
Add "Supported By Posit" badge to parsnip website

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -2,7 +2,7 @@ url: https://parsnip.tidymodels.org/
 
 navbar:
   components:
-    home: ~
+    home:
     tutorials:
       text: Learn more
       menu:
@@ -20,8 +20,9 @@ template:
     primary: "#CA225E"
 
   includes:
-      in_header: |
-        <script defer data-domain="parsnip.tidymodels.org,all.tidymodels.org" src="https://plausible.io/js/plausible.js"></script>
+    in_header: |
+      <script src="https://cdn.jsdelivr.net/gh/posit-dev/supported-by-posit/js/badge.min.js" data-max-height="43" data-hide-below="1200" data-light-bg="#666f76" data-light-fg="#f9f9f9"></script>
+      <script defer data-domain="parsnip.tidymodels.org,all.tidymodels.org" src="https://plausible.io/js/plausible.js"></script>
 
 development:
   mode: auto
@@ -31,84 +32,84 @@ figures:
   fig.height: 5.75
 
 reference:
-  - title: Models
-    contents:
-      - auto_ml
-      - bag_mars
-      - bag_mlp
-      - bag_tree
-      - bart
-      - boost_tree
-      - cubist_rules
-      - C5_rules
-      - decision_tree
-      - discrim_flexible
-      - discrim_linear
-      - discrim_quad
-      - discrim_regularized
-      - gen_additive_mod
-      - glm_grouped
-      - linear_reg
-      - logistic_reg
-      - mars
-      - mlp
-      - multinom_reg
-      - naive_Bayes
-      - nearest_neighbor
-      - null_model
-      - pls
-      - poisson_reg
-      - proportional_hazards
-      - rand_forest
-      - rule_fit
-      - survival_reg
-      - svm_linear
-      - svm_poly
-      - svm_rbf
-  - title: Infrastructure
-    contents:
-      - autoplot.model_fit
-      - add_rowindex
-      - augment.model_fit
-      - case_weights
-      - case_weights_allowed
-      - descriptors
-      - extract-parsnip
-      - fit.model_spec
-      - fit_xy
-      - control_parsnip
-      - glance.model_fit
-      - matrix_to_quantile_pred
-      - model_fit
-      - model_formula
-      - model_spec
-      - multi_predict
-      - parsnip_addin
-      - predict.model_fit
-      - reexports
-      - repair_call
-      - set_args
-      - set_engine
-      - set_mode
-      - show_engines
-      - sparse_data
-      - tidy.model_fit
-      - translate
-      - starts_with("update")
-      - matches("_train")
+- title: Models
+  contents:
+  - auto_ml
+  - bag_mars
+  - bag_mlp
+  - bag_tree
+  - bart
+  - boost_tree
+  - cubist_rules
+  - C5_rules
+  - decision_tree
+  - discrim_flexible
+  - discrim_linear
+  - discrim_quad
+  - discrim_regularized
+  - gen_additive_mod
+  - glm_grouped
+  - linear_reg
+  - logistic_reg
+  - mars
+  - mlp
+  - multinom_reg
+  - naive_Bayes
+  - nearest_neighbor
+  - null_model
+  - pls
+  - poisson_reg
+  - proportional_hazards
+  - rand_forest
+  - rule_fit
+  - survival_reg
+  - svm_linear
+  - svm_poly
+  - svm_rbf
+- title: Infrastructure
+  contents:
+  - autoplot.model_fit
+  - add_rowindex
+  - augment.model_fit
+  - case_weights
+  - case_weights_allowed
+  - descriptors
+  - extract-parsnip
+  - fit.model_spec
+  - fit_xy
+  - control_parsnip
+  - glance.model_fit
+  - matrix_to_quantile_pred
+  - model_fit
+  - model_formula
+  - model_spec
+  - multi_predict
+  - parsnip_addin
+  - predict.model_fit
+  - reexports
+  - repair_call
+  - set_args
+  - set_engine
+  - set_mode
+  - show_engines
+  - sparse_data
+  - tidy.model_fit
+  - translate
+  - starts_with("update")
+  - matches("_train")
 
-  - title: Developer tools
-    contents:
-      - condense_control
-      - contr_one_hot
-      - set_new_model
-      - maybe_matrix
-      - min_cols
-      - max_mtry_formula
-      - required_pkgs
-      - required_pkgs.model_spec
-      - req_pkgs
-      - .extract_surv_status
-      - .extract_surv_time
-      - .model_param_name_key
-      - .get_prediction_column_names
+- title: Developer tools
+  contents:
+  - condense_control
+  - contr_one_hot
+  - set_new_model
+  - maybe_matrix
+  - min_cols
+  - max_mtry_formula
+  - required_pkgs
+  - required_pkgs.model_spec
+  - req_pkgs
+  - .extract_surv_status
+  - .extract_surv_time
+  - .model_param_name_key
+  - .get_prediction_column_names


### PR DESCRIPTION
## Overview

This PR adds the "Supported by Posit" badge to the parsnip website.

## Background

We've recently started adding a "Supported by Posit" badge across all Posit package websites to create a more cohesive brand presence. The badge appears on the far right of the top navigation bar or at the bottom of the hamburger menu. It links to Posit’s main website. @hadley is involved with this initiative.

The following websites already have the "Supported by Posit" badge: [ggplot2](https://ggplot2.tidyverse.org), [Great Tables](https://posit-dev.github.io/great-tables/articles/intro.html), [gt](https://gt.rstudio.com), [Plotnine](https://plotnine.org), [Pointblank](https://posit-dev.github.io/pointblank/), [pointblank](https://rstudio.github.io/pointblank/), and [Quarto](https://quarto.org).

See https://posit-dev.github.io/supported-by-posit/ for more information.

## Changes

- Added a line to `_pkgdown.yml` to include the JavaScript file
- Standardized indentation in `_pkgdown.yml`

## Screenshots

At 1200px browser width:

![Screenshot of parsnip website at 1200px browser width](https://posit-dev.github.io/supported-by-posit/screenshots/parsnip-1200.png)

At 992px browser width:

![Screenshot of parsnip website at 992px browser width](https://posit-dev.github.io/supported-by-posit/screenshots/parsnip-992.png)

At 991px browser width:

![Screenshot of parsnip website at 991px browser width](https://posit-dev.github.io/supported-by-posit/screenshots/parsnip-991.png)

