### PR TITLE
generalize glmnet helpers to check & set penalty path arguments

### DIFF
--- a/R/glmnet-engines.R
+++ b/R/glmnet-engines.R
@@ -386,18 +386,23 @@ format_glmnet_multinom_class <- function(pred, penalty, lvl, n_obs) {
 #' @rdname glmnet_helpers
 #' @keywords internal
 #' @export
-.check_glmnet_penalty_fit <- function(x, call = rlang::caller_env()) {
+.check_glmnet_penalty_fit <- function(
+    x,
+    engine,
+    call = rlang::caller_env()
+) {
   pen <- rlang::eval_tidy(x$args$penalty)
 
-  if (length(pen) != 1) {
+  if (length(pen) != 1L) {
     cli::cli_abort(
       c(
-        "x" = "For the glmnet engine, {.arg penalty} must be a single number
-        (or a value of {.fn tune}).",
+        "x" = "For the {.val {engine}} engine, {.arg penalty} must be
+        a single number (or a value of {.fn tune}).",
         "!" = "There are {length(pen)} value{?s} for {.arg penalty}.",
         "i" = "To try multiple values for total regularization, use the
         {.pkg tune} package.",
-        "i" = "To predict multiple penalties, use {.fn multi_predict}."
+        "i" = "To predict multiple penalties, use {.fn multi_predict}.",
+        "i" = "To override the default path, use {.arg path_values}."
       ),
       call = call
     )
@@ -448,18 +453,18 @@ format_glmnet_multinom_class <- function(pred, penalty, lvl, n_obs) {
   penalty
 }
 
-set_glmnet_penalty_path <- function(x) {
+set_glmnet_penalty_path <- function(x, penalty_arg) {
   if (any(names(x$eng_args) == "path_values")) {
-    # Since we decouple the parsnip `penalty` argument from being the same
-    # as the glmnet `lambda` value, `path_values` allows users to set the
-    # path differently from the default that glmnet uses. See
+    # Since we decouple the parsnip `penalty` argument from the engine argument
+    # (e.g. `lambda` in glmnet), `path_values` allows users to set the path
+    # differently from the default that the engine uses. See
     # https://github.com/tidymodels/parsnip/issues/431
-    x$method$fit$args$lambda <- x$eng_args$path_values
+    x$method$fit$args[[penalty_arg]] <- x$eng_args$path_values
     x$eng_args$path_values <- NULL
     x$method$fit$args$path_values <- NULL
   } else {
     # See discussion in https://github.com/tidymodels/parsnip/issues/195
-    x$method$fit$args$lambda <- NULL
+    x$method$fit$args[[penalty_arg]] <- NULL
   }
   x
 }

--- a/R/linear_reg.R
+++ b/R/linear_reg.R
@@ -63,8 +63,8 @@ translate.linear_reg <- function(x, engine = x$engine, ...) {
 
   if (engine == "glmnet") {
     # See https://parsnip.tidymodels.org/reference/glmnet-details.html
-    .check_glmnet_penalty_fit(x)
-    x <- set_glmnet_penalty_path(x)
+    .check_glmnet_penalty_fit(x, engine)
+    x <- set_glmnet_penalty_path(x, "penalty")
     # Since the `fit` information is gone for the penalty, we need to have an
     # evaluated value for the parameter.
     x$args$penalty <- rlang::eval_tidy(x$args$penalty)

--- a/R/linear_reg.R
+++ b/R/linear_reg.R
@@ -64,7 +64,7 @@ translate.linear_reg <- function(x, engine = x$engine, ...) {
   if (engine == "glmnet") {
     # See https://parsnip.tidymodels.org/reference/glmnet-details.html
     .check_glmnet_penalty_fit(x, engine)
-    x <- set_glmnet_penalty_path(x, "penalty")
+    x <- set_glmnet_penalty_path(x, "lambda")
     # Since the `fit` information is gone for the penalty, we need to have an
     # evaluated value for the parameter.
     x$args$penalty <- rlang::eval_tidy(x$args$penalty)

--- a/R/logistic_reg.R
+++ b/R/logistic_reg.R
@@ -79,8 +79,8 @@ translate.logistic_reg <- function(x, engine = x$engine, ...) {
 
   if (engine == "glmnet") {
     # See https://parsnip.tidymodels.org/reference/glmnet-details.html
-    .check_glmnet_penalty_fit(x)
-    x <- set_glmnet_penalty_path(x)
+    .check_glmnet_penalty_fit(x, engine)
+    x <- set_glmnet_penalty_path(x, "penalty")
     # Since the `fit` information is gone for the penalty, we need to have an
     # evaluated value for the parameter.
     x$args$penalty <- rlang::eval_tidy(x$args$penalty)

--- a/R/logistic_reg.R
+++ b/R/logistic_reg.R
@@ -80,7 +80,7 @@ translate.logistic_reg <- function(x, engine = x$engine, ...) {
   if (engine == "glmnet") {
     # See https://parsnip.tidymodels.org/reference/glmnet-details.html
     .check_glmnet_penalty_fit(x, engine)
-    x <- set_glmnet_penalty_path(x, "penalty")
+    x <- set_glmnet_penalty_path(x, "lambda")
     # Since the `fit` information is gone for the penalty, we need to have an
     # evaluated value for the parameter.
     x$args$penalty <- rlang::eval_tidy(x$args$penalty)

--- a/R/poisson_reg.R
+++ b/R/poisson_reg.R
@@ -93,7 +93,7 @@ translate.poisson_reg <- function(x, engine = x$engine, ...) {
   if (engine == "glmnet") {
     # See https://parsnip.tidymodels.org/reference/glmnet-details.html
     .check_glmnet_penalty_fit(x, engine)
-    x <- set_glmnet_penalty_path(x, "penalty")
+    x <- set_glmnet_penalty_path(x, "lambda")
     # Since the `fit` information is gone for the penalty, we need to have an
     # evaluated value for the parameter.
     x$args$penalty <- rlang::eval_tidy(x$args$penalty)

--- a/R/poisson_reg.R
+++ b/R/poisson_reg.R
@@ -92,8 +92,8 @@ translate.poisson_reg <- function(x, engine = x$engine, ...) {
 
   if (engine == "glmnet") {
     # See https://parsnip.tidymodels.org/reference/glmnet-details.html
-    .check_glmnet_penalty_fit(x)
-    x <- set_glmnet_penalty_path(x)
+    .check_glmnet_penalty_fit(x, engine)
+    x <- set_glmnet_penalty_path(x, "penalty")
     # Since the `fit` information is gone for the penalty, we need to have an
     # evaluated value for the parameter.
     x$args$penalty <- rlang::eval_tidy(x$args$penalty)

--- a/R/proportional_hazards.R
+++ b/R/proportional_hazards.R
@@ -90,8 +90,8 @@ translate.proportional_hazards <- function(x, engine = x$engine, ...) {
 
   if (engine == "glmnet") {
     # See https://parsnip.tidymodels.org/reference/glmnet-details.html
-    .check_glmnet_penalty_fit(x)
-    x <- set_glmnet_penalty_path(x)
+    .check_glmnet_penalty_fit(x, engine)
+    x <- set_glmnet_penalty_path(x, "penalty")
     # Since the `fit` information is gone for the penalty, we need to have an
     # evaluated value for the parameter.
     x$args$penalty <- rlang::eval_tidy(x$args$penalty)

--- a/R/proportional_hazards.R
+++ b/R/proportional_hazards.R
@@ -91,7 +91,7 @@ translate.proportional_hazards <- function(x, engine = x$engine, ...) {
   if (engine == "glmnet") {
     # See https://parsnip.tidymodels.org/reference/glmnet-details.html
     .check_glmnet_penalty_fit(x, engine)
-    x <- set_glmnet_penalty_path(x, "penalty")
+    x <- set_glmnet_penalty_path(x, "lambda")
     # Since the `fit` information is gone for the penalty, we need to have an
     # evaluated value for the parameter.
     x$args$penalty <- rlang::eval_tidy(x$args$penalty)

--- a/tests/testthat/_snaps/translate.md
+++ b/tests/testthat/_snaps/translate.md
@@ -504,10 +504,11 @@
       translate_args(set_engine(basic, "glmnet"))
     Condition
       Error in `translate()`:
-      x For the glmnet engine, `penalty` must be a single number (or a value of `tune()`).
+      x For the "glmnet" engine, `penalty` must be a single number (or a value of `tune()`).
       ! There are 0 values for `penalty`.
       i To try multiple values for total regularization, use the tune package.
       i To predict multiple penalties, use `multi_predict()`.
+      i To override the default path, use `path_values`.
 
 ---
 
@@ -555,10 +556,11 @@
       translate_args(set_engine(mixture, "glmnet"))
     Condition
       Error in `translate()`:
-      x For the glmnet engine, `penalty` must be a single number (or a value of `tune()`).
+      x For the "glmnet" engine, `penalty` must be a single number (or a value of `tune()`).
       ! There are 0 values for `penalty`.
       i To try multiple values for total regularization, use the tune package.
       i To predict multiple penalties, use `multi_predict()`.
+      i To override the default path, use `path_values`.
 
 ---
 
@@ -688,10 +690,11 @@
       translate_args(set_engine(basic, "glmnet"))
     Condition
       Error in `translate()`:
-      x For the glmnet engine, `penalty` must be a single number (or a value of `tune()`).
+      x For the "glmnet" engine, `penalty` must be a single number (or a value of `tune()`).
       ! There are 0 values for `penalty`.
       i To try multiple values for total regularization, use the tune package.
       i To predict multiple penalties, use `multi_predict()`.
+      i To override the default path, use `path_values`.
 
 ---
 
@@ -827,10 +830,11 @@
       translate_args(set_engine(mixture, "glmnet"))
     Condition
       Error in `translate()`:
-      x For the glmnet engine, `penalty` must be a single number (or a value of `tune()`).
+      x For the "glmnet" engine, `penalty` must be a single number (or a value of `tune()`).
       ! There are 0 values for `penalty`.
       i To try multiple values for total regularization, use the tune package.
       i To predict multiple penalties, use `multi_predict()`.
+      i To override the default path, use `path_values`.
 
 ---
 
@@ -968,10 +972,11 @@
       translate_args(set_engine(mixture_v, "glmnet"))
     Condition
       Error in `translate()`:
-      x For the glmnet engine, `penalty` must be a single number (or a value of `tune()`).
+      x For the "glmnet" engine, `penalty` must be a single number (or a value of `tune()`).
       ! There are 0 values for `penalty`.
       i To try multiple values for total regularization, use the tune package.
       i To predict multiple penalties, use `multi_predict()`.
+      i To override the default path, use `path_values`.
 
 ---
 
@@ -1349,10 +1354,11 @@
       translate_args(set_engine(basic, "glmnet"))
     Condition
       Error in `translate()`:
-      x For the glmnet engine, `penalty` must be a single number (or a value of `tune()`).
+      x For the "glmnet" engine, `penalty` must be a single number (or a value of `tune()`).
       ! There are 0 values for `penalty`.
       i To try multiple values for total regularization, use the tune package.
       i To predict multiple penalties, use `multi_predict()`.
+      i To override the default path, use `path_values`.
 
 ---
 
@@ -1711,10 +1717,11 @@
       translate_args(basic_incomplete)
     Condition
       Error in `translate()`:
-      x For the glmnet engine, `penalty` must be a single number (or a value of `tune()`).
+      x For the "glmnet" engine, `penalty` must be a single number (or a value of `tune()`).
       ! There are 0 values for `penalty`.
       i To try multiple values for total regularization, use the tune package.
       i To predict multiple penalties, use `multi_predict()`.
+      i To override the default path, use `path_values`.
 
 # arguments (rand_forest)
 


### PR DESCRIPTION
As prompted [here](https://github.com/tidymodels/parsnip/issues/1411#issuecomment-5618978993), this is a minimal revision to the glmnet helper functions that generalizes them to work for similar engines that may use different penalty parameters:
* `.check_glmnet_penalty_fit()` gets an `engine` argument with no default that is set to `"glmnet"` in all invocations. It is used only to specialize the `cli_abort()` message.
* `set_glmnet_penalty_path()` gets a `penalty_arg` argument with no default that is set to `"lambda"` in all invocations. It is used to access the penalty value stored at `x$method$fit$args[[penalty_arg]]`.

Additionally, a new line is added to the (already long) `.check_glmnet_penalty_fit()` abort message to explicitly reference the `path_values` argument. I think this is essential for users to be pointed to.

~Note that i have not updated the snapshot tests, in part since i don't have all engines installed.~ Snapshot tests are now updated.

The generalization is in anticipation of also invoking these functions for glmnetcr and ordinalNet penalty paths; if other engines have similar controls then they might invoke them as well.

The helper functions might be renamed, e.g. by replacing `_glmnet_` with `_elastic_net_` in each name; but, since the glmnet engine (i think) originated the design pattern, it might make sense to keep `glmnet` in the name.