### PR TITLE
Fix case weights docs referring to fit()/fit_xy() as arguments

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # parsnip (development version)
 
+* Corrected documentation that referred to `fit()` and `fit_xy()` as arguments rather than functions in the case weights template (#1394).
+
 * Fitting with sparse data now respects the model mode, so loading an extension package that registers an engine for a different mode can no longer alter sparse data support for the original mode (#1382).
 
 * For censored regression models, the censoring weights can now be added to the predictions of survival probability by setting `add_censoring_weights = TRUE` in `predict(type = "survival")` (#1371).

--- a/man/details_C5_rules_C5.0.Rd
+++ b/man/details_C5_rules_C5.0.Rd
@@ -67,7 +67,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 }
 

--- a/man/details_auto_ml_h2o.Rd
+++ b/man/details_auto_ml_h2o.Rd
@@ -82,7 +82,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 }
 

--- a/man/details_bag_mars_earth.Rd
+++ b/man/details_bag_mars_earth.Rd
@@ -96,7 +96,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 
 Note that the \code{earth} package documentation has: “In the current

--- a/man/details_bag_mlp_nnet.Rd
+++ b/man/details_bag_mlp_nnet.Rd
@@ -94,7 +94,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 }
 

--- a/man/details_bag_tree_C5.0.Rd
+++ b/man/details_bag_tree_C5.0.Rd
@@ -57,7 +57,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 }
 

--- a/man/details_bag_tree_rpart.Rd
+++ b/man/details_bag_tree_rpart.Rd
@@ -139,7 +139,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 }
 

--- a/man/details_bart_dbarts.Rd
+++ b/man/details_bart_dbarts.Rd
@@ -127,7 +127,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 }
 

--- a/man/details_boost_tree_C5.0.Rd
+++ b/man/details_boost_tree_C5.0.Rd
@@ -64,7 +64,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 }
 

--- a/man/details_boost_tree_catboost.Rd
+++ b/man/details_boost_tree_catboost.Rd
@@ -144,7 +144,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 }
 

--- a/man/details_boost_tree_catboost.Rd
+++ b/man/details_boost_tree_catboost.Rd
@@ -13,11 +13,18 @@ catboost has native support for categorical predictors.
 For this engine, there are multiple modes: regression and classification
 \subsection{Tuning Parameters}{
 
-This model has 3 tuning parameters:
+This model has 7 tuning parameters:
 \itemize{
 \item \code{tree_depth}: Tree Depth (type: integer, default: 6L)
 \item \code{trees}: # Trees (type: integer, default: 1000L)
 \item \code{learn_rate}: Learning Rate (type: double, default: 0.03)
+\item \code{mtry}: Proportion Randomly Selected Predictors (type: double,
+default: see below)
+\item \code{min_n}: Minimal Node Size (type: integer, default: 1L)
+\item \code{sample_size}: Proportion Observations Sampled (type: double, default:
+see below)
+\item \code{stop_iter}: # Iterations Before Stopping (type: integer, default:
+Inf)
 }
 
 The \code{mtry} parameter controls the proportion of predictors that will be
@@ -75,9 +82,11 @@ The \strong{bonsai} extension package is required to fit this model.
 ## 
 ## Model fit template:
 ## bonsai::train_catboost(x = missing_arg(), y = missing_arg(), 
-##     weights = missing_arg(), iterations = integer(), depth = integer(), 
-##     learning_rate = numeric(), thread_count = 1, allow_writing_files = FALSE, 
-##     random_seed = sample.int(10^5, 1))
+##     weights = missing_arg(), rsm = integer(), iterations = integer(), 
+##     min_data_in_leaf = integer(), depth = integer(), learning_rate = numeric(), 
+##     subsample = numeric(), early_stopping_rounds = integer(), 
+##     thread_count = 1, allow_writing_files = FALSE, random_seed = sample.int(10^5, 
+##         1))
 }\if{html}{\out{</div>}}
 }
 
@@ -109,9 +118,11 @@ The \strong{bonsai} extension package is required to fit this model.
 ## 
 ## Model fit template:
 ## bonsai::train_catboost(x = missing_arg(), y = missing_arg(), 
-##     weights = missing_arg(), iterations = integer(), depth = integer(), 
-##     learning_rate = numeric(), thread_count = 1, allow_writing_files = FALSE, 
-##     random_seed = sample.int(10^5, 1))
+##     weights = missing_arg(), rsm = integer(), iterations = integer(), 
+##     min_data_in_leaf = integer(), depth = integer(), learning_rate = numeric(), 
+##     subsample = numeric(), early_stopping_rounds = integer(), 
+##     thread_count = 1, allow_writing_files = FALSE, random_seed = sample.int(10^5, 
+##         1))
 }\if{html}{\out{</div>}}
 
 \code{\link[bonsai:train_catboost]{bonsai::train_catboost()}} is a wrapper

--- a/man/details_boost_tree_h2o.Rd
+++ b/man/details_boost_tree_h2o.Rd
@@ -131,7 +131,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 }
 

--- a/man/details_boost_tree_lightgbm.Rd
+++ b/man/details_boost_tree_lightgbm.Rd
@@ -141,7 +141,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 
 Although the source documentation is unclear about how the weights are

--- a/man/details_boost_tree_spark.Rd
+++ b/man/details_boost_tree_spark.Rd
@@ -111,7 +111,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 
 Note that, for spark engines, the \code{case_weight} argument value should be

--- a/man/details_boost_tree_xgboost.Rd
+++ b/man/details_boost_tree_xgboost.Rd
@@ -171,7 +171,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 }
 

--- a/man/details_cubist_rules_Cubist.Rd
+++ b/man/details_cubist_rules_Cubist.Rd
@@ -65,7 +65,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 }
 

--- a/man/details_decision_tree_C5.0.Rd
+++ b/man/details_decision_tree_C5.0.Rd
@@ -55,7 +55,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 }
 

