### PR TITLE
Remove unused functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,8 +39,7 @@ Imports:
     tibble (>= 2.1.1),
     tidyr (>= 1.3.0),
     utils,
-    vctrs (>= 0.6.0),
-    withr
+    vctrs (>= 0.6.0)
 Suggests: 
     bench,
     C50,
@@ -68,6 +67,7 @@ Suggests:
     survival,
     tensorflow,
     testthat (>= 3.0.0),
+    withr,
     xgboost (>= 1.5.0.1)
 VignetteBuilder: 
     knitr

--- a/R/descriptors.R
+++ b/R/descriptors.R
@@ -323,13 +323,6 @@ get_descr_xy <- function(x, y, call = rlang::caller_env()) {
   )
 }
 
-has_exprs <- function(x) {
-  if (is.null(x) | is_varying(x) | is_missing_arg(x)) {
-    return(FALSE)
-  }
-  is_symbolic(x)
-}
-
 # Locate descriptors -----------------------------------------------------------
 
 # take a model spec, see if any require descriptors

--- a/R/engine_docs.R
+++ b/R/engine_docs.R
@@ -341,10 +341,6 @@ find_details_topics <- function(mod, pkg = "parsnip") {
   unique(res)
 }
 
-sort_c <- function(x) {
-  withr::with_collate("C", sort(x))
-}
-
 # ------------------------------------------------------------------------------
 
 #' Locate and show errors/warnings in engine-specific documentation

--- a/R/mars.R
+++ b/R/mars.R
@@ -141,28 +141,6 @@ check_args.mars <- function(object, call = rlang::caller_env()) {
   invisible(object)
 }
 
-# ------------------------------------------------------------------------------
-
-earth_submodel_pred <- function(object, new_data, terms = 2:3, ...) {
-  load_libs(object, quiet = TRUE, attach = TRUE)
-  map(terms, earth_reg_updater, object = object, newdata = new_data, ...) |>
-    purrr::list_rbind()
-}
-
-earth_reg_updater <- function(num, object, new_data, ...) {
-  object <- update(object, nprune = num)
-  pred <- predict(object, new_data, ...)
-  if (ncol(pred) == 1) {
-    res <- tibble::tibble(.pred = pred[, 1], nprune = num)
-  } else {
-    names(res) <- paste0(".pred_", names(res))
-    res <- tibble::as_tibble(res)
-    res$nprune <- num
-  }
-  res
-}
-
-
 # earth helpers ----------------------------------------------------------------
 
 #' @rdname multi_predict

--- a/R/mlp.R
+++ b/R/mlp.R
@@ -396,10 +396,6 @@ parse_keras_args <- function(...) {
   )
 }
 
-mlp_num_weights <- function(p, hidden_units, classes) {
-  ((p + 1) * hidden_units) + ((hidden_units + 1) * classes)
-}
-
 allowed_keras_activation <-
   c(
     "elu",

--- a/R/surv_reg.R
+++ b/R/surv_reg.R
@@ -103,30 +103,6 @@ check_args.surv_reg <- function(object, call = rlang::caller_env()) {
 
 # ------------------------------------------------------------------------------
 
-survreg_quant <- function(results, object) {
-  pctl <- object$spec$method$pred$quantile$args$p
-  n <- nrow(results)
-  p <- ncol(results)
-  colnames(results) <- names0(p)
-  results <-
-    results |>
-    as_tibble() |>
-    mutate(.row = seq_len(n)) |>
-    gather(.label, .pred, -.row) |>
-    arrange(.row, .label) |>
-    mutate(.quantile = rep(pctl, n)) |>
-    dplyr::select(-.label)
-  .row <- results[[".row"]]
-  results <-
-    results |>
-    dplyr::select(-.row)
-  results <- split(results, .row)
-  names(results) <- NULL
-  tibble(.pred = results)
-}
-
-# ------------------------------------------------------------------------------
-
 flexsurv_mean <- function(results, object) {
   results <- unclass(results)
   results <- bind_rows(results)

--- a/R/surv_reg.R
+++ b/R/surv_reg.R
@@ -109,14 +109,4 @@ flexsurv_mean <- function(results, object) {
   results$est
 }
 
-flexsurv_quant <- function(results, object) {
-  results <- map(results, as_tibble)
-  names(results) <- NULL
-  results <- map(
-    results,
-    setNames,
-    c(".quantile", ".pred", ".pred_lower", ".pred_upper")
-  )
-}
-
 # nocov end


### PR DESCRIPTION
closes #1357

I decided to keep `.is_censored_right()` because it's also in a standalone file. The rest of the functions listed in the issue are true positives and should be removed.