### PR TITLE
reduce overhead for `fit()`

### DIFF
--- a/R/aaa_models.R
+++ b/R/aaa_models.R
@@ -82,8 +82,7 @@ get_model_env <- function() {
 #' @export
 get_from_env <- function(items) {
   check_character(items)
-  mod_env <- get_model_env()
-  rlang::env_get(mod_env, items, default = NULL)
+  get_model_env()[[items]]
 }
 
 #' @rdname get_model_env
@@ -240,7 +239,7 @@ check_spec_mode_engine_val <- function(
     )
   }
 
-  model_info <- rlang::env_get(get_model_env(), cls)
+  model_info <- get_model_env()[[cls]]
 
   # Initially, check if the specification is well-defined in the current model
   # parsnip model environment. If so, return early.

--- a/R/control_parsnip.R
+++ b/R/control_parsnip.R
@@ -32,7 +32,8 @@ check_control <- function(x, call = rlang::caller_env()) {
   if (!is.list(x)) {
     cli::cli_abort("{.arg control} should be a named list.", call = call)
   }
-  if (!isTRUE(all.equal(sort(names(x)), c("catch", "verbosity")))) {
+  x_names <- names(x)
+  if (!"catch" %in% x_names || !"verbosity" %in% x_names) {
     cli::cli_abort(
       "{.arg control} should be a named list with elements {.field verbosity}
        and {.field catch}.",

--- a/R/convert_data.R
+++ b/R/convert_data.R
@@ -281,7 +281,7 @@
     y <- as.data.frame(y)
   } else {
     if (is.atomic(y)) {
-      y <- data.frame(y)
+      y <- as.data.frame(y)
       names(y) <- y_name
     }
   }
@@ -290,7 +290,7 @@
   check_dup_names(x, y)
   form <- make_formula(names(x), names(y))
 
-  x <- bind_cols(x, y)
+  x <- vctrs::vec_cbind(x, y)
   if (!is.null(rn) & !inherits(x, "tbl_df")) {
     rownames(x) <- rn
   }

--- a/R/descriptors.R
+++ b/R/descriptors.R
@@ -327,10 +327,15 @@ get_descr_xy <- function(x, y, call = rlang::caller_env()) {
 
 # take a model spec, see if any require descriptors
 requires_descrs <- function(object) {
-  any(c(
-    map_lgl(object$args, has_any_descrs),
-    map_lgl(object$eng_args, has_any_descrs)
-  ))
+  args <- c(object$args, object$eng_args)
+
+  for (arg in args) {
+    if (has_any_descrs(arg)) {
+      return(TRUE)
+    }
+  }
+
+  FALSE
 }
 
 # given a quosure arg, does the expression contain a descriptor function?
@@ -354,22 +359,22 @@ has_any_descrs <- function(x) {
 
   .globals <- names(.globals)
 
-  any(map_lgl(.globals, is_descr))
+  any(.globals %in% .descr_names)
 }
 
-is_descr <- function(x) {
-  descrs <- list(
-    ".cols",
-    ".preds",
-    ".obs",
-    ".lvls",
-    ".facts",
-    ".x",
-    ".y",
-    ".dat"
-  )
+.descr_names <- c(
+  ".cols",
+  ".preds",
+  ".obs",
+  ".lvls",
+  ".facts",
+  ".x",
+  ".y",
+  ".dat"
+)
 
-  any(map_lgl(descrs, identical, y = x))
+is_descr <- function(x) {
+  x %in% .descr_names
 }
 
 # Helpers for overwriting descriptors temporarily ------------------------------

--- a/R/fit_helpers.R
+++ b/R/fit_helpers.R
@@ -16,7 +16,7 @@ form_form <-
             encoding_info$engine == object$engine
         )
 
-      remove_intercept <- encoding_info |> dplyr::pull(remove_intercept)
+      remove_intercept <- encoding_info$remove_intercept
       if (remove_intercept) {
         env$data <- env$data[,
           colnames(env$data) != "(Intercept)",
@@ -88,7 +88,7 @@ xy_xy <- function(
     get_encoding(class(object)[1]) |>
     dplyr::filter(mode == object$mode, engine == object$engine)
 
-  remove_intercept <- encoding_info |> dplyr::pull(remove_intercept)
+  remove_intercept <- encoding_info$remove_intercept
   if (remove_intercept) {
     env$x <- env$x[, colnames(env$x) != "(Intercept)", drop = FALSE]
   }
@@ -141,9 +141,9 @@ form_xy <- function(
     get_encoding(class(object)[1]) |>
     dplyr::filter(mode == object$mode, engine == object$engine)
 
-  indicators <- encoding_info |> dplyr::pull(predictor_indicators)
-  remove_intercept <- encoding_info |> dplyr::pull(remove_intercept)
-  allow_sparse_x <- encoding_info |> dplyr::pull(allow_sparse_x)
+  indicators <- encoding_info$predictor_indicators
+  remove_intercept <- encoding_info$remove_intercept
+  allow_sparse_x <- encoding_info$allow_sparse_x
 
   if (allow_sparse_x && sparsevctrs::has_sparse_elements(env$data)) {
     target <- "dgCMatrix"

--- a/R/translate.R
+++ b/R/translate.R
@@ -115,7 +115,7 @@ get_model_spec <- function(model, mode, engine) {
 
   res <- list()
 
-  libs <- rlang::env_get(m_env, paste0(model, "_pkgs"))
+  libs <- m_env[[paste0(model, "_pkgs")]]
   libs <- vctrs::vec_slice(libs$pkg, libs$engine == engine)
   res$libs <- if (length(libs) > 0) {
     libs[[1]]
@@ -123,7 +123,7 @@ get_model_spec <- function(model, mode, engine) {
     NULL
   }
 
-  fits <- rlang::env_get(m_env, paste0(model, "_fit"))
+  fits <- m_env[[paste0(model, "_fit")]]
   fits <- vctrs::vec_slice(
     fits$value,
     fits$mode == mode & fits$engine == engine
@@ -134,7 +134,7 @@ get_model_spec <- function(model, mode, engine) {
     NULL
   }
 
-  preds <- rlang::env_get(m_env, paste0(model, "_predict"))
+  preds <- m_env[[paste0(model, "_predict")]]
   where <- preds$mode == mode & preds$engine == engine
   types <- vctrs::vec_slice(preds$type, where)
   values <- vctrs::vec_slice(preds$value, where)
@@ -147,7 +147,7 @@ get_model_spec <- function(model, mode, engine) {
 get_args <- function(model, engine) {
   m_env <- get_model_env()
 
-  args <- rlang::env_get(m_env, paste0(model, "_args"))
+  args <- m_env[[paste0(model, "_args")]]
   args <- vctrs::vec_slice(args, args$engine == engine)
   args$engine <- NULL
 


### PR DESCRIPTION
This PR does a bunch of smaller changes to hopefully pull down the overhead of fit, to shut up that one test for a little while

## Before

``` r
library(parsnip)

bench::mark(
    time_engine = lm(mpg ~ ., mtcars),
    time_parsnip_form = fit(linear_reg(), mpg ~ ., mtcars),
    time_parsnip_xy = fit_xy(linear_reg(), mtcars[2:11], mtcars[1]),
    iterations = 10000,
    relative = TRUE,
    check = FALSE
)
#> # A tibble: 3 × 6
#>   expression          min median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>        <dbl>  <dbl>     <dbl>     <dbl>    <dbl>
#> 1 time_engine        1      1         2.90      1.43     1.73
#> 2 time_parsnip_form  2.42   2.39      1.22      7.48     1.02
#> 3 time_parsnip_xy    2.96   2.90      1         1        1
```

## After

``` r
library(parsnip)

bench::mark(
    time_engine = lm(mpg ~ ., mtcars),
    time_parsnip_form = fit(linear_reg(), mpg ~ ., mtcars),
    time_parsnip_xy = fit_xy(linear_reg(), mtcars[2:11], mtcars[1]),
    iterations = 10000,
    relative = TRUE,
    check = FALSE
)
#> # A tibble: 3 × 6
#>   expression          min median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>        <dbl>  <dbl>     <dbl>     <dbl>    <dbl>
#> 1 time_engine        1      1         2.23      2.06     1.69
#> 2 time_parsnip_form  1.96   1.95      1.15      9.08     1.00
#> 3 time_parsnip_xy    2.25   2.24      1         1        1
```