--- a/man/details_decision_tree_partykit.Rd
+++ b/man/details_decision_tree_partykit.Rd
@@ -131,7 +131,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 }
 

--- a/man/details_decision_tree_rpart.Rd
+++ b/man/details_decision_tree_rpart.Rd
@@ -123,7 +123,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 }
 

--- a/man/details_decision_tree_rpartScore.Rd
+++ b/man/details_decision_tree_rpartScore.Rd
@@ -62,7 +62,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 }
 

--- a/man/details_decision_tree_spark.Rd
+++ b/man/details_decision_tree_spark.Rd
@@ -78,7 +78,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 
 Note that, for spark engines, the \code{case_weight} argument value should be

--- a/man/details_discrim_flexible_earth.Rd
+++ b/man/details_discrim_flexible_earth.Rd
@@ -69,7 +69,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 }
 

--- a/man/details_discrim_linear_mda.Rd
+++ b/man/details_discrim_linear_mda.Rd
@@ -60,7 +60,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 }
 

--- a/man/details_gen_additive_mod_mgcv.Rd
+++ b/man/details_gen_additive_mod_mgcv.Rd
@@ -140,7 +140,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 }
 

--- a/man/details_gen_additive_mod_mgcv.Rd
+++ b/man/details_gen_additive_mod_mgcv.Rd
@@ -151,16 +151,16 @@ The \code{fit()} and \code{fit_xy()} functions have arguments called
   dplyr::select(mode, type)
 }\if{html}{\out{</div>}}
 
-\if{html}{\out{<div class="sourceCode">}}\preformatted{## # A tibble: 7 x 2
-##   mode           type    
-##   <chr>          <chr>   
-## 1 regression     numeric 
-## 2 regression     conf_int
-## 3 regression     raw     
-## 4 classification class   
-## 5 classification prob    
-## 6 classification raw     
-## # i 1 more row
+\if{html}{\out{<div class="sourceCode">}}\preformatted{## # A tibble: 8 x 2
+##   mode           type       
+##   <chr>          <chr>      
+## 1 regression     numeric    
+## 2 regression     conf_int   
+## 3 regression     linear_pred
+## 4 regression     raw        
+## 5 classification class      
+## 6 classification prob       
+## # i 2 more rows
 }\if{html}{\out{</div>}}
 }
 

--- a/man/details_gen_additive_mod_vgam.Rd
+++ b/man/details_gen_additive_mod_vgam.Rd
@@ -97,7 +97,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 }
 

--- a/man/details_linear_reg_glm.Rd
+++ b/man/details_linear_reg_glm.Rd
@@ -67,7 +67,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 
 \emph{However}, the documentation in \code{\link[stats:glm]{stats::glm()}} assumes

--- a/man/details_linear_reg_glmer.Rd
+++ b/man/details_linear_reg_glmer.Rd
@@ -122,7 +122,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 }
 

--- a/man/details_linear_reg_glmnet.Rd
+++ b/man/details_linear_reg_glmnet.Rd
@@ -64,7 +64,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 }
 

--- a/man/details_linear_reg_h2o.Rd
+++ b/man/details_linear_reg_h2o.Rd
@@ -77,7 +77,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 }
 

--- a/man/details_linear_reg_lm.Rd
+++ b/man/details_linear_reg_lm.Rd
@@ -43,7 +43,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 
 \emph{However}, the documentation in \code{\link[stats:lm]{stats::lm()}} assumes

--- a/man/details_linear_reg_lmer.Rd
+++ b/man/details_linear_reg_lmer.Rd
@@ -114,7 +114,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 }
 

--- a/man/details_linear_reg_quantreg.Rd
+++ b/man/details_linear_reg_quantreg.Rd
@@ -158,7 +158,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 }
 

--- a/man/details_linear_reg_spark.Rd
+++ b/man/details_linear_reg_spark.Rd
@@ -70,7 +70,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 
 Note that, for spark engines, the \code{case_weight} argument value should be

--- a/man/details_linear_reg_stan.Rd
+++ b/man/details_linear_reg_stan.Rd
@@ -79,7 +79,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 }
 

--- a/man/details_linear_reg_stan_glmer.Rd
+++ b/man/details_linear_reg_stan_glmer.Rd
@@ -140,7 +140,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 }
 

--- a/man/details_logistic_reg_glm.Rd
+++ b/man/details_logistic_reg_glm.Rd
@@ -67,7 +67,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 
 \emph{However}, the documentation in \code{\link[stats:glm]{stats::glm()}} assumes

--- a/man/details_logistic_reg_glmer.Rd
+++ b/man/details_logistic_reg_glmer.Rd
@@ -114,7 +114,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 }
 

--- a/man/details_logistic_reg_glmnet.Rd
+++ b/man/details_logistic_reg_glmnet.Rd
@@ -69,7 +69,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 }
 

--- a/man/details_logistic_reg_h2o.Rd
+++ b/man/details_logistic_reg_h2o.Rd
@@ -111,7 +111,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 }
 

--- a/man/details_logistic_reg_spark.Rd
+++ b/man/details_logistic_reg_spark.Rd
@@ -72,7 +72,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 
 Note that, for spark engines, the \code{case_weight} argument value should be

--- a/man/details_logistic_reg_stan.Rd
+++ b/man/details_logistic_reg_stan.Rd
@@ -80,7 +80,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 }
 

--- a/man/details_logistic_reg_stan_glmer.Rd
+++ b/man/details_logistic_reg_stan_glmer.Rd
@@ -139,7 +139,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 }
 

--- a/man/details_mars_earth.Rd
+++ b/man/details_mars_earth.Rd
@@ -90,7 +90,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 
 Note that the \code{earth} package documentation has: “In the current

--- a/man/details_mlp_h2o.Rd
+++ b/man/details_mlp_h2o.Rd
@@ -145,7 +145,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 }
 

