### PR TITLE
document automatic handling of custom objective functions in lightgbm

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # parsnip (development version)
 
+* Documentation for the lightgbm engine now includes information about custom objective functions and automatic `num_class` handling (#1275).
+
 * Fixed a bug in random forest fits using the `"aorsf"` engine where the check for `mtry` could not be performed (#1276)
 
 * Fix bug in predicting class probabilities for multiclass earth models (#1334)

--- a/man/details_boost_tree_lightgbm.Rd
+++ b/man/details_boost_tree_lightgbm.Rd
@@ -220,6 +220,30 @@ if \code{sample_size} (i.e. \code{bagging_fraction}) is not equal to 1 and no
 setting the \code{bagging_freq} argument to \code{set_engine()} manually.
 }
 
+\subsection{Custom Objective Functions}{
+
+The default objective for classification models is set automatically
+based on the number of outcome levels: \code{binary} for two-class problems
+and \code{multiclass} for more than two classes. For regression, the default
+is \code{regression}.
+
+You can specify an alternative objective using \code{set_engine()}:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{boost_tree() |>
+  set_engine("lightgbm", objective = "multiclassova") |>
+  set_mode("classification")
+}\if{html}{\out{</div>}}
+
+For multiclass objectives (\code{multiclass}, \code{softmax}, \code{multiclassova},
+\code{multiclass_ova}, \code{ova}, \code{ovr}), the \code{num_class} parameter is
+automatically determined from the number of outcome levels. This means
+you do not need to manually specify \code{num_class} when using these
+objectives.
+
+See the \href{https://lightgbm.readthedocs.io/en/latest/Parameters.html#core-parameters}{LightGBM documentation}
+for a full list of available objectives.
+}
+
 \subsection{Verbosity}{
 
 bonsai quiets much of the logging output from

--- a/man/rmd/boost_tree_lightgbm.Rmd
+++ b/man/rmd/boost_tree_lightgbm.Rmd
@@ -112,6 +112,24 @@ The `sample_size` argument is translated to the `bagging_fraction` parameter in 
 
 To effectively enable bagging, the user would also need to set the `bagging_freq` argument to lightgbm. `bagging_freq` defaults to 0, which means bagging is disabled, and a `bagging_freq` argument of `k` means that the booster will perform bagging at every `k`th boosting iteration. Thus, by default, the `sample_size` argument would be ignored without setting this argument manually. Other boosting libraries, like xgboost, do not have an analogous argument to `bagging_freq` and use `k = 1` when the analogue to `bagging_fraction` is in $(0, 1)$. _bonsai will thus automatically set_ `bagging_freq = 1` _in_ `set_engine("lightgbm", ...)` if `sample_size` (i.e. `bagging_fraction`) is not equal to 1 and no `bagging_freq` value is supplied. This default can be overridden by setting the `bagging_freq` argument to `set_engine()` manually.
 
+### Custom Objective Functions
+
+The default objective for classification models is set automatically based on the number of outcome levels: `binary` for two-class problems and `multiclass` for more than two classes. For regression, the default is `regression`.
+
+You can specify an alternative objective using `set_engine()`:
+
+```{r}
+#| label: lightgbm-objective
+#| eval: false
+boost_tree() |>
+  set_engine("lightgbm", objective = "multiclassova") |>
+  set_mode("classification")
+```
+
+For multiclass objectives (`multiclass`, `softmax`, `multiclassova`, `multiclass_ova`, `ova`, `ovr`), the `num_class` parameter is automatically determined from the number of outcome levels. This means you do not need to manually specify `num_class` when using these objectives.
+
+See the [LightGBM documentation](https://lightgbm.readthedocs.io/en/latest/Parameters.html#core-parameters) for a full list of available objectives.
+
 ### Verbosity
 
 bonsai quiets much of the logging output from [lightgbm::lgb.train()] by default. With default settings, logged warnings and errors will still be passed on to the user. To print out all logs during training, set `quiet = TRUE`.

--- a/man/rmd/boost_tree_lightgbm.md
+++ b/man/rmd/boost_tree_lightgbm.md
@@ -159,6 +159,23 @@ The `sample_size` argument is translated to the `bagging_fraction` parameter in 
 
 To effectively enable bagging, the user would also need to set the `bagging_freq` argument to lightgbm. `bagging_freq` defaults to 0, which means bagging is disabled, and a `bagging_freq` argument of `k` means that the booster will perform bagging at every `k`th boosting iteration. Thus, by default, the `sample_size` argument would be ignored without setting this argument manually. Other boosting libraries, like xgboost, do not have an analogous argument to `bagging_freq` and use `k = 1` when the analogue to `bagging_fraction` is in $(0, 1)$. _bonsai will thus automatically set_ `bagging_freq = 1` _in_ `set_engine("lightgbm", ...)` if `sample_size` (i.e. `bagging_fraction`) is not equal to 1 and no `bagging_freq` value is supplied. This default can be overridden by setting the `bagging_freq` argument to `set_engine()` manually.
 
+### Custom Objective Functions
+
+The default objective for classification models is set automatically based on the number of outcome levels: `binary` for two-class problems and `multiclass` for more than two classes. For regression, the default is `regression`.
+
+You can specify an alternative objective using `set_engine()`:
+
+
+``` r
+boost_tree() |>
+  set_engine("lightgbm", objective = "multiclassova") |>
+  set_mode("classification")
+```
+
+For multiclass objectives (`multiclass`, `softmax`, `multiclassova`, `multiclass_ova`, `ova`, `ovr`), the `num_class` parameter is automatically determined from the number of outcome levels. This means you do not need to manually specify `num_class` when using these objectives.
+
+See the [LightGBM documentation](https://lightgbm.readthedocs.io/en/latest/Parameters.html#core-parameters) for a full list of available objectives.
+
 ### Verbosity
 
 bonsai quiets much of the logging output from [lightgbm::lgb.train()] by default. With default settings, logged warnings and errors will still be passed on to the user. To print out all logs during training, set `quiet = TRUE`.


### PR DESCRIPTION
To close #1275 

We:

  - Explains the default objective behavior for binary, multiclass, and regression
  - Shows how to set custom objectives via set_engine()
  - Documents that num_class is automatically determined for multiclass objectives