### PR TITLE
Fix `y_var` coming from `fit_xy()`

### DIFF
--- a/R/fit_helpers.R
+++ b/R/fit_helpers.R
@@ -119,10 +119,14 @@ xy_xy <- function(
   )
   elapsed <- proc.time() - time
 
-  if (is.atomic(env$y)) {
-    y_name <- character(0)
+  if (!is.null(env$y_var)) {
+    y_name <- env$y_var
   } else {
-    y_name <- colnames(env$y)
+    if (is.atomic(env$y)) {
+      y_name <- character(0)
+    } else {
+      y_name <- colnames(env$y)
+    }
   }
   res$preproc <- list(y_var = y_name, x_names = colnames(env$x))
   res$elapsed <- list(elapsed = elapsed, print = control$verbosity > 1L)

--- a/R/predict.R
+++ b/R/predict.R
@@ -569,8 +569,7 @@ prepare_data <- function(object, new_data) {
   translate_from_xy_to_formula <- any(preproc_names == "x_var", na.rm = TRUE)
   # For backwards compatibility, only do this if `y_var` is missing and
   # `x_names` is present
-  translate_from_xy_to_xy <- any(preproc_names == "x_names", na.rm = TRUE) &&
-    identical(object$preproc$y_var, character(0))
+  translate_from_xy_to_xy <- any(preproc_names == "x_names", na.rm = TRUE)
 
   if (translate_from_formula_to_xy) {
     new_data <- .convert_form_to_xy_new(object$preproc, new_data)$x


### PR DESCRIPTION
closes #1375 -- it was due to a change in #1372

The first commit has the breaking change from #1372 in it and we see tests breaking in same way and captured in #1375.

The second commit fixes it. Once this is on `main` I'll update #1372 with the change.

Long story short of what happened:
- I noticed that when we captured `y_var` from the matrix interface in `fit_xy()` in https://github.com/tidymodels/parsnip/pull/961, we only passed it through `xy_form()` but not `xy_xy()` and I fixed that when working on the survival PR. 
- Some engines with a matrix interface are strict in that they only want the predictors given to them for prediction - and xgboost happens to be one of them. That got fixed in https://github.com/tidymodels/parsnip/pull/1168 but it relied on the missing `y_var` in the xy-xy path as the path signal.
- So when I evened out the path, it broke the path signal. 
- I now let it rely on the `x_names` which were added for this purpose.
- I do think we should capture the path between interfaces in a flag instead of relying on the absence or presence of other things but as this whole story illustrates yet again, that should be its separate PR.