--- a/man/details_mlp_nnet.Rd
+++ b/man/details_mlp_nnet.Rd
@@ -100,7 +100,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 }
 

--- a/man/details_multinom_reg_glmnet.Rd
+++ b/man/details_multinom_reg_glmnet.Rd
@@ -75,7 +75,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 }
 

--- a/man/details_multinom_reg_h2o.Rd
+++ b/man/details_multinom_reg_h2o.Rd
@@ -78,7 +78,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 }
 

--- a/man/details_multinom_reg_spark.Rd
+++ b/man/details_multinom_reg_spark.Rd
@@ -71,7 +71,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 
 Note that, for spark engines, the \code{case_weight} argument value should be

--- a/man/details_naive_Bayes_h2o.Rd
+++ b/man/details_naive_Bayes_h2o.Rd
@@ -63,7 +63,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 }
 

--- a/man/details_ordinal_reg_ordinalNet.Rd
+++ b/man/details_ordinal_reg_ordinalNet.Rd
@@ -109,7 +109,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 }
 

--- a/man/details_ordinal_reg_vglm.Rd
+++ b/man/details_ordinal_reg_vglm.Rd
@@ -59,7 +59,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 
 \emph{However}, the documentation in \code{\link[VGAM:vglm]{VGAM::vglm()}} notes

--- a/man/details_poisson_reg_glm.Rd
+++ b/man/details_poisson_reg_glm.Rd
@@ -48,7 +48,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 }
 
@@ -58,7 +58,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 
 \emph{However}, the documentation in \code{\link[stats:glm]{stats::glm()}} assumes

--- a/man/details_poisson_reg_glmer.Rd
+++ b/man/details_poisson_reg_glmer.Rd
@@ -113,7 +113,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 }
 

--- a/man/details_poisson_reg_glmnet.Rd
+++ b/man/details_poisson_reg_glmnet.Rd
@@ -72,7 +72,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 }
 

--- a/man/details_poisson_reg_h2o.Rd
+++ b/man/details_poisson_reg_h2o.Rd
@@ -82,7 +82,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 }
 

--- a/man/details_poisson_reg_hurdle.Rd
+++ b/man/details_poisson_reg_hurdle.Rd
@@ -120,7 +120,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 }
 

--- a/man/details_poisson_reg_stan.Rd
+++ b/man/details_poisson_reg_stan.Rd
@@ -82,7 +82,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 }
 

--- a/man/details_poisson_reg_stan_glmer.Rd
+++ b/man/details_poisson_reg_stan_glmer.Rd
@@ -138,7 +138,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 }
 

--- a/man/details_poisson_reg_zeroinfl.Rd
+++ b/man/details_poisson_reg_zeroinfl.Rd
@@ -121,7 +121,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 }
 

--- a/man/details_proportional_hazards_glmnet.Rd
+++ b/man/details_proportional_hazards_glmnet.Rd
@@ -143,7 +143,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 }
 

--- a/man/details_proportional_hazards_survival.Rd
+++ b/man/details_proportional_hazards_survival.Rd
@@ -124,7 +124,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 }
 

--- a/man/details_rand_forest_aorsf.Rd
+++ b/man/details_rand_forest_aorsf.Rd
@@ -111,7 +111,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 }
 

--- a/man/details_rand_forest_h2o.Rd
+++ b/man/details_rand_forest_h2o.Rd
@@ -102,7 +102,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 }
 

--- a/man/details_rand_forest_ordinalForest.Rd
+++ b/man/details_rand_forest_ordinalForest.Rd
@@ -71,7 +71,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 }
 

--- a/man/details_rand_forest_partykit.Rd
+++ b/man/details_rand_forest_partykit.Rd
@@ -106,7 +106,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 }
 

--- a/man/details_rand_forest_randomForest.Rd
+++ b/man/details_rand_forest_randomForest.Rd
@@ -102,7 +102,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 
 Note that the data passed to the \code{case.weights} column are not used for

--- a/man/details_rand_forest_randomForestSRC.Rd
+++ b/man/details_rand_forest_randomForestSRC.Rd
@@ -23,6 +23,8 @@ ceiling(sqrt(n_predictors)))
 
 \subsection{Translation from parsnip to the original package (censored regression)}{
 
+The \strong{censored} extension package is required to fit this model.
+
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{library(censored)
 
 rand_forest() |>

--- a/man/details_rand_forest_randomForestSRC.Rd
+++ b/man/details_rand_forest_randomForestSRC.Rd
@@ -59,7 +59,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 }
 

--- a/man/details_rand_forest_ranger.Rd
+++ b/man/details_rand_forest_ranger.Rd
@@ -155,7 +155,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 
 Note that the data passed to the \code{case.weights} column are not used for

--- a/man/details_rand_forest_spark.Rd
+++ b/man/details_rand_forest_spark.Rd
@@ -119,7 +119,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 
 Note that, for spark engines, the \code{case_weight} argument value should be

--- a/man/details_rule_fit_h2o.Rd
+++ b/man/details_rule_fit_h2o.Rd
@@ -118,7 +118,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 }
 

--- a/man/details_rule_fit_xrf.Rd
+++ b/man/details_rule_fit_xrf.Rd
@@ -12,18 +12,20 @@ is a wrapper around this function.
 For this engine, there are multiple modes: classification and regression
 \subsection{Tuning Parameters}{
 
-This model has 8 tuning parameters:
+This model has 9 tuning parameters:
 \itemize{
-\item \code{mtry}: Proportion Randomly Selected Predictors (type: double,
-default: see below)
-\item \code{trees}: # Trees (type: integer, default: 15L)
-\item \code{min_n}: Minimal Node Size (type: integer, default: 1L)
 \item \code{tree_depth}: Tree Depth (type: integer, default: 6L)
+\item \code{trees}: # Trees (type: integer, default: 15L)
 \item \code{learn_rate}: Learning Rate (type: double, default: 0.3)
+\item \code{mtry}: # Randomly Selected Predictors (type: integer, default: see
+below)
+\item \code{min_n}: Minimal Node Size (type: integer, default: 1L)
 \item \code{loss_reduction}: Minimum Loss Reduction (type: double, default: 0.0)
 \item \code{sample_size}: Proportion Observations Sampled (type: double, default:
 1.0)
 \item \code{penalty}: Amount of Regularization (type: double, default: 0.1)
+\item \code{stop_iter}: # Iterations Before Stopping (type: integer, default:
+Inf)
 }
 }
 

--- a/man/details_survival_reg_flexsurv.Rd
+++ b/man/details_survival_reg_flexsurv.Rd
@@ -61,7 +61,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 }
 

--- a/man/details_survival_reg_flexsurvspline.Rd
+++ b/man/details_survival_reg_flexsurvspline.Rd
@@ -58,7 +58,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 }
 

--- a/man/details_survival_reg_survival.Rd
+++ b/man/details_survival_reg_survival.Rd
@@ -94,7 +94,7 @@ This model can utilize case weights during model fitting. To use them,
 see the documentation in \link{case_weights} and the examples
 on \code{tidymodels.org}.
 
-The \code{fit()} and \code{fit_xy()} arguments have arguments called
+The \code{fit()} and \code{fit_xy()} functions have arguments called
 \code{case_weights} that expect vectors of case weights.
 }
 

--- a/man/rmd/C5_rules_C5.0.md
+++ b/man/rmd/C5_rules_C5.0.md
@@ -56,7 +56,7 @@ This engine does not require any special encoding of the predictors. Categorical
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 ## Prediction types
 

--- a/man/rmd/auto_ml_h2o.md
+++ b/man/rmd/auto_ml_h2o.md
@@ -70,7 +70,7 @@ Factor/categorical predictors need to be converted to numeric values (e.g., dumm
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 ## Initializing h2o 
 

--- a/man/rmd/bag_mars_earth.md
+++ b/man/rmd/bag_mars_earth.md
@@ -89,7 +89,7 @@ Factor/categorical predictors need to be converted to numeric values (e.g., dumm
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 Note that the `earth` package documentation has: "In the current implementation, _building models with weights can be slow_."
 

--- a/man/rmd/bag_mlp_nnet.md
+++ b/man/rmd/bag_mlp_nnet.md
@@ -91,7 +91,7 @@ scale each so that each predictor has mean zero and a variance of one.
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 ## Prediction types
 

--- a/man/rmd/bag_tree_C5.0.md
+++ b/man/rmd/bag_tree_C5.0.md
@@ -49,7 +49,7 @@ This engine does not require any special encoding of the predictors. Categorical
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 ## Prediction types
 

--- a/man/rmd/bag_tree_rpart.md
+++ b/man/rmd/bag_tree_rpart.md
@@ -134,7 +134,7 @@ This engine does not require any special encoding of the predictors. Categorical
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 ## Prediction types
 

--- a/man/rmd/bart_dbarts.md
+++ b/man/rmd/bart_dbarts.md
@@ -116,7 +116,7 @@ Factor/categorical predictors need to be converted to numeric values (e.g., dumm
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 ## Prediction types
 

--- a/man/rmd/boost_tree_C5.0.md
+++ b/man/rmd/boost_tree_C5.0.md
@@ -54,7 +54,7 @@ This engine does not require any special encoding of the predictors. Categorical
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 ## Prediction types
 

--- a/man/rmd/boost_tree_catboost.md
+++ b/man/rmd/boost_tree_catboost.md
@@ -7,13 +7,21 @@ For this engine, there are multiple modes: regression and classification
 
 
 
-This model has 3 tuning parameters:
+This model has 7 tuning parameters:
 
 - `tree_depth`: Tree Depth (type: integer, default: 6L)
 
 - `trees`: # Trees (type: integer, default: 1000L)
 
 - `learn_rate`: Learning Rate (type: double, default: 0.03)
+
+- `mtry`: Proportion Randomly Selected Predictors (type: double, default: see below)
+
+- `min_n`: Minimal Node Size (type: integer, default: 1L)
+
+- `sample_size`: Proportion Observations Sampled (type: double, default: see below)
+
+- `stop_iter`: # Iterations Before Stopping (type: integer, default: Inf)
 
 The `mtry` parameter controls the proportion of predictors that will be randomly sampled at each split. catboost's `rsm` argument natively expects a proportion between 0 and 1. The default is to use all predictors (`rsm = 1`).
 
@@ -60,9 +68,11 @@ boost_tree(
 ## 
 ## Model fit template:
 ## bonsai::train_catboost(x = missing_arg(), y = missing_arg(), 
-##     weights = missing_arg(), iterations = integer(), depth = integer(), 
-##     learning_rate = numeric(), thread_count = 1, allow_writing_files = FALSE, 
-##     random_seed = sample.int(10^5, 1))
+##     weights = missing_arg(), rsm = integer(), iterations = integer(), 
+##     min_data_in_leaf = integer(), depth = integer(), learning_rate = numeric(), 
+##     subsample = numeric(), early_stopping_rounds = integer(), 
+##     thread_count = 1, allow_writing_files = FALSE, random_seed = sample.int(10^5, 
+##         1))
 ```
 
 ## Translation from parsnip to the original package (classification)
@@ -96,9 +106,11 @@ boost_tree(
 ## 
 ## Model fit template:
 ## bonsai::train_catboost(x = missing_arg(), y = missing_arg(), 
-##     weights = missing_arg(), iterations = integer(), depth = integer(), 
-##     learning_rate = numeric(), thread_count = 1, allow_writing_files = FALSE, 
-##     random_seed = sample.int(10^5, 1))
+##     weights = missing_arg(), rsm = integer(), iterations = integer(), 
+##     min_data_in_leaf = integer(), depth = integer(), learning_rate = numeric(), 
+##     subsample = numeric(), early_stopping_rounds = integer(), 
+##     thread_count = 1, allow_writing_files = FALSE, random_seed = sample.int(10^5, 
+##         1))
 ```
 
 [bonsai::train_catboost()] is a wrapper around `catboost::catboost.train()` (and other functions) that makes it easier to run this model.

--- a/man/rmd/boost_tree_catboost.md
+++ b/man/rmd/boost_tree_catboost.md
@@ -117,7 +117,7 @@ Non-numeric predictors (i.e., factors) are internally converted to numeric using
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 ## Prediction types
 

--- a/man/rmd/boost_tree_h2o.md
+++ b/man/rmd/boost_tree_h2o.md
@@ -118,7 +118,7 @@ Non-numeric predictors (i.e., factors) are internally converted to numeric. In t
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 ## Interpreting `mtry`
 

--- a/man/rmd/boost_tree_lightgbm.md
+++ b/man/rmd/boost_tree_lightgbm.md
@@ -119,7 +119,7 @@ Non-numeric predictors (i.e., factors) are internally converted to numeric. In t
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 Although the source documentation is unclear about how the weights are utilized, it appears that the weights are applied to the objective function, not just the sampling mechanism. A GitHub issue ([`https://github.com/lightgbm-org/LightGBM/issues/1299`](https://github.com/lightgbm-org/LightGBM/issues/1299)) has evidence that the weights are a "multiplication applied to every positive label weight" and shows some C++ code to that effect.
 

--- a/man/rmd/boost_tree_spark.md
+++ b/man/rmd/boost_tree_spark.md
@@ -105,7 +105,7 @@ This engine does not require any special encoding of the predictors. Categorical
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 Note that, for spark engines, the `case_weight` argument value should be a character string to specify the column with the numeric case weights. 
 

--- a/man/rmd/boost_tree_xgboost.md
+++ b/man/rmd/boost_tree_xgboost.md
@@ -157,7 +157,7 @@ For classification, non-numeric outcomes (i.e., factors) are internally converte
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 ## Prediction types
 

--- a/man/rmd/cubist_rules_Cubist.md
+++ b/man/rmd/cubist_rules_Cubist.md
@@ -60,7 +60,7 @@ This engine does not require any special encoding of the predictors. Categorical
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 
 ## Prediction types

--- a/man/rmd/decision_tree_C5.0.md
+++ b/man/rmd/decision_tree_C5.0.md
@@ -46,7 +46,7 @@ This engine does not require any special encoding of the predictors. Categorical
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 ## Prediction types
 

--- a/man/rmd/decision_tree_partykit.md
+++ b/man/rmd/decision_tree_partykit.md
@@ -120,7 +120,7 @@ This engine does not require any special encoding of the predictors. Categorical
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 ## Prediction types
 

--- a/man/rmd/decision_tree_rpart.md
+++ b/man/rmd/decision_tree_rpart.md
@@ -121,7 +121,7 @@ This engine does not require any special encoding of the predictors. Categorical
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 ## Prediction types
 

--- a/man/rmd/decision_tree_rpartScore.md
+++ b/man/rmd/decision_tree_rpartScore.md
@@ -55,7 +55,7 @@ This engine does not require any special encoding of the predictors. Categorical
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 ## Prediction types
 

--- a/man/rmd/decision_tree_spark.md
+++ b/man/rmd/decision_tree_spark.md
@@ -74,7 +74,7 @@ This engine does not require any special encoding of the predictors. Categorical
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 Note that, for spark engines, the `case_weight` argument value should be a character string to specify the column with the numeric case weights. 
 

--- a/man/rmd/discrim_flexible_earth.md
+++ b/man/rmd/discrim_flexible_earth.md
@@ -59,7 +59,7 @@ Factor/categorical predictors need to be converted to numeric values (e.g., dumm
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 ## Prediction types
 

--- a/man/rmd/discrim_linear_mda.md
+++ b/man/rmd/discrim_linear_mda.md
@@ -53,7 +53,7 @@ Variance calculations are used in these computations so _zero-variance_ predicto
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 ## Prediction types
 

--- a/man/rmd/gen_additive_mod_mgcv.md
+++ b/man/rmd/gen_additive_mod_mgcv.md
@@ -150,16 +150,16 @@ parsnip:::get_from_env("gen_additive_mod_predict") |>
 ```
 
 ```
-## # A tibble: 7 x 2
-##   mode           type    
-##   <chr>          <chr>   
-## 1 regression     numeric 
-## 2 regression     conf_int
-## 3 regression     raw     
-## 4 classification class   
-## 5 classification prob    
-## 6 classification raw     
-## # i 1 more row
+## # A tibble: 8 x 2
+##   mode           type       
+##   <chr>          <chr>      
+## 1 regression     numeric    
+## 2 regression     conf_int   
+## 3 regression     linear_pred
+## 4 regression     raw        
+## 5 classification class      
+## 6 classification prob       
+## # i 2 more rows
 ```
 
 ## Saving fitted model objects

--- a/man/rmd/gen_additive_mod_mgcv.md
+++ b/man/rmd/gen_additive_mod_mgcv.md
@@ -138,7 +138,7 @@ Factor/categorical predictors need to be converted to numeric values (e.g., dumm
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 ## Prediction types
 

--- a/man/rmd/gen_additive_mod_vgam.md
+++ b/man/rmd/gen_additive_mod_vgam.md
@@ -83,7 +83,7 @@ Factor/categorical predictors need to be converted to numeric values (e.g., dumm
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 ## Prediction types
 

--- a/man/rmd/linear_reg_glm.md
+++ b/man/rmd/linear_reg_glm.md
@@ -58,7 +58,7 @@ Factor/categorical predictors need to be converted to numeric values (e.g., dumm
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 _However_, the documentation in [stats::glm()] assumes that is specific type of case weights are being used:"Non-NULL weights can be used to indicate that different observations have different dispersions (with the values in weights being inversely proportional to the dispersions); or equivalently, when the elements of weights are positive integers `w_i`, that each response `y_i` is the mean of `w_i` unit-weight observations. For a binomial GLM prior weights are used to give the number of trials when the response is the proportion of successes: they would rarely be used for a Poisson GLM."
 

--- a/man/rmd/linear_reg_glmer.md
+++ b/man/rmd/linear_reg_glmer.md
@@ -103,7 +103,7 @@ fit(glmer_wflow, data = riesby)
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 ## Prediction types
 

--- a/man/rmd/linear_reg_glmnet.md
+++ b/man/rmd/linear_reg_glmnet.md
@@ -55,7 +55,7 @@ By default, [glmnet::glmnet()] uses the argument `standardize = TRUE` to center 
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 ## Prediction types
 

--- a/man/rmd/linear_reg_h2o.md
+++ b/man/rmd/linear_reg_h2o.md
@@ -61,7 +61,7 @@ By default, [h2o::h2o.glm()] uses the argument `standardize = TRUE` to center an
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 ## Prediction types
 

--- a/man/rmd/linear_reg_lm.md
+++ b/man/rmd/linear_reg_lm.md
@@ -35,7 +35,7 @@ Factor/categorical predictors need to be converted to numeric values (e.g., dumm
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 _However_, the documentation in [stats::lm()] assumes that is specific type of case weights are being used: "Non-NULL weights can be used to indicate that different observations have different variances (with the values in weights being inversely proportional to the variances); or equivalently, when the elements of weights are positive integers `w_i`, that each response `y_i` is the mean of `w_i` unit-weight observations (including the case that there are w_i observations equal to `y_i` and the data have been summarized). However, in the latter case, notice that within-group variation is not used. Therefore, the sigma estimate and residual degrees of freedom may be suboptimal; in the case of replication weights, **even wrong**. Hence, standard errors and analysis of variance tables should be treated with care" (emphasis added)
 

--- a/man/rmd/linear_reg_lmer.md
+++ b/man/rmd/linear_reg_lmer.md
@@ -94,7 +94,7 @@ fit(lmer_wflow, data = riesby)
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 ## Prediction types
 

--- a/man/rmd/linear_reg_quantreg.md
+++ b/man/rmd/linear_reg_quantreg.md
@@ -154,7 +154,7 @@ parsnip:::get_from_env("linear_reg_predict") |>
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 ## Saving fitted model objects
 

--- a/man/rmd/linear_reg_spark.md
+++ b/man/rmd/linear_reg_spark.md
@@ -59,7 +59,7 @@ By default, `ml_linear_regression()` uses the argument `standardization = TRUE` 
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 Note that, for spark engines, the `case_weight` argument value should be a character string to specify the column with the numeric case weights. 
 

--- a/man/rmd/linear_reg_stan.md
+++ b/man/rmd/linear_reg_stan.md
@@ -55,7 +55,7 @@ For prediction, the `"stan"` engine can compute posterior  intervals analogous t
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 ## Prediction types
 

--- a/man/rmd/linear_reg_stan_glmer.md
+++ b/man/rmd/linear_reg_stan_glmer.md
@@ -110,7 +110,7 @@ For prediction, the `"stan_glmer"` engine can compute posterior intervals analog
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 ## Prediction types
 

--- a/man/rmd/logistic_reg_glm.md
+++ b/man/rmd/logistic_reg_glm.md
@@ -58,7 +58,7 @@ Factor/categorical predictors need to be converted to numeric values (e.g., dumm
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 _However_, the documentation in [stats::glm()] assumes that is specific type of case weights are being used:"Non-NULL weights can be used to indicate that different observations have different dispersions (with the values in weights being inversely proportional to the dispersions); or equivalently, when the elements of weights are positive integers `w_i`, that each response `y_i` is the mean of `w_i` unit-weight observations. For a binomial GLM prior weights are used to give the number of trials when the response is the proportion of successes: they would rarely be used for a Poisson GLM."
 

--- a/man/rmd/logistic_reg_glmer.md
+++ b/man/rmd/logistic_reg_glmer.md
@@ -94,7 +94,7 @@ fit(glmer_wflow, data = toenail)
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 ## Prediction types
 

--- a/man/rmd/logistic_reg_glmnet.md
+++ b/man/rmd/logistic_reg_glmnet.md
@@ -57,7 +57,7 @@ By default, [glmnet::glmnet()] uses the argument `standardize = TRUE` to center 
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 ## Prediction types
 

--- a/man/rmd/logistic_reg_h2o.md
+++ b/man/rmd/logistic_reg_h2o.md
@@ -97,7 +97,7 @@ parsnip:::get_from_env("logistic_reg_predict") |>
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 ## Initializing h2o 
 

--- a/man/rmd/logistic_reg_spark.md
+++ b/man/rmd/logistic_reg_spark.md
@@ -59,7 +59,7 @@ By default, `ml_logistic_regression()` uses the argument `standardization = TRUE
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 Note that, for spark engines, the `case_weight` argument value should be a character string to specify the column with the numeric case weights. 
 

--- a/man/rmd/logistic_reg_stan.md
+++ b/man/rmd/logistic_reg_stan.md
@@ -55,7 +55,7 @@ For prediction, the `"stan"` engine can compute posterior intervals analogous to
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 ## Prediction types
 

--- a/man/rmd/logistic_reg_stan_glmer.md
+++ b/man/rmd/logistic_reg_stan_glmer.md
@@ -109,7 +109,7 @@ For prediction, the `"stan_glmer"` engine can compute posterior intervals analog
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 ## Prediction types
 

--- a/man/rmd/mars_earth.md
+++ b/man/rmd/mars_earth.md
@@ -85,7 +85,7 @@ Factor/categorical predictors need to be converted to numeric values (e.g., dumm
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 Note that the `earth` package documentation has: "In the current implementation, _building models with weights can be slow_."
 

--- a/man/rmd/mlp_h2o.md
+++ b/man/rmd/mlp_h2o.md
@@ -127,7 +127,7 @@ By default, [h2o::h2o.deeplearning()] uses the argument `standardize = TRUE` to 
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 ## Prediction types
 

--- a/man/rmd/mlp_nnet.md
+++ b/man/rmd/mlp_nnet.md
@@ -95,7 +95,7 @@ scale each so that each predictor has mean zero and a variance of one.
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 
 ## Prediction types

--- a/man/rmd/multinom_reg_glmnet.md
+++ b/man/rmd/multinom_reg_glmnet.md
@@ -61,7 +61,7 @@ The "Fitting and Predicting with parsnip" [article](https://www.tidymodels.org/l
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 ## Prediction types
 

--- a/man/rmd/multinom_reg_h2o.md
+++ b/man/rmd/multinom_reg_h2o.md
@@ -60,7 +60,7 @@ By default, [h2o::h2o.glm()] uses the argument `standardize = TRUE` to center an
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 ## Prediction types
 

--- a/man/rmd/multinom_reg_spark.md
+++ b/man/rmd/multinom_reg_spark.md
@@ -59,7 +59,7 @@ By default, `ml_multinom_regression()` uses the argument `standardization = TRUE
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 Note that, for spark engines, the `case_weight` argument value should be a character string to specify the column with the numeric case weights. 
 

--- a/man/rmd/naive_Bayes_h2o.md
+++ b/man/rmd/naive_Bayes_h2o.md
@@ -54,7 +54,7 @@ naive_Bayes(Laplace = numeric(0)) |>
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 ## Prediction types
 

--- a/man/rmd/ordinal_reg_ordinalNet.md
+++ b/man/rmd/ordinal_reg_ordinalNet.md
@@ -90,7 +90,7 @@ By default, [ordinalNet::ordinalNet()] uses the argument `standardize = TRUE` to
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 ## Prediction types
 

--- a/man/rmd/ordinal_reg_vglm.md
+++ b/man/rmd/ordinal_reg_vglm.md
@@ -52,7 +52,7 @@ Factor/categorical predictors need to be converted to numeric values (e.g., dumm
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 _However_, the documentation in [VGAM::vglm()] notes that matrix of case weights can be passed so that different classes have different weights. tidymodels assumes vector of a weights; a matrix cannot be passed in. 
 

--- a/man/rmd/poisson_reg_glm.md
+++ b/man/rmd/poisson_reg_glm.md
@@ -40,7 +40,7 @@ Factor/categorical predictors need to be converted to numeric values (e.g., dumm
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 
 ## Case weights
@@ -48,7 +48,7 @@ The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that e
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 _However_, the documentation in [stats::glm()] assumes that is specific type of case weights are being used:"Non-NULL weights can be used to indicate that different observations have different dispersions (with the values in weights being inversely proportional to the dispersions); or equivalently, when the elements of weights are positive integers `w_i`, that each response `y_i` is the mean of `w_i` unit-weight observations. For a binomial GLM prior weights are used to give the number of trials when the response is the proportion of successes: they would rarely be used for a Poisson GLM."
 

--- a/man/rmd/poisson_reg_glmer.md
+++ b/man/rmd/poisson_reg_glmer.md
@@ -93,7 +93,7 @@ fit(glmer_wflow, data = longitudinal_counts)
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 ## Prediction types
 

--- a/man/rmd/poisson_reg_glmnet.md
+++ b/man/rmd/poisson_reg_glmnet.md
@@ -62,7 +62,7 @@ By default, `glmnet::glmnet()` uses the argument `standardize = TRUE` to center 
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 ## Prediction types
 

--- a/man/rmd/poisson_reg_h2o.md
+++ b/man/rmd/poisson_reg_h2o.md
@@ -64,7 +64,7 @@ By default, `h2o::h2o.glm()` uses the argument `standardize = TRUE` to center an
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 ## Prediction types
 

--- a/man/rmd/poisson_reg_hurdle.md
+++ b/man/rmd/poisson_reg_hurdle.md
@@ -106,7 +106,7 @@ The reason for this is that [workflows::add_formula()] will try to create the mo
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 ## Prediction types
 

--- a/man/rmd/poisson_reg_stan.md
+++ b/man/rmd/poisson_reg_stan.md
@@ -59,7 +59,7 @@ For prediction, the `"stan"` engine can compute posterior intervals analogous to
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 ## Prediction types
 

--- a/man/rmd/poisson_reg_stan_glmer.md
+++ b/man/rmd/poisson_reg_stan_glmer.md
@@ -108,7 +108,7 @@ For prediction, the `"stan_glmer"` engine can compute posterior intervals analog
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 ## Prediction types
 

--- a/man/rmd/poisson_reg_zeroinfl.md
+++ b/man/rmd/poisson_reg_zeroinfl.md
@@ -107,7 +107,7 @@ The reason for this is that [workflows::add_formula()] will try to create the mo
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 ## Prediction types
 

--- a/man/rmd/proportional_hazards_glmnet.md
+++ b/man/rmd/proportional_hazards_glmnet.md
@@ -117,7 +117,7 @@ This behavior can be changed by using the `increasing` argument when calling `pr
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 ## Saving fitted model objects
 

--- a/man/rmd/proportional_hazards_survival.md
+++ b/man/rmd/proportional_hazards_survival.md
@@ -104,7 +104,7 @@ This behavior can be changed by using the `increasing` argument when calling `pr
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 ## Prediction types
 

--- a/man/rmd/rand_forest_aorsf.md
+++ b/man/rmd/rand_forest_aorsf.md
@@ -100,7 +100,7 @@ This engine does not require any special encoding of the predictors. Categorical
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 ## Prediction types
 

--- a/man/rmd/rand_forest_h2o.md
+++ b/man/rmd/rand_forest_h2o.md
@@ -91,7 +91,7 @@ This engine does not require any special encoding of the predictors. Categorical
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 ## Prediction types
 

--- a/man/rmd/rand_forest_ordinalForest.md
+++ b/man/rmd/rand_forest_ordinalForest.md
@@ -60,7 +60,7 @@ This engine does not require any special encoding of the predictors. Categorical
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 ## Other notes
 

--- a/man/rmd/rand_forest_partykit.md
+++ b/man/rmd/rand_forest_partykit.md
@@ -102,7 +102,7 @@ This engine does not require any special encoding of the predictors. Categorical
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 ## Prediction types
 

--- a/man/rmd/rand_forest_randomForest.md
+++ b/man/rmd/rand_forest_randomForest.md
@@ -92,7 +92,7 @@ This engine does not require any special encoding of the predictors. Categorical
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 Note that the data passed to the `case.weights` column are not used for traditional case weights (where the objective function is multiplied by a row-specific weight). From `?randomForest::randomForest`: "A vector of length same as`y` that are positive weights used only in sampling data to grow each tree (not used in any other calculation)."
 

--- a/man/rmd/rand_forest_randomForestSRC.md
+++ b/man/rmd/rand_forest_randomForestSRC.md
@@ -17,7 +17,7 @@ This model has 3 tuning parameters:
 
 ## Translation from parsnip to the original package (censored regression)
 
-
+The **censored** extension package is required to fit this model.
 
 
 ``` r

--- a/man/rmd/rand_forest_randomForestSRC.md
+++ b/man/rmd/rand_forest_randomForestSRC.md
@@ -51,7 +51,7 @@ This engine does not require any special encoding of the predictors. Categorical
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 ## Prediction types
 

--- a/man/rmd/rand_forest_ranger.md
+++ b/man/rmd/rand_forest_ranger.md
@@ -137,7 +137,7 @@ For `ranger` confidence intervals, the intervals are  constructed using the form
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 Note that the data passed to the `case.weights` column are not used for traditional case weights (where the objective function is multiplied by a row-specific weight). From `?ranger::ranger`: "Observations with larger weights will be selected with higher probability in the bootstrap (or subsampled) samples for the trees."
 

--- a/man/rmd/rand_forest_spark.md
+++ b/man/rmd/rand_forest_spark.md
@@ -101,7 +101,7 @@ For models created using the `"spark"` engine, there are several things to consi
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 Note that, for spark engines, the `case_weight` argument value should be a character string to specify the column with the numeric case weights. 
 

--- a/man/rmd/rule_fit_h2o.md
+++ b/man/rmd/rule_fit_h2o.md
@@ -108,7 +108,7 @@ Factor/categorical predictors need to be converted to numeric values (e.g., dumm
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 ## Prediction types
 

--- a/man/rmd/rule_fit_xrf.md
+++ b/man/rmd/rule_fit_xrf.md
@@ -7,23 +7,25 @@ For this engine, there are multiple modes: classification and regression
 
 
 
-This model has 8 tuning parameters:
-
-- `mtry`: Proportion Randomly Selected Predictors (type: double, default: see below)
-
-- `trees`: # Trees (type: integer, default: 15L)
-
-- `min_n`: Minimal Node Size (type: integer, default: 1L)
+This model has 9 tuning parameters:
 
 - `tree_depth`: Tree Depth (type: integer, default: 6L)
 
+- `trees`: # Trees (type: integer, default: 15L)
+
 - `learn_rate`: Learning Rate (type: double, default: 0.3)
+
+- `mtry`: # Randomly Selected Predictors (type: integer, default: see below)
+
+- `min_n`: Minimal Node Size (type: integer, default: 1L)
 
 - `loss_reduction`: Minimum Loss Reduction (type: double, default: 0.0)
 
 - `sample_size`: Proportion Observations Sampled (type: double, default: 1.0)
 
 - `penalty`: Amount of Regularization (type: double, default: 0.1)
+
+- `stop_iter`: # Iterations Before Stopping (type: integer, default: Inf)
 
 
 ## Translation from parsnip to the underlying model call  (regression)

--- a/man/rmd/survival_reg_flexsurv.md
+++ b/man/rmd/survival_reg_flexsurv.md
@@ -53,7 +53,7 @@ Predictions of type `"time"` are predictions of the mean survival time.
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 ## Saving fitted model objects
 

--- a/man/rmd/survival_reg_flexsurvspline.md
+++ b/man/rmd/survival_reg_flexsurvspline.md
@@ -48,7 +48,7 @@ Predictions of type `"time"` are predictions of the mean survival time.
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 ## Prediction types
 

--- a/man/rmd/survival_reg_survival.md
+++ b/man/rmd/survival_reg_survival.md
@@ -84,7 +84,7 @@ Predictions of type `"time"` are predictions of the mean survival time.
 
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 
 
 ## Prediction types
 

--- a/man/rmd/template-uses-case-weights.Rmd
+++ b/man/rmd/template-uses-case-weights.Rmd
@@ -1,3 +1,3 @@
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 

--- a/man/rmd/template-uses-case-weights.md
+++ b/man/rmd/template-uses-case-weights.md
@@ -1,3 +1,3 @@
 This model can utilize case weights during model fitting. To use them, see the documentation in [case_weights] and the examples on `tidymodels.org`. 
 
-The `fit()` and `fit_xy()` arguments have arguments called `case_weights` that expect vectors of case weights. 
+The `fit()` and `fit_xy()` functions have arguments called `case_weights` that expect vectors of case weights. 


### PR DESCRIPTION
## Summary

- The shared case weights template said `fit()` and `fit_xy()` were arguments; they are functions.
- Updated `man/rmd/template-uses-case-weights.Rmd` and the generated `.md` / `.Rd` copies that include that sentence.
- Added a NEWS bullet.

Fixes #1394.

## Test plan

- [x] Confirmed the typo phrase no longer appears under `man/`
- [x] Spot-checked the template Rmd/md and a sample Rd (`details_linear_reg_lm.Rd